### PR TITLE
Refactor: deduplicate code and improve maintainability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.0.9"
+version = "2.1.0"
 dependencies = [
  "clap",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.0.9"
+version = "2.1.0"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,24 +1,48 @@
-use std::{env, path::PathBuf};
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use serde::Deserialize;
 
-use hashbrown::HashMap;
+use crate::utils::{SCRIPT_DIR_NAME, SUPPORTED_EXTENSIONS, Shortcuts, home_dir};
 
-/// Structure representing the shortcuts mapping file.
-#[derive(Debug, Deserialize)]
-struct Shortcuts {
-    /// A mapping of shortcut keys to script file names.
-    shortcuts: HashMap<String, String>,
-}
-
-#[derive(Debug, Deserialize, Parser)]
+#[derive(Debug, Parser)]
 pub struct Input {
     /// A descriptive name for the script.
     pub command: String,
     /// Optional parameters (positional arguments) that will be mapped to the script's expected params.
     #[arg(num_args = 0..)]
     pub params: Vec<String>,
+}
+
+fn find_script_in_dir(
+    dir: &Path,
+    name: &str,
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    for ext in SUPPORTED_EXTENSIONS {
+        let path = dir.join(format!("{name}.{ext}"));
+        if path.exists() {
+            return Ok(Some(path.canonicalize()?));
+        }
+    }
+
+    let shortcuts_path = dir.join(".shortcuts.yaml");
+    if shortcuts_path.exists() {
+        let content = std::fs::read_to_string(&shortcuts_path)?;
+        let shortcuts: Shortcuts = serde_yaml::from_str(&content)?;
+        if let Some(mapped_file) = shortcuts.shortcuts.get(name) {
+            let path = dir.join(mapped_file);
+            if path.exists() {
+                return Ok(Some(path.canonicalize()?));
+            }
+            for ext in SUPPORTED_EXTENSIONS {
+                let path = dir.join(format!("{mapped_file}.{ext}"));
+                if path.exists() {
+                    return Ok(Some(path.canonicalize()?));
+                }
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 impl Input {
@@ -28,59 +52,14 @@ impl Input {
             return Ok(cmd_path.canonicalize()?);
         }
 
-        let base_dir = PathBuf::from(".zirv");
-        let extensions = ["yaml", "yml", "json", "toml"];
-
-        for ext in &extensions {
-            let path = base_dir.join(format!("{}.{}", &self.command, ext));
-            if path.exists() {
-                return Ok(path.canonicalize()?);
-            }
+        let local_dir = PathBuf::from(SCRIPT_DIR_NAME);
+        if let Some(path) = find_script_in_dir(&local_dir, &self.command)? {
+            return Ok(path);
         }
 
-        let shortcuts_path = base_dir.join(".shortcuts.yaml");
-        if shortcuts_path.exists() {
-            let content = std::fs::read_to_string(&shortcuts_path)?;
-            let shortcuts: Shortcuts = serde_yaml::from_str(&content)?;
-            if let Some(mapped_file) = shortcuts.shortcuts.get(&self.command) {
-                let path = base_dir.join(mapped_file);
-                if path.exists() {
-                    return Ok(path.canonicalize()?);
-                }
-                for ext in &extensions {
-                    let path = base_dir.join(format!("{mapped_file}.{ext}"));
-                    if path.exists() {
-                        return Ok(path.canonicalize()?);
-                    }
-                }
-            }
-        }
-        let home_dir = PathBuf::from(env::var("HOME").or_else(|_| env::var("USERPROFILE"))?);
-
-        let root = home_dir.join(".zirv");
-        for ext in &extensions {
-            let path = root.join(format!("{}.{}", self.command, ext));
-            if path.exists() {
-                return Ok(path.canonicalize()?);
-            }
-        }
-
-        let shortcuts_path = root.join(".shortcuts.yaml");
-        if shortcuts_path.exists() {
-            let content = std::fs::read_to_string(&shortcuts_path)?;
-            let shortcuts: Shortcuts = serde_yaml::from_str(&content)?;
-            if let Some(mapped_file) = shortcuts.shortcuts.get(&self.command) {
-                let path = root.join(mapped_file);
-                if path.exists() {
-                    return Ok(path.canonicalize()?);
-                }
-                for ext in &extensions {
-                    let path = root.join(format!("{mapped_file}.{ext}"));
-                    if path.exists() {
-                        return Ok(path.canonicalize()?);
-                    }
-                }
-            }
+        let global_dir = home_dir()?.join(SCRIPT_DIR_NAME);
+        if let Some(path) = find_script_in_dir(&global_dir, &self.command)? {
+            return Ok(path);
         }
 
         Err(format!("No script or shortcut found for '{}'", self.command).into())

--- a/src/script_runner/command_types.rs
+++ b/src/script_runner/command_types.rs
@@ -17,7 +17,7 @@ impl CommandTypes {
         context: &mut HashMap<String, String>,
     ) -> Result<Option<String>, String> {
         match self {
-            CommandTypes::Command(cmd) => cmd.clone().execute(context).await,
+            CommandTypes::Command(cmd) => cmd.execute(context).await,
             CommandTypes::Commands(cmds) => {
                 if cmds.is_empty() {
                     return Ok(None);

--- a/src/script_runner/script.rs
+++ b/src/script_runner/script.rs
@@ -22,12 +22,10 @@ impl Script {
         // Execution loop
         for step in &self.commands {
             match step.execute(context).await {
-                Ok(output) => {
-                    if output.is_some() {
-                        // If the command returns output, you can handle it here
-                        println!("Command output: {}", output.unwrap());
-                    }
+                Ok(Some(output)) => {
+                    println!("Command output: {output}");
                 }
+                Ok(None) => {}
                 Err(e) => {
                     return Err(format!(
                         "Error executing command in script '{}': {}",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,22 +1,44 @@
-use std::{fs, path::PathBuf};
+use std::{env, fs, path::PathBuf};
+
+use hashbrown::HashMap;
+use serde::{Deserialize, Serialize};
 
 use crate::script_runner::script::Script;
 
+pub const SUPPORTED_EXTENSIONS: &[&str] = &["yaml", "yml", "json", "toml"];
+pub const SCRIPT_DIR_NAME: &str = ".zirv";
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct Shortcuts {
+    pub shortcuts: HashMap<String, String>,
+}
+
+pub fn home_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    env::var("HOME")
+        .or_else(|_| env::var("USERPROFILE"))
+        .map(PathBuf::from)
+        .map_err(|_| "Could not determine home directory".into())
+}
+
+pub fn parse_script_content(
+    content: &str,
+    ext: &str,
+) -> Result<Script, Box<dyn std::error::Error>> {
+    let script: Script = match ext {
+        "yaml" | "yml" => serde_yaml::from_str(content)?,
+        "json" => serde_json::from_str(content)?,
+        "toml" => toml::from_str(content)?,
+        other => return Err(format!("Unsupported extension: {other}").into()),
+    };
+    Ok(script)
+}
+
 pub fn file_to_script(path: &PathBuf) -> Result<Script, Box<dyn std::error::Error>> {
     let content = fs::read_to_string(path)?;
-
     let ext = path
         .extension()
         .and_then(|s| s.to_str())
         .unwrap_or("")
         .to_lowercase();
-
-    let script: Script = match ext.as_str() {
-        "yaml" | "yml" => serde_yaml::from_str(&content)?,
-        "json" => serde_json::from_str(&content)?,
-        "toml" => toml::from_str(&content)?,
-        other => return Err(format!("Unsupported extension: {other}").into()),
-    };
-
-    Ok(script)
+    parse_script_content(&content, &ext)
 }


### PR DESCRIPTION
## Summary
- Extract shared utilities (constants, types, functions) into `utils.rs` to eliminate duplication across modules
- Deduplicate script search logic in `input.rs` and script listing in `help.rs` via helper functions
- Change `Command.execute()` to take `&self` instead of `&mut self`, removing unnecessary struct cloning
- Fix `is_some()`/`unwrap()` anti-pattern with proper pattern matching
- Bump version to 2.1.0

## Test plan
- [x] All 13 existing tests pass
- [x] Clippy clean
- [x] Formatting verified