### PR TITLE
Add Linux install support and fix security vulnerabilities

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -171,6 +171,12 @@ jobs:
           name: zirv-macos
           path: artifacts
 
+      - name: Download Linux Artifact for Homebrew
+        uses: actions/download-artifact@v4
+        with:
+          name: zirv-linux
+          path: artifacts
+
       - name: Get version from Cargo.toml
         id: get_version
         shell: bash
@@ -188,7 +194,8 @@ jobs:
           chmod +x ./scripts/update_homebrew.sh
           ./scripts/update_homebrew.sh \
             "${{ steps.get_version.outputs.version }}" \
-            "artifacts/zirv-${{ steps.get_version.outputs.version }}-macos.tar.gz"
+            "artifacts/zirv-${{ steps.get_version.outputs.version }}-macos.tar.gz" \
+            "artifacts/zirv-${{ steps.get_version.outputs.version }}-linux.tar.gz"
 
   update-chocolatey:
     name: Update Chocolatey Package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,16 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,18 +618,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -798,16 +786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -995,7 +983,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "slab",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10.0"
 serde_json = "1.0.149"
 toml = "1.0.6"
 dirs = "6.0.0"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - [Features](#features)
 - [Installation](#installation)
+- [Upgrading](#upgrading)
 - [Usage](#usage)
   - [Initialize a Project](#initialize-a-project)
   - [Running Scripts](#running-scripts)
@@ -65,7 +66,7 @@ curl -sSfL https://raw.githubusercontent.com/Glubiz/zirv-dynamic-cli/main/instal
 To install a specific version:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/Glubiz/zirv-dynamic-cli/main/install.sh | sh -s -- 2.3.0
+curl -sSfL https://raw.githubusercontent.com/Glubiz/zirv-dynamic-cli/main/install.sh | sh -s -- 2.4.0
 ```
 
 ### Cargo (All Platforms)
@@ -78,6 +79,34 @@ cargo build --release
 ### Precompiled Binaries
 Download the latest release from the [GitHub Releases]:
 https://github.com/Glubiz/zirv-dynamic-cli/releases
+
+## Upgrading
+
+### Homebrew
+
+```bash
+brew upgrade zirv
+```
+
+### Chocolatey
+
+```bash
+choco upgrade zirv
+```
+
+### Install Script
+
+Re-run the install script to get the latest version:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/Glubiz/zirv-dynamic-cli/main/install.sh | sh
+```
+
+### Cargo
+
+```bash
+cargo build --release
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 Choose one of the following methods:
 
-### Homebrew (macOS)
+### Homebrew (macOS & Linux)
 
 ```bash
 brew tap glubiz/homebrew-tap
@@ -56,23 +56,21 @@ brew install zirv
 choco install zirv
 ```
 
-### Download from Releases
-#### Linux
-Download the latest release from the [GitHub Releases]:
+### Install Script (macOS & Linux)
+
 ```bash
-VERSION="1.0.0" && \
-curl -L -o zirv.tar.gz "https://github.com/Glubiz/zirv-dynamic-cli/releases/download/${VERSION}/zirv-${VERSION}-linux.tar.gz" && \
-tar -xzf zirv.tar.gz && \
-sudo mv zirv /usr/local/bin/zirv && \
-rm zirv.tar.gz && \
-echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc && \
-source ~/.bashrc
+curl -sSfL https://raw.githubusercontent.com/Glubiz/zirv-dynamic-cli/main/install.sh | sh
+```
+
+To install a specific version:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/Glubiz/zirv-dynamic-cli/main/install.sh | sh -s -- 2.3.0
 ```
 
 ### Cargo (All Platforms)
-  
+
 ```bash
-# Build from source
 cargo build --release
 # Add `target/release` to your PATH
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="Glubiz/zirv-dynamic-cli"
+INSTALL_DIR="/usr/local/bin"
+BINARY_NAME="zirv"
+
+get_latest_version() {
+    curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name"' \
+        | sed -E 's/.*"v([^"]+)".*/\1/'
+}
+
+detect_platform() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        linux*)  echo "linux" ;;
+        darwin*) echo "macos" ;;
+        *)
+            echo "Error: Unsupported operating system: $OS" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main() {
+    VERSION="${1:-$(get_latest_version)}"
+    if [ -z "$VERSION" ]; then
+        echo "Error: Could not determine latest version." >&2
+        exit 1
+    fi
+
+    PLATFORM=$(detect_platform)
+    ARCHIVE="${BINARY_NAME}-${VERSION}-${PLATFORM}.tar.gz"
+    URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+
+    echo "Installing zirv v${VERSION} for ${PLATFORM}..."
+
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    echo "Downloading ${URL}..."
+    curl -sSfL -o "${TMPDIR}/${ARCHIVE}" "$URL"
+
+    echo "Extracting..."
+    tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+    chmod +x "${TMPDIR}/${BINARY_NAME}"
+
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "${TMPDIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+        sudo mv "${TMPDIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
+
+    echo "zirv v${VERSION} installed to ${INSTALL_DIR}/${BINARY_NAME}"
+    echo "Run 'zirv --version' to verify."
+}
+
+main "$@"

--- a/scripts/update_homebrew.sh
+++ b/scripts/update_homebrew.sh
@@ -1,52 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <version> <artifact_path>"
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <version> <macos_artifact_path> <linux_artifact_path>"
     exit 1
 fi
 
 VERSION=$1
-ARTIFACT_INPUT=$2
-BASENAME=$(basename "$ARTIFACT_INPUT")
+MACOS_ARTIFACT_INPUT=$2
+LINUX_ARTIFACT_INPUT=$3
+MACOS_BASENAME=$(basename "$MACOS_ARTIFACT_INPUT")
+LINUX_BASENAME=$(basename "$LINUX_ARTIFACT_INPUT")
 
 # Normalize Windows backslashes
-ARTIFACT_INPUT=${ARTIFACT_INPUT//\\//}
+MACOS_ARTIFACT_INPUT=${MACOS_ARTIFACT_INPUT//\\//}
+LINUX_ARTIFACT_INPUT=${LINUX_ARTIFACT_INPUT//\\//}
 
-echo "Looking for artifact matching: '$BASENAME'"
-# Ensure artifacts directory exists
 mkdir -p artifacts
 
-echo "Contents of artifacts directory:"
-find artifacts -type f || echo "(empty)"
+find_artifact() {
+    local INPUT=$1
+    local BASENAME=$2
 
-# First, check if the direct path exists
-if [ -f "$ARTIFACT_INPUT" ]; then
-    ARTIFACT_PATH="$ARTIFACT_INPUT"
-else
-    # Otherwise, search recursively under artifacts/ for the filename
+    if [ -f "$INPUT" ]; then
+        echo "$INPUT"
+        return
+    fi
+
     FOUND=$(find artifacts -type f -name "$BASENAME" -print -quit || true)
     if [ -n "$FOUND" ]; then
-        ARTIFACT_PATH="$FOUND"
-    else
-        echo "Error: Artifact '$BASENAME' not found under artifacts/"
-        exit 1
+        echo "$FOUND"
+        return
     fi
-fi
 
-echo "Using artifact file: $ARTIFACT_PATH"
+    echo "Error: Artifact '$BASENAME' not found under artifacts/" >&2
+    exit 1
+}
 
-# Compute checksum
-CHECKSUM=$(sha256sum "$ARTIFACT_PATH" | awk '{print $1}')
-echo "Computed checksum: $CHECKSUM"
+MACOS_PATH=$(find_artifact "$MACOS_ARTIFACT_INPUT" "$MACOS_BASENAME")
+LINUX_PATH=$(find_artifact "$LINUX_ARTIFACT_INPUT" "$LINUX_BASENAME")
 
-# Ensure token
+echo "Using macOS artifact: $MACOS_PATH"
+echo "Using Linux artifact: $LINUX_PATH"
+
+MACOS_CHECKSUM=$(sha256sum "$MACOS_PATH" | awk '{print $1}')
+LINUX_CHECKSUM=$(sha256sum "$LINUX_PATH" | awk '{print $1}')
+
+echo "macOS checksum: $MACOS_CHECKSUM"
+echo "Linux checksum: $LINUX_CHECKSUM"
+
 if [ -z "${HOMEBREW_TOKEN:-}" ]; then
   echo "Error: HOMEBREW_TOKEN is not set!"
   exit 1
 fi
 
-# Clone tap and update formula
 TAP_DIR=$(mktemp -d)
 
 echo "Cloning homebrew-tap into $TAP_DIR"
@@ -58,31 +65,39 @@ if [ ! -f "$FORMULA" ]; then
     exit 1
 fi
 
-echo "Updating $FORMULA to v$VERSION with new URL and checksum"
+MACOS_URL="https://github.com/Glubiz/zirv-dynamic-cli/releases/download/v${VERSION}/${MACOS_BASENAME}"
+LINUX_URL="https://github.com/Glubiz/zirv-dynamic-cli/releases/download/v${VERSION}/${LINUX_BASENAME}"
 
-RELEASE_URL="https://github.com/Glubiz/zirv-dynamic-cli/releases/download/v${VERSION}/${BASENAME}"
+echo "Writing updated formula"
 
-# 1) Update the URL line
-#    - single‑quoted sed program
-#    - close quote, insert shell var, reopen quote
-sed -i \
-    's|^ *url *".*"|  url "'"${RELEASE_URL}"'"|' \
-    "$FORMULA"
+cat > "$FORMULA" << RUBY
+class Zirv < Formula
+  desc "Dynamic CLI tool to streamline tasks and boost productivity"
+  homepage "https://github.com/Glubiz/zirv-dynamic-cli"
+  license "MIT"
+  version "${VERSION}"
 
-# 2) Update the version line
-sed -i \
-    's|^ *version *".*"|  version "'"${VERSION}"'"|' \
-    "$FORMULA"
+  if OS.mac?
+    url "${MACOS_URL}"
+    sha256 "${MACOS_CHECKSUM}"
+  elsif OS.linux?
+    url "${LINUX_URL}"
+    sha256 "${LINUX_CHECKSUM}"
+  end
 
-# 3) Update the sha256 line
-sed -i \
-    's|^ *sha256 *".*"|  sha256 "'"${CHECKSUM}"'"|' \
-    "$FORMULA"
+  def install
+    bin.install "zirv"
+  end
+
+  test do
+    system "#{bin}/zirv", "--version"
+  end
+end
+RUBY
 
 echo "Formula after update:"
-sed -n '1,10p; /sha256/,/end/p; 1q' "$FORMULA"
+cat "$FORMULA"
 
-# Commit and push
 cd "$TAP_DIR"
 git config user.email "ci@github.com"
 git config user.name "GitHub Actions"

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -73,14 +73,14 @@ pub fn create_script_interactive() -> Result<(), Box<dyn std::error::Error>> {
         let shortcuts_path = target_dir.join(".shortcuts.yaml");
         let mut shortcuts: Shortcuts = if shortcuts_path.exists() {
             let content = fs::read_to_string(&shortcuts_path)?;
-            serde_yml::from_str(&content).unwrap_or_default()
+            serde_yaml_ng::from_str(&content).unwrap_or_default()
         } else {
             Shortcuts::default()
         };
         shortcuts
             .shortcuts
             .insert(shortcut.clone(), file_name.clone());
-        let yaml_string = serde_yml::to_string(&shortcuts)?;
+        let yaml_string = serde_yaml_ng::to_string(&shortcuts)?;
         fs::write(&shortcuts_path, yaml_string)?;
         println!("Updated shortcuts file: {shortcuts_path:?}");
     }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -40,7 +40,7 @@ fn write_shortcuts<W: Write>(writer: &mut W, dir: &Path) -> Result<(), Box<dyn s
     let shortcuts_path = dir.join(".shortcuts.yaml");
     if shortcuts_path.exists() {
         let content = fs::read_to_string(shortcuts_path)?;
-        let shortcuts: Shortcuts = serde_yml::from_str(&content)?;
+        let shortcuts: Shortcuts = serde_yaml_ng::from_str(&content)?;
         for (key, value) in shortcuts.shortcuts {
             writeln!(writer, "  {key} -> {value}")?;
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -29,7 +29,7 @@ fn find_script_in_dir(
     let shortcuts_path = dir.join(".shortcuts.yaml");
     if shortcuts_path.exists() {
         let content = std::fs::read_to_string(&shortcuts_path)?;
-        let shortcuts: Shortcuts = serde_yml::from_str(&content)?;
+        let shortcuts: Shortcuts = serde_yaml_ng::from_str(&content)?;
         if let Some(mapped_file) = shortcuts.shortcuts.get(name) {
             let path = dir.join(mapped_file);
             if path.exists() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ pub fn parse_script_content(
     ext: &str,
 ) -> Result<Script, Box<dyn std::error::Error>> {
     let script: Script = match ext {
-        "yaml" | "yml" => serde_yml::from_str(content)?,
+        "yaml" | "yml" => serde_yaml_ng::from_str(content)?,
         "json" => serde_json::from_str(content)?,
         "toml" => toml::from_str(content)?,
         other => return Err(format!("Unsupported extension: {other}").into()),


### PR DESCRIPTION
## Summary
- Homebrew formula now supports both macOS and Linux
- Added shell install script (`curl | sh`) for easy Linux/macOS installation
- Replaced unmaintained `serde_yml`/`libyml` with `serde_yaml_ng` to resolve Dependabot security alerts

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 23 tests pass
- [x] `cargo clippy` and `cargo fmt` clean
- [ ] Verify Homebrew install works on Linux after merge
- [ ] Verify `curl -sSfL .../install.sh | sh` works after merge to main