### PR TITLE
fix(ctx): wrap no-supervise injection contract and --help exit codes (2.5.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -99,6 +99,22 @@ pub fn select(
     Ok(adapter)
 }
 
+/// True when the wrapped command can be trusted to actually be this adapter's
+/// agent: either the operator named it explicitly (`--agent`, or the config's
+/// `agent` key), or detection matched the command's own argv. Neither true
+/// means `select`'s last arm defaulted here with nothing to back it up (an
+/// arbitrary wrapped command that matches no adapter), and injecting this
+/// adapter's own flags (e.g. `--append-system-prompt`) into whatever program
+/// that turns out to be would leak them into its output instead of an agent
+/// that would ever read them.
+pub fn command_matches_adapter(
+    adapter: &dyn AgentAdapter,
+    agent_explicit: bool,
+    command: &[String],
+) -> bool {
+    agent_explicit || adapter.detect(command)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,5 +156,29 @@ mod tests {
     fn registry_exposes_both_v1_adapters() {
         let names: Vec<&str> = all(None).iter().map(|a| a.name()).collect();
         assert_eq!(names, vec!["claude", "codex"]);
+    }
+
+    /// The gate wrap and exec use before injecting: a command that matches no
+    /// adapter, with no explicit `--agent` to back it, must not be treated as
+    /// a match just because `select` had to default to one.
+    #[test]
+    fn an_undetected_command_with_no_explicit_agent_does_not_match() {
+        let adapter = claude::ClaudeAdapter::new(None);
+        let command = vec!["echo".to_string(), "hello".to_string()];
+        assert!(!command_matches_adapter(&adapter, false, &command));
+    }
+
+    #[test]
+    fn an_explicit_agent_matches_regardless_of_the_command() {
+        let adapter = claude::ClaudeAdapter::new(None);
+        let command = vec!["echo".to_string(), "hello".to_string()];
+        assert!(command_matches_adapter(&adapter, true, &command));
+    }
+
+    #[test]
+    fn a_detected_command_matches_even_without_an_explicit_agent() {
+        let adapter = claude::ClaudeAdapter::new(None);
+        let command = vec!["/opt/homebrew/bin/claude".to_string()];
+        assert!(command_matches_adapter(&adapter, false, &command));
     }
 }

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -89,17 +89,23 @@ pub fn run_with<W: Write>(
     env: EnvLookup<'_>,
 ) -> CtxResult<i32> {
     let cfg = CtxConfig::load(repo, env)?;
-    let adapter = adapters::select(
-        args.agent.as_deref().or(cfg.agent.as_deref()),
-        &args.command,
-        cfg.agent_bin.as_deref(),
-    )?;
+    let agent_name = args.agent.as_deref().or(cfg.agent.as_deref());
+    let adapter = adapters::select(agent_name, &args.command, cfg.agent_bin.as_deref())?;
     let state = StateDir::resolve(env)?;
 
+    // A wrapped command that matches no adapter (no explicit `--agent`,
+    // detection came up empty) is not actually the agent whose flags we would
+    // be injecting; see the matching gate in wrap.rs.
+    let skip_injection = args.simple
+        || !adapters::command_matches_adapter(
+            adapter.as_ref(),
+            agent_name.is_some(),
+            &args.command,
+        );
     let composed = super::prompt::compose(
         crate::utils::home_dir().ok().as_deref(),
         repo,
-        args.simple,
+        skip_injection,
         &cfg.prompt,
     );
     // The first spawn's own argv may already carry the adapter's system-prompt

--- a/src/commands/ctx/mod.rs
+++ b/src/commands/ctx/mod.rs
@@ -162,6 +162,18 @@ pub fn dispatch(args: &[String]) -> i32 {
         Ok(cli) => cli,
         Err(err) => {
             let _ = err.print();
+            // clap represents `--help`/`--version` as an `Err` too, since
+            // printing and exiting is the caller's job here; both are
+            // informational, not a rejected invocation, and must exit 0 like
+            // top-level `zirv --help` already does via `Parser::parse()`'s
+            // own exit path. A genuine parse error keeps falling through to
+            // `classify_parse_failure` below.
+            if matches!(
+                err.kind(),
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+            ) {
+                return 0;
+            }
             let mut out = std::io::stdout();
             return match classify_parse_failure(args) {
                 ParseFailure::Reject => 2,
@@ -376,6 +388,35 @@ mod tests {
     fn unknown_verb_exits_two() {
         let code = dispatch(&["ctx".to_string(), "nope".to_string()]);
         assert_eq!(code, 2, "clap parse failure must map to exit code 2");
+    }
+
+    /// Bug (2026-08-02 validation of 2.5.0): clap represents `--help` as an
+    /// `Err(...)` from `try_parse_from` (printing and exiting is the caller's
+    /// job), and `dispatch` collapsed every parse failure to `classify_parse_
+    /// failure`'s verdict, which only special-cases `hook` and `usage tee`.
+    /// Every other verb's `--help` exited 2 instead of 0, breaking scripts
+    /// that treat `--help` as success. Top-level `zirv --help` was never
+    /// affected: it goes through `Parser::parse()`, which exits correctly on
+    /// its own before any of this code runs.
+    #[test]
+    fn help_exits_zero_on_every_verb_and_bare_ctx() {
+        for argv in [
+            vec!["ctx", "--help"],
+            vec!["ctx", "score", "--help"],
+            vec!["ctx", "optimize", "--help"],
+            vec!["ctx", "usage", "--help"],
+            vec!["ctx", "status", "--help"],
+            vec!["ctx", "wrap", "--help"],
+            vec!["ctx", "exec", "--help"],
+            vec!["ctx", "handoff", "--help"],
+            vec!["ctx", "resume", "--help"],
+            vec!["ctx", "loop", "--help"],
+            vec!["ctx", "wrap", "-h"],
+            vec!["ctx", "hook", "--help"],
+        ] {
+            let args: Vec<String> = argv.iter().map(|a| (*a).to_string()).collect();
+            assert_eq!(dispatch(&args), 0, "--help must exit 0: {argv:?}");
+        }
     }
 
     /// The invariant is "a hook always exits 0", and clap's own error path is

--- a/src/commands/ctx/wrap.rs
+++ b/src/commands/ctx/wrap.rs
@@ -404,21 +404,29 @@ pub fn run_with<W: Write>(
     }
 
     let cfg = CtxConfig::load(repo, env)?;
+    let agent_name = args.agent.as_deref().or(cfg.agent.as_deref());
     // Selection happens here so an unknown or unverified agent fails before the
     // terminal is touched.
-    let adapter = adapters::select(
-        args.agent.as_deref().or(cfg.agent.as_deref()),
-        &args.command,
-        cfg.agent_bin.as_deref(),
-    )?;
+    let adapter = adapters::select(agent_name, &args.command, cfg.agent_bin.as_deref())?;
 
     let state_dir = super::state::StateDir::resolve(env)?;
     let session = super::event::SessionId::new_v4();
 
+    // Two independent reasons to compose nothing: `--no-supervise` promises
+    // pure passthrough (its own help text says so), and a wrapped command that
+    // matches no adapter (no explicit `--agent`, detection came up empty) is
+    // not actually the agent whose flags we would be injecting.
+    let skip_injection = args.simple
+        || args.no_supervise
+        || !adapters::command_matches_adapter(
+            adapter.as_ref(),
+            agent_name.is_some(),
+            &args.command,
+        );
     let composed = super::prompt::compose(
         crate::utils::home_dir().ok().as_deref(),
         repo,
-        args.simple,
+        skip_injection,
         &cfg.prompt,
     );
     // The wrapped command's own argv may already carry the adapter's
@@ -870,8 +878,16 @@ mod tests {
         pub child: Box<dyn portable_pty::Child + Send + Sync>,
     }
 
+    /// The general form: `flags` are wrap's own arguments, inserted before the
+    /// `--` separator. `spawn_wrap` below is the common case (`--agent claude`)
+    /// most tests want; this exists for the tests that need to vary wrap's own
+    /// flags (`--no-supervise`, an omitted `--agent`, ...).
     #[cfg(unix)]
-    pub(crate) fn spawn_wrap(extra_env: &[(&str, String)], wrapped: &[&str]) -> Harness {
+    pub(crate) fn spawn_wrap_with_flags(
+        extra_env: &[(&str, String)],
+        flags: &[&str],
+        wrapped: &[&str],
+    ) -> Harness {
         let pair = native_pty_system()
             .openpty(PtySize {
                 rows: 24,
@@ -884,8 +900,9 @@ mod tests {
         let mut cmd = CommandBuilder::new(zirv_bin());
         cmd.arg("ctx");
         cmd.arg("wrap");
-        cmd.arg("--agent");
-        cmd.arg("claude");
+        for flag in flags {
+            cmd.arg(flag);
+        }
         cmd.arg("--");
         for arg in wrapped {
             cmd.arg(arg);
@@ -902,6 +919,11 @@ mod tests {
             writer: pair.master.take_writer().expect("writer"),
             child,
         }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn spawn_wrap(extra_env: &[(&str, String)], wrapped: &[&str]) -> Harness {
+        spawn_wrap_with_flags(extra_env, &["--agent", "claude"], wrapped)
     }
 
     /// Reads until `needle` appears or the timeout expires.
@@ -949,12 +971,15 @@ mod tests {
     /// empty after the merge even though `args.command` itself was not empty
     /// at the top of `run_with`. This must be a returned error, not a panic:
     /// release is `panic = "abort"` and this is a supervisor hot path.
+    /// `--agent claude` is explicit here so the adapter-match gate does not
+    /// also suppress composition: the wrapped "command" is a bare flag pair,
+    /// which detection would never recognize as any adapter's own binary.
     #[test]
     fn a_prompt_flag_that_empties_the_argv_after_merging_is_an_error_not_a_panic() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let args = WrapArgs {
-            agent: None,
-            no_supervise: true,
+            agent: Some("claude".to_string()),
+            no_supervise: false,
             command: vec!["--append-system-prompt".to_string(), "foo".to_string()],
             simple: false,
         };
@@ -1014,6 +1039,68 @@ mod tests {
         h.writer.write_all(b"/exit\r").expect("write");
         h.writer.flush().expect("flush");
         let _ = read_until(&mut h.reader, "bye", Duration::from_secs(10));
+        let status = h.child.wait().expect("wait");
+        assert_eq!(status.exit_code(), 0);
+    }
+
+    /// Bug (2026-08-02 validation of 2.5.0): `--no-supervise`'s own help text
+    /// promises "no scoring, no injection", but it only turned off scoring;
+    /// the system prompt was still composed and injected. `--no-supervise`
+    /// must skip injection exactly like `--simple` does, including leaving a
+    /// user's own `--append-system-prompt` untouched (nothing left to merge
+    /// it into once nothing is composed).
+    #[cfg(unix)]
+    #[test]
+    fn no_supervise_injects_nothing_and_leaves_the_users_own_flag_untouched() {
+        let script = fixture("stub-tui.sh").display().to_string();
+        let mut h = spawn_wrap_with_flags(
+            &[],
+            &["--agent", "claude", "--no-supervise"],
+            &[
+                "sh",
+                &script,
+                "--append-system-prompt",
+                "always answer in Danish",
+            ],
+        );
+
+        let seen = read_until(&mut h.reader, "stub-tui ready", Duration::from_secs(10));
+        assert_eq!(
+            seen.matches("--append-system-prompt").count(),
+            1,
+            "the user's own flag must pass through untouched: {seen:?}"
+        );
+        assert!(
+            seen.contains("always answer in Danish"),
+            "the user's own instruction is not stripped: {seen:?}"
+        );
+        assert!(
+            !seen.contains("zirv session conventions"),
+            "no-supervise is pure passthrough, no injection: {seen:?}"
+        );
+
+        h.writer.write_all(b"/exit\r").expect("write");
+        h.writer.flush().expect("flush");
+        let _ = read_until(&mut h.reader, "bye", Duration::from_secs(10));
+        let _ = h.child.wait();
+    }
+
+    /// Bug (same validation pass): with no `--agent` given, `adapters::select`
+    /// falls back to `ClaudeAdapter` when detection finds no match at all, and
+    /// wrap injected that adapter's flags into the wrapped command regardless.
+    /// `echo` is not claude or codex; nothing should be injected into it.
+    #[cfg(unix)]
+    #[test]
+    fn wrapping_a_command_that_matches_no_adapter_injects_nothing() {
+        let mut h = spawn_wrap_with_flags(&[], &[], &["echo", "hello"]);
+
+        let seen = read_until(&mut h.reader, "hello", Duration::from_secs(10));
+        assert!(seen.contains("hello"), "got {seen:?}");
+        assert!(
+            !seen.contains("--append-system-prompt"),
+            "echo was never the selected agent; nothing should be injected: {seen:?}"
+        );
+
         let status = h.child.wait().expect("wait");
         assert_eq!(status.exit_code(), 0);
     }


### PR DESCRIPTION
Fixes the two bugs found validating 2.5.0 (issue #13, validation comment):

- `zirv ctx wrap --no-supervise` no longer injects the system prompt (its help text promised pure passthrough), and wrap/exec only inject into commands that actually match the selected agent instead of falling back to claude flags for any command
- `--help` now exits 0 on every ctx verb (was 2); genuine parse errors and the hook's always-exit-0 invariant unchanged
- Version 2.5.1

Full serial suite 493/493, fmt/clippy clean, both original repros re-verified on the built binary.