### PR TITLE
chore: release 2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.5.1"
+version = "2.6.0"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml`/`Cargo.lock` version from 2.5.1 to 2.6.0.

## Why
PR #15 merged real features (agent steps, orchestrator prompt injection, Windows platform fixes) without bumping the package version. The CD pipeline's Chocolatey step re-attempted publishing 2.5.1, which already exists on the Chocolatey feed, and failed with a 409 Conflict. This unblocks the next release.

## Test plan
- [x] `cargo build` succeeds with the new version
- [x] `zirv version` reports 2.6.0
- [ ] CD pipeline's "Update Chocolatey Package" step succeeds on merge