### PR TITLE
fix(ci): only release from main's own CI runs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,7 +13,11 @@ on:
 jobs:
   build:
     name: Build Binaries
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    # Only release from main: the workflow_run trigger fires for CI runs on
+    # every branch (PRs included) but checks out the default branch, so an
+    # ungated run rebuilds and re-publishes whatever version main already
+    # has — failing at the release/Chocolatey step on the duplicate.
+    if: ${{ (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
The CD pipeline's `workflow_run` trigger fires when CI completes on **any** branch, but the job checks out the default branch — so every green PR run launched a release build of whatever version main already had and died at the Chocolatey push on the duplicate (seen three times on 2026-08-16 while #21's branch was going green).

Gate the entry job on `head_branch == 'main'`; the `workflow_dispatch` path stays available for manual releases. Cherry-picked from `feat/dashboard` (`f6b6a78`), which merged in #21 just before this commit landed on it.