### PR TITLE
fix(ctx): codex approval posture — config-override pinning, writable roots, network knob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.30.1"
+version = "2.32.0"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.30.1"
+version = "2.32.0"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/src/commands/ctx/adapters/codex.rs
+++ b/src/commands/ctx/adapters/codex.rs
@@ -986,12 +986,13 @@ impl AgentAdapter for CodexAdapter {
     /// method already threads `policy` through, so it is the one place that
     /// costs nothing extra to reach it from.
     ///
-    /// `network` defaults to `Deny` (`EffectivePolicy`'s own `Default` impl,
-    /// see its doc comment), matching what an unwired install has always
-    /// done -- codex's own native default under `--sandbox workspace-write`
-    /// is already `network_access: false` with no zirv-added flag at all, so
-    /// `Deny`/`Ask` add nothing here, exactly as codex's shipped baseline
-    /// already behaves. Only the operator's explicit `Allow` adds the
+    /// `network` defaults to `None` (`EffectivePolicy`'s own `Option<Stance>`
+    /// field, see its doc comment) when no operator layer has ever named it,
+    /// which behaves exactly like `Deny`/`Ask` here -- neither adds any argv
+    /// -- matching what an unwired install has always done: codex's own
+    /// native default under `--sandbox workspace-write` is already
+    /// `network_access: false` with no zirv-added flag at all. Only the
+    /// operator's explicit `Some(Stance::Allow)` adds the
     /// `-c sandbox_workspace_write.network_access=true` config override --
     /// verified to work on both the interactive and `exec` command surfaces
     /// (`approval_suppression_args`'s own doc comment cites the same fact for
@@ -1011,7 +1012,7 @@ impl AgentAdapter for CodexAdapter {
         } else {
             Vec::new()
         };
-        if policy.network == Stance::Allow {
+        if policy.network == Some(Stance::Allow) {
             args.push("-c".to_string());
             args.push("sandbox_workspace_write.network_access=true".to_string());
         }
@@ -1790,13 +1791,14 @@ mod tests {
         );
     }
 
-    /// `network` (2026-08-26, codex approval-posture round): `Deny`/`Ask`
-    /// (including `EffectivePolicy::default()`'s own `network: Deny`) add
-    /// nothing here -- codex's own native default under `--sandbox
-    /// workspace-write` is already closed, matching what an unwired install
-    /// has always done. Only the operator's explicit `Allow` adds the config
-    /// override, and as one `-c` occurrence -- never a bare `network_access`
-    /// substring split across two tokens some other way.
+    /// `network` (2026-08-26, codex approval-posture round): `None`
+    /// (including `EffectivePolicy::default()`'s own unconfigured value),
+    /// `Deny` and `Ask` all add nothing here -- codex's own native default
+    /// under `--sandbox workspace-write` is already closed, matching what an
+    /// unwired install has always done. Only the operator's explicit
+    /// `Some(Stance::Allow)` adds the config override, and as one `-c`
+    /// occurrence -- never a bare `network_access` substring split across two
+    /// tokens some other way.
     #[test]
     fn policy_args_adds_the_network_override_only_when_policy_explicitly_allows_it() {
         use crate::commands::ctx::policy::{EffectivePolicy, Stance};
@@ -1812,7 +1814,7 @@ mod tests {
         );
 
         let allowed_policy = EffectivePolicy {
-            network: Stance::Allow,
+            network: Some(Stance::Allow),
             ..EffectivePolicy::default()
         };
         let allowed = adapter.policy_args(&allowed_policy, super::super::LaunchMode::Headless);
@@ -2271,8 +2273,15 @@ mod tests {
         // actually distinguishes "the state root named as its own array
         // element" from "the mail subtree, which happens to start with the
         // state root's path".
-        let quoted_mail = format!("\"{}\"", mail_dir.display());
-        let quoted_state_root = format!("\"{}\"", state_root.path().display());
+        //
+        // Built through the same `toml_quoted_string` the implementation
+        // uses, not a bare `"<path>"` wrap: on Windows a raw path contains
+        // `\`, which `toml_quoted_string` doubles to stay valid inside a
+        // TOML basic string, so the naive wrap never matches the real argv
+        // there (found 2026-08-26, Windows dev machine -- the implementation
+        // was already correct, only this assertion was not).
+        let quoted_mail = toml_quoted_string(&mail_dir.display().to_string());
+        let quoted_state_root = toml_quoted_string(&state_root.path().display().to_string());
         assert!(
             joined.contains(&quoted_mail),
             "must name the mail subtree: {args:?}"
@@ -2327,12 +2336,18 @@ mod tests {
         let args = adapter.extra_writable_root_args(&linked_path, &mail_dir);
 
         let joined = args.join(" ");
+        // Same fix as `extra_writable_root_args_always_includes_the_mail_
+        // dir_but_never_the_bare_state_root` above: compare against the
+        // `toml_quoted_string`-escaped form, since a raw Windows path's `\`
+        // is doubled by the implementation to stay valid inside the TOML
+        // basic string, and a bare `.display()` substring check never
+        // matches that escaped form there.
         assert!(
-            joined.contains(&expected_git_dir.display().to_string()),
+            joined.contains(&toml_quoted_string(&expected_git_dir.display().to_string())),
             "must name the shared git common dir for a linked worktree: {args:?}"
         );
         assert!(
-            joined.contains(&mail_dir.display().to_string()),
+            joined.contains(&toml_quoted_string(&mail_dir.display().to_string())),
             "must still name the mail subtree too: {args:?}"
         );
     }

--- a/src/commands/ctx/adapters/codex.rs
+++ b/src/commands/ctx/adapters/codex.rs
@@ -585,6 +585,19 @@ fn find_rollout(dir: &Path, filename_suffix: &str) -> Option<PathBuf> {
     None
 }
 
+/// `value` rendered as a quoted TOML basic string, for embedding inside a
+/// `-c key=["..."]`-style config-override argv token (`extra_writable_root_
+/// args`, `approval_suppression_args`'s sibling for path values rather than
+/// bare identifiers). Escapes only the two bytes a TOML basic string cannot
+/// contain literally -- `\` and `"` -- which is the whole alphabet a real
+/// filesystem path can ever carry that would otherwise break out of the
+/// quotes; codex's own `-c`/`--config` value parser is TOML, so this mirrors
+/// the escaping any TOML parser requires, not a zirv-invented format.
+fn toml_quoted_string(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
 impl AgentAdapter for CodexAdapter {
     fn name(&self) -> &'static str {
         "codex"
@@ -963,19 +976,46 @@ impl AgentAdapter for CodexAdapter {
     /// installed codex-cli's `codex exec --help` no longer documents the
     /// flag, this projects the config-override form instead so the launch
     /// does not fail outright with an unrecognized-argument error.
+    ///
+    /// **`network` (2026-08-26, codex approval-posture round) is folded into
+    /// this method too, not `default_sandbox_args`**: that method's own
+    /// signature (`sandbox`, `safety`, `mode` -- no `policy`) would have to
+    /// change to reach `EffectivePolicy`, which is a trait-wide signature
+    /// change every adapter's `impl` must match, rippling into `claude.rs`
+    /// for a codex-only mapping this round is scoped to leave untouched. This
+    /// method already threads `policy` through, so it is the one place that
+    /// costs nothing extra to reach it from.
+    ///
+    /// `network` defaults to `Deny` (`EffectivePolicy`'s own `Default` impl,
+    /// see its doc comment), matching what an unwired install has always
+    /// done -- codex's own native default under `--sandbox workspace-write`
+    /// is already `network_access: false` with no zirv-added flag at all, so
+    /// `Deny`/`Ask` add nothing here, exactly as codex's shipped baseline
+    /// already behaves. Only the operator's explicit `Allow` adds the
+    /// `-c sandbox_workspace_write.network_access=true` config override --
+    /// verified to work on both the interactive and `exec` command surfaces
+    /// (`approval_suppression_args`'s own doc comment cites the same fact for
+    /// `approval_policy`). Claude's own sandbox network settings are
+    /// untouched by this round.
     fn policy_args(
         &self,
         policy: &crate::commands::ctx::policy::EffectivePolicy,
         mode: super::LaunchMode,
     ) -> Vec<String> {
         use crate::commands::ctx::policy::Stance;
-        if policy.repo_fs_write == Stance::Deny || policy.shell_exec == Stance::Deny {
+        let mut args = if policy.repo_fs_write == Stance::Deny || policy.shell_exec == Stance::Deny
+        {
             let mut args = self.read_only_args();
             args.extend(self.approval_suppression_args(mode, "never"));
             args
         } else {
             Vec::new()
+        };
+        if policy.network == Stance::Allow {
+            args.push("-c".to_string());
+            args.push("sandbox_workspace_write.network_access=true".to_string());
         }
+        args
     }
 
     /// The codex side of the shipped-default posture, split by launch mode
@@ -1038,6 +1078,50 @@ impl AgentAdapter for CodexAdapter {
             args.push("--approve-for-me".to_string());
         }
         args
+    }
+
+    /// Issue #119 (dash worktree panes) + the mail report-back gap
+    /// (2026-08-26, codex approval-posture round): see the trait method's own
+    /// doc comment for what this closes and why `cwd`/`mail_dir` are not
+    /// threaded through `default_sandbox_args` instead.
+    ///
+    /// One `-c sandbox_workspace_write.writable_roots=[...]` config override
+    /// carries every extra root this launch needs, never several separate
+    /// `-c` occurrences for the same key: codex's own config resolution is
+    /// last-value-wins (the same fact `approval_suppression_args`'s fallback
+    /// relies on for `approval_policy`), so a second `-c ...writable_roots=`
+    /// would silently replace the first rather than add to it. Verified to
+    /// work on both the interactive and `exec` command surfaces, the same
+    /// `-c/--config key=value` fact `approval_suppression_args`'s own doc
+    /// comment cites.
+    ///
+    /// The linked-worktree root is only added when `git_common_dir(cwd)`
+    /// resolves OUTSIDE `cwd` itself -- a main checkout's own `.git` already
+    /// sits inside `cwd`, and so inside `--sandbox workspace-write`'s own
+    /// root, without needing to be named again. `mail_dir` is always added:
+    /// it sits under the state root, always outside `cwd`, regardless of
+    /// worktree shape.
+    fn extra_writable_root_args(&self, cwd: &Path, mail_dir: &Path) -> Vec<String> {
+        let cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
+        let mut roots: Vec<PathBuf> = Vec::new();
+        if let Some(git_dir) = super::git_common_dir(&cwd)
+            && !git_dir.starts_with(&cwd)
+        {
+            roots.push(git_dir);
+        }
+        roots.push(mail_dir.to_path_buf());
+
+        let quoted: Vec<String> = roots
+            .iter()
+            .map(|root| toml_quoted_string(&root.display().to_string()))
+            .collect();
+        vec![
+            "-c".to_string(),
+            format!(
+                "sandbox_workspace_write.writable_roots=[{}]",
+                quoted.join(",")
+            ),
+        ]
     }
 
     fn launch_prefix_len(&self) -> usize {
@@ -1706,6 +1790,40 @@ mod tests {
         );
     }
 
+    /// `network` (2026-08-26, codex approval-posture round): `Deny`/`Ask`
+    /// (including `EffectivePolicy::default()`'s own `network: Deny`) add
+    /// nothing here -- codex's own native default under `--sandbox
+    /// workspace-write` is already closed, matching what an unwired install
+    /// has always done. Only the operator's explicit `Allow` adds the config
+    /// override, and as one `-c` occurrence -- never a bare `network_access`
+    /// substring split across two tokens some other way.
+    #[test]
+    fn policy_args_adds_the_network_override_only_when_policy_explicitly_allows_it() {
+        use crate::commands::ctx::policy::{EffectivePolicy, Stance};
+        let adapter = CodexAdapter::new(None);
+
+        let denied = adapter.policy_args(
+            &EffectivePolicy::default(),
+            super::super::LaunchMode::Headless,
+        );
+        assert!(
+            !denied.iter().any(|a| a.contains("network_access")),
+            "network must stay closed under the default policy: {denied:?}"
+        );
+
+        let allowed_policy = EffectivePolicy {
+            network: Stance::Allow,
+            ..EffectivePolicy::default()
+        };
+        let allowed = adapter.policy_args(&allowed_policy, super::super::LaunchMode::Headless);
+        assert!(
+            allowed
+                .windows(2)
+                .any(|w| w == ["-c", "sandbox_workspace_write.network_access=true"]),
+            "got {allowed:?}"
+        );
+    }
+
     /// `-a, --ask-for-approval <untrusted|on-request|never>`, verified
     /// against the installed `codex-cli 0.147.0`'s own `--help`/`exec --help`
     /// (see `policy_args`'s own doc comment and the 2026-08-22 addendum to
@@ -2119,6 +2237,131 @@ mod tests {
                 .iter()
                 .any(|a| a.contains("dangerously-bypass-approvals-and-sandbox")),
             "must never widen: {args:?}"
+        );
+    }
+
+    /// Issue #119 + the mail report-back gap (2026-08-26): a launch inside a
+    /// PLAIN checkout (not a linked worktree) must still get the mail
+    /// subtree as a writable root -- `zirv ctx send` report-back always
+    /// needs it -- but must never name the state root itself: only the
+    /// invariant is asserted (some writable-root arg naming the mail dir),
+    /// never exact argv, since the config-override string this builds is an
+    /// internal choice a test must not lock in more tightly than the
+    /// mechanism itself is verified.
+    #[test]
+    fn extra_writable_root_args_always_includes_the_mail_dir_but_never_the_bare_state_root() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        std::process::Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .arg(repo.path())
+            .status()
+            .expect("git init");
+        let state_root = tempfile::tempdir().expect("tempdir");
+        let mail_dir = state_root.path().join("mail");
+
+        let adapter = CodexAdapter::new(None);
+        let args = adapter.extra_writable_root_args(repo.path(), &mail_dir);
+
+        let joined = args.join(" ");
+        // Checked as a QUOTED, closed TOML string element (`"<path>"`), not a
+        // bare substring: `mail_dir` is itself `<state_root>/mail`, so a
+        // plain substring check for the state root's own path would also
+        // match inside the (correct) mail entry. Quoting-and-closing is what
+        // actually distinguishes "the state root named as its own array
+        // element" from "the mail subtree, which happens to start with the
+        // state root's path".
+        let quoted_mail = format!("\"{}\"", mail_dir.display());
+        let quoted_state_root = format!("\"{}\"", state_root.path().display());
+        assert!(
+            joined.contains(&quoted_mail),
+            "must name the mail subtree: {args:?}"
+        );
+        assert!(
+            !joined.contains(&quoted_state_root),
+            "must never name the bare state root as its own writable-root entry: {args:?}"
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "-c"
+                    && w[1].starts_with("sandbox_workspace_write.writable_roots=[")),
+            "got {args:?}"
+        );
+    }
+
+    /// The other half of issue #119: a launch whose `cwd` is a linked `git
+    /// worktree add` sibling must ALSO get the shared `.git` common dir as a
+    /// writable root, since it sits outside `cwd` (and so outside `--sandbox
+    /// workspace-write`'s own root) -- every git object/ref write from that
+    /// worktree lands there. A real linked worktree, not a guessed path: the
+    /// mechanism this pins is `git rev-parse --git-common-dir` itself, via
+    /// the moved-and-shared `adapters::git_common_dir`.
+    #[test]
+    fn extra_writable_root_args_adds_the_shared_git_dir_for_a_linked_worktree() {
+        let main_repo = tempfile::tempdir().expect("tempdir");
+        let run_git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(main_repo.path())
+                .status()
+                .expect("git");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        run_git(&["init", "-q"]);
+        run_git(&["config", "user.email", "test@example.com"]);
+        run_git(&["config", "user.name", "test"]);
+        std::fs::write(main_repo.path().join("f.txt"), "x").expect("write");
+        run_git(&["add", "."]);
+        run_git(&["commit", "-q", "-m", "init"]);
+
+        let linked = tempfile::tempdir().expect("tempdir");
+        let linked_path = linked.path().join("worktree");
+        run_git(&["worktree", "add", linked_path.to_str().expect("utf8 path")]);
+
+        let expected_git_dir =
+            super::super::git_common_dir(main_repo.path()).expect("main repo has a git common dir");
+
+        let state_root = tempfile::tempdir().expect("tempdir");
+        let mail_dir = state_root.path().join("mail");
+        let adapter = CodexAdapter::new(None);
+        let args = adapter.extra_writable_root_args(&linked_path, &mail_dir);
+
+        let joined = args.join(" ");
+        assert!(
+            joined.contains(&expected_git_dir.display().to_string()),
+            "must name the shared git common dir for a linked worktree: {args:?}"
+        );
+        assert!(
+            joined.contains(&mail_dir.display().to_string()),
+            "must still name the mail subtree too: {args:?}"
+        );
+    }
+
+    /// Issue "codex approval hell" (2026-08-26): an operator's own `-c
+    /// approval_policy=on-request` config override must pin the launch
+    /// exactly the way a bare `--ask-for-approval on-request` flag already
+    /// does -- `flags_pin_policy` now recognises the split `-c key=value`
+    /// form (see its own doc comment in `adapters/mod.rs`), so
+    /// `policy_launch_args` must append nothing at all after it, on any
+    /// installed codex-cli regardless of what its own `--help` probes
+    /// report.
+    #[test]
+    fn policy_launch_args_appends_nothing_after_an_operator_config_override_of_approval_policy() {
+        let cfg = CtxConfig::default();
+        let adapter = CodexAdapter::new(None)
+            .with_on_request_approval_forced(true)
+            .with_exec_ask_for_approval_forced(false);
+        let flags = vec!["-c".to_string(), "approval_policy=on-request".to_string()];
+        let out = crate::commands::ctx::adapters::policy_launch_args(
+            &cfg,
+            &adapter,
+            &flags,
+            super::super::LaunchMode::Headless,
+        );
+        assert!(
+            out.is_empty(),
+            "zirv must not append anything after the operator's own -c approval_policy=... \
+             override: {out:?}"
         );
     }
 

--- a/src/commands/ctx/adapters/codex.rs
+++ b/src/commands/ctx/adapters/codex.rs
@@ -585,15 +585,36 @@ fn find_rollout(dir: &Path, filename_suffix: &str) -> Option<PathBuf> {
     None
 }
 
-/// `value` rendered as a quoted TOML basic string, for embedding inside a
-/// `-c key=["..."]`-style config-override argv token (`extra_writable_root_
+/// `value` rendered as a quoted TOML string, for embedding inside a `-c
+/// key=["..."]`-style config-override argv token (`extra_writable_root_
 /// args`, `approval_suppression_args`'s sibling for path values rather than
-/// bare identifiers). Escapes only the two bytes a TOML basic string cannot
-/// contain literally -- `\` and `"` -- which is the whole alphabet a real
-/// filesystem path can ever carry that would otherwise break out of the
-/// quotes; codex's own `-c`/`--config` value parser is TOML, so this mirrors
-/// the escaping any TOML parser requires, not a zirv-invented format.
+/// bare identifiers). codex's own `-c`/`--config` value parser is TOML, so
+/// this always produces syntax any TOML parser accepts, never a
+/// zirv-invented format.
+///
+/// **Prefers a TOML LITERAL string (`'...'`)** -- no escape processing at
+/// all, so a Windows path's `\` survives untouched -- **over a basic string
+/// (`"..."`), specifically to avoid ever emitting a literal `"`.** A real
+/// bug (2026-08-26, found running this branch's own gates on Windows): the
+/// previous basic-string form escaped `\`/`"` correctly per TOML's own
+/// rules, but `guard_cmd_shim_reparse`'s `CMD_REPARSE_METACHARS` refuses any
+/// argument containing a raw `"` outright on a `cmd.exe`/`powershell` shim
+/// launch (CVE-2024-24576's quote-toggle) -- so the moment `extra_writable_
+/// root_args` was wired in (unconditionally, into every dashboard-spawned
+/// worker pane), a codex pane reached through an npm-installed `.cmd` or a
+/// `.ps1` could never launch at all: its own writable-roots argument tripped
+/// the very guard meant to stop injected content, despite carrying nothing
+/// but zirv-computed paths. A literal string sidesteps this rather than
+/// weakening the guard, which stays a correct, unconditional backstop.
+///
+/// Falls back to an escaped basic string only when `value` itself contains a
+/// literal `'`, which a TOML literal string has no way to represent at all
+/// (pathological for a real filesystem path; that case is not, and was never,
+/// spawnable through a shim launch either way).
 fn toml_quoted_string(value: &str) -> String {
+    if !value.contains('\'') && !value.chars().any(|c| c.is_control() && c != '\t') {
+        return format!("'{value}'");
+    }
     let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
     format!("\"{escaped}\"")
 }
@@ -2250,6 +2271,17 @@ mod tests {
     /// never exact argv, since the config-override string this builds is an
     /// internal choice a test must not lock in more tightly than the
     /// mechanism itself is verified.
+    ///
+    /// A real bug found running this branch's own gates on Windows
+    /// (2026-08-26): `toml_quoted_string`'s basic-string form embeds a
+    /// literal `"` in every writable-root argv token it builds, and
+    /// `guard_cmd_shim_reparse`'s `CMD_REPARSE_METACHARS` refuses `"`
+    /// outright on any `cmd.exe`/`powershell` shim launch (an npm-installed
+    /// `.cmd`, or a `.ps1`) -- so a codex pane spawned through a shim could
+    /// never launch at all once `extra_writable_root_args` was wired in,
+    /// unconditionally, into every dashboard-spawned worker pane. See
+    /// `no_extra_writable_root_arg_ever_trips_the_cmd_shim_reparse_guard`
+    /// below for the direct regression test.
     #[test]
     fn extra_writable_root_args_always_includes_the_mail_dir_but_never_the_bare_state_root() {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -2275,11 +2307,10 @@ mod tests {
         // state root's path".
         //
         // Built through the same `toml_quoted_string` the implementation
-        // uses, not a bare `"<path>"` wrap: on Windows a raw path contains
-        // `\`, which `toml_quoted_string` doubles to stay valid inside a
-        // TOML basic string, so the naive wrap never matches the real argv
-        // there (found 2026-08-26, Windows dev machine -- the implementation
-        // was already correct, only this assertion was not).
+        // uses, not a bare `"<path>"` wrap: `toml_quoted_string` quotes with
+        // `'...'` (a TOML literal string) whenever it can, not `"..."`, so a
+        // naive double-quote wrap never matches the real argv (found
+        // 2026-08-26, Windows dev machine).
         let quoted_mail = toml_quoted_string(&mail_dir.display().to_string());
         let quoted_state_root = toml_quoted_string(&state_root.path().display().to_string());
         assert!(
@@ -2337,11 +2368,10 @@ mod tests {
 
         let joined = args.join(" ");
         // Same fix as `extra_writable_root_args_always_includes_the_mail_
-        // dir_but_never_the_bare_state_root` above: compare against the
-        // `toml_quoted_string`-escaped form, since a raw Windows path's `\`
-        // is doubled by the implementation to stay valid inside the TOML
-        // basic string, and a bare `.display()` substring check never
-        // matches that escaped form there.
+        // dir_but_never_the_bare_state_root` above: compare against
+        // `toml_quoted_string`'s own quoted form (a TOML literal string,
+        // `'...'`), not a bare `.display()` substring check, which never
+        // matches once the value is quoted.
         assert!(
             joined.contains(&toml_quoted_string(&expected_git_dir.display().to_string())),
             "must name the shared git common dir for a linked worktree: {args:?}"
@@ -2350,6 +2380,37 @@ mod tests {
             joined.contains(&toml_quoted_string(&mail_dir.display().to_string())),
             "must still name the mail subtree too: {args:?}"
         );
+    }
+
+    /// The regression this round fixes, exercised end to end through the
+    /// real guard rather than only inspecting `toml_quoted_string`'s output
+    /// (2026-08-26): `extra_writable_root_args`'s own argv, appended after a
+    /// `cmd.exe /c <shim>` prefix exactly as a real npm-installed codex shim
+    /// launch would carry it, must never trip `guard_cmd_shim_reparse`. This
+    /// is not a hypothetical -- `dash::worker_pane_extra_args` calls
+    /// `extra_writable_root_args` unconditionally for every dashboard-spawned
+    /// worker pane (see that function's own doc comment), so before this fix
+    /// a codex pane reached through a `.cmd` shim could never launch at all.
+    #[test]
+    fn no_extra_writable_root_arg_ever_trips_the_cmd_shim_reparse_guard() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        std::process::Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .arg(repo.path())
+            .status()
+            .expect("git init");
+        let state_root = tempfile::tempdir().expect("tempdir");
+        let mail_dir = state_root.path().join("mail");
+
+        let adapter = CodexAdapter::new(None);
+        let extra = adapter.extra_writable_root_args(repo.path(), &mail_dir);
+        assert!(!extra.is_empty(), "the mail root alone must still add args");
+
+        let mut shim_args = vec!["/c".to_string(), "codex.cmd".to_string()];
+        shim_args.extend(extra);
+        crate::commands::ctx::adapters::guard_cmd_shim_reparse("cmd.exe", &shim_args)
+            .expect("extra_writable_root_args must never trip the cmd-shim reparse guard");
     }
 
     /// Issue "codex approval hell" (2026-08-26): an operator's own `-c

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -150,13 +150,17 @@ impl LaunchMode {
 /// overridden by zirv's own. `CODEX_CONFIG_OVERRIDE_KEYS` below closes that
 /// gap for the split form (`-c`/`--config` followed by a `key=value` token,
 /// checked pairwise since the key lives in the *next* token, unlike every
-/// other flag this function recognises) and the `=`-joined single-token form
+/// other flag this function recognises), the `=`-joined single-token form
 /// (`--config=approval_policy=...`), mirroring the existing `--sandbox=...`
-/// handling above. All-or-nothing, same as every other flag this function
-/// recognises: pinning just one dimension (e.g. only `approval_policy`)
-/// withholds zirv's *entire* computed prefix, not only the approval half --
-/// `policy_launch_args` has no partial-prefix concept, and this function's
-/// contract has always been "the operator's own flag pins policy outright".
+/// handling above, and (2026-08-26, correction round) codex's own attached
+/// short form -- `-cKEY=VALUE` with no space at all, verified accepted by
+/// codex-cli 0.149.1, mirroring the attached `-mvalue` form
+/// `classify_model_flag` already recognises for `--model`. All-or-nothing,
+/// same as every other flag this function recognises: pinning just one
+/// dimension (e.g. only `approval_policy`) withholds zirv's *entire*
+/// computed prefix, not only the approval half -- `policy_launch_args` has
+/// no partial-prefix concept, and this function's contract has always been
+/// "the operator's own flag pins policy outright".
 ///
 /// Mirrors `agent.rs`'s own `flags_pin_model` in spirit: the operator's own
 /// explicit choice must demonstrably win over a zirv-computed default, not
@@ -196,6 +200,15 @@ pub fn flags_pin_policy(flags: &[String]) -> bool {
             return flags
                 .get(i + 1)
                 .is_some_and(|next| names_a_config_override_key(next));
+        }
+        // Codex's attached short form (`-cKEY=VALUE`, no space) -- checked
+        // after the `f == "-c"` split form above so a bare `-c` still falls
+        // through to that pairwise check rather than being consumed here
+        // with an empty attached value.
+        if let Some(rest) = f.strip_prefix("-c") {
+            if !rest.is_empty() && names_a_config_override_key(rest) {
+                return true;
+            }
         }
         false
     })
@@ -1144,15 +1157,19 @@ pub trait AgentAdapter: std::fmt::Debug {
     /// Default is empty: the same "nothing verified to guess" shape every
     /// other optional method on this trait uses, and also the *correct*
     /// answer for the shipped default -- `EffectivePolicy::default()` is
-    /// all-`Allow` (`Stance::Allow`'s own doc comment: "zirv declares no
-    /// restriction of its own"), so an operator who has set no `[policy]`
-    /// table at all gets byte-for-byte the same argv as before this method
-    /// existed, on every adapter. Anything more restrictive requires an
-    /// explicit `[policy]` stance, and anything more *permissive* than the
-    /// default cannot come from this method at all: there is no `Stance`
-    /// value that widens past `Allow`, and a repo checkout cannot set one
-    /// stricter than the operator's own layer either (`policy::resolve`'s
-    /// narrow-only fold -- see that module's doc comment).
+    /// `Allow` on every capability except `network` (`Stance::Allow`'s own
+    /// doc comment: "zirv declares no restriction of its own";
+    /// `EffectivePolicy`'s own doc comment covers `network`'s exception,
+    /// `Option<Stance>` defaulting to `None` -- "no operator layer has ever
+    /// named it" -- rather than a `Stance` this method would need to act
+    /// on), so an operator who has set no `[policy]` table at all gets
+    /// byte-for-byte the same argv as before this method existed, on every
+    /// adapter. Anything more restrictive requires an explicit `[policy]`
+    /// stance, and anything more *permissive* than the default cannot come
+    /// from this method at all: there is no `Stance` value that widens past
+    /// `Allow`, and a repo checkout cannot set one stricter than the
+    /// operator's own layer either (`policy::resolve`'s narrow-only fold --
+    /// see that module's doc comment).
     ///
     /// Only a capability this adapter also names `Enforced`/`Degraded` for in
     /// `policy_support` may ever change this launch's argv: `Ask`/`Allow`
@@ -1231,8 +1248,14 @@ pub trait AgentAdapter: std::fmt::Debug {
     }
 
     /// Extra writable-root argv for a launch whose working directory is
-    /// `cwd`, beyond `default_sandbox_args`'s own baseline sandbox flags --
-    /// added as a distinct method (2026-08-26, codex approval-posture round)
+    /// `cwd`, beyond `default_sandbox_args`'s own baseline sandbox flags.
+    ///
+    /// **Caller contract:** call only where both `cwd` and `mail_dir` are
+    /// already in hand for a launch that is actually happening -- today that
+    /// is `dash::worker_pane_extra_args` alone (see below), called
+    /// unconditionally for every dashboard-spawned worker pane, never
+    /// speculatively for a launch that may not occur. Added as a distinct
+    /// method (2026-08-26, codex approval-posture round)
     /// rather than folded into `default_sandbox_args` itself, since neither
     /// `cwd` nor `mail_dir` is available at that method's existing call site
     /// (`policy_launch_args`) without threading them through all seven
@@ -2616,6 +2639,28 @@ mod tests {
         assert!(flags_pin_policy(&[
             "--config=sandbox_mode=danger-full-access".to_string()
         ]));
+    }
+
+    /// The bug this round fixes: codex-cli 0.149.1 also accepts `-c`'s
+    /// argument attached to the flag itself with no space (`-cKEY=VALUE`),
+    /// mirroring the attached short form `classify_model_flag` already
+    /// recognises for `-m` (`-mopus`). Before this, only the split
+    /// (`-c`/`--config` plus a following token) and `--config=`-joined forms
+    /// were recognised, so an operator spelling their override as
+    /// `-capproval_policy=on-request` was invisible to `flags_pin_policy` and
+    /// zirv's own computed prefix still landed after it.
+    #[test]
+    fn flags_pin_policy_recognizes_codexs_attached_short_config_override_form() {
+        assert!(flags_pin_policy(&[
+            "-capproval_policy=on-request".to_string()
+        ]));
+        assert!(flags_pin_policy(&[
+            "-csandbox_mode=read-only".to_string()
+        ]));
+        // Precision still matters: an attached `-c` naming an unrelated key
+        // must not false-positive, and `-c` itself (no attached value) is the
+        // ordinary split form, already covered above.
+        assert!(!flags_pin_policy(&["-cmodel=gpt-5.6-sol".to_string()]));
     }
 
     /// A bare `-c`/`--config` with no following token, or one overriding an

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -137,6 +137,27 @@ impl LaunchMode {
 /// silently *withholding* zirv's own restriction rather than merely
 /// mis-ordering a model flag, so precision matters more than coverage.
 ///
+/// **Codex `-c`/`--config` overrides (2026-08-26, approval-posture round):**
+/// an operator may also pin codex's approval/sandbox posture via a raw
+/// config override -- `-c approval_policy=<value>`, `-c sandbox_mode=<value>`,
+/// or the long `--config` spelling of either -- rather than the dedicated
+/// `--ask-for-approval`/`--sandbox` flags above. Before this, that spelling
+/// was invisible to this function: `flags_pin_policy` returned `false`, so
+/// `policy_launch_args` still prepended zirv's own `-c approval_policy=...`
+/// (`CodexAdapter::approval_suppression_args`'s exec-probe fallback) *after*
+/// the operator's own override, and codex's config resolution is
+/// last-value-wins, so the operator's explicit choice was silently
+/// overridden by zirv's own. `CODEX_CONFIG_OVERRIDE_KEYS` below closes that
+/// gap for the split form (`-c`/`--config` followed by a `key=value` token,
+/// checked pairwise since the key lives in the *next* token, unlike every
+/// other flag this function recognises) and the `=`-joined single-token form
+/// (`--config=approval_policy=...`), mirroring the existing `--sandbox=...`
+/// handling above. All-or-nothing, same as every other flag this function
+/// recognises: pinning just one dimension (e.g. only `approval_policy`)
+/// withholds zirv's *entire* computed prefix, not only the approval half --
+/// `policy_launch_args` has no partial-prefix concept, and this function's
+/// contract has always been "the operator's own flag pins policy outright".
+///
 /// Mirrors `agent.rs`'s own `flags_pin_model` in spirit: the operator's own
 /// explicit choice must demonstrably win over a zirv-computed default, not
 /// merely happen to survive because a CLI takes the last occurrence of a
@@ -153,10 +174,30 @@ pub fn flags_pin_policy(flags: &[String]) -> bool {
         "-a",
         "--approve-for-me",
     ];
-    flags.iter().any(|f| {
-        POLICY_FLAG_NAMES
+    const CODEX_CONFIG_OVERRIDE_KEYS: &[&str] = &["approval_policy", "sandbox_mode"];
+
+    let names_a_config_override_key = |value: &str| {
+        CODEX_CONFIG_OVERRIDE_KEYS
+            .iter()
+            .any(|key| value == *key || value.starts_with(&format!("{key}=")))
+    };
+
+    flags.iter().enumerate().any(|(i, f)| {
+        if POLICY_FLAG_NAMES
             .iter()
             .any(|name| f == name || f.starts_with(&format!("{name}=")))
+        {
+            return true;
+        }
+        if let Some(rest) = f.strip_prefix("--config=") {
+            return names_a_config_override_key(rest);
+        }
+        if f == "-c" || f == "--config" {
+            return flags
+                .get(i + 1)
+                .is_some_and(|next| names_a_config_override_key(next));
+        }
+        false
     })
 }
 
@@ -1186,6 +1227,37 @@ pub trait AgentAdapter: std::fmt::Debug {
         mode: LaunchMode,
     ) -> Vec<String> {
         let _ = (sandbox, safety, mode);
+        Vec::new()
+    }
+
+    /// Extra writable-root argv for a launch whose working directory is
+    /// `cwd`, beyond `default_sandbox_args`'s own baseline sandbox flags --
+    /// added as a distinct method (2026-08-26, codex approval-posture round)
+    /// rather than folded into `default_sandbox_args` itself, since neither
+    /// `cwd` nor `mail_dir` is available at that method's existing call site
+    /// (`policy_launch_args`) without threading them through all seven
+    /// launch seams that call it; this is called separately, only where a
+    /// caller already has both in hand (currently `dash::worker_pane_extra_
+    /// args`, the one seam issue #119's own evidence names).
+    ///
+    /// Two concrete gaps this closes for codex, neither addressed by
+    /// `default_sandbox_args`'s `--sandbox workspace-write`:
+    /// - a dashboard pane whose `cwd` is a linked `git worktree add` sibling
+    ///   (issue #119) shares its `.git` common dir with the main checkout,
+    ///   which sits OUTSIDE `cwd` and so outside the workspace-write
+    ///   sandbox -- every git object/ref write a worker makes there fails
+    ///   (headless) or escalates (interactive) with no mechanism to grant it.
+    /// - `zirv ctx send`'s report-back write lands under the state dir's
+    ///   `mail/` subtree, also outside `cwd`, so it is denied the same way.
+    ///
+    /// Default empty -- no verified per-run mechanism, matching every other
+    /// "no verified mechanism" trait default on this trait (`policy_args`,
+    /// `default_sandbox_args`); only `CodexAdapter` overrides it. `mail_dir`
+    /// is deliberately the mail subtree alone (`StateDir::mail()`), never the
+    /// whole state root: policy snapshots and the decision log must stay
+    /// unwritable by the workload even when this widens the mail path.
+    fn extra_writable_root_args(&self, cwd: &Path, mail_dir: &Path) -> Vec<String> {
+        let _ = (cwd, mail_dir);
         Vec::new()
     }
 
@@ -2446,9 +2518,141 @@ pub fn command_matches_adapter(
     agent_explicit || adapter.detect(command)
 }
 
+/// The canonicalised git "common dir" that owns `path` -- the shared `.git`
+/// directory a plain repo and every `git worktree add`-linked sibling of it
+/// all point back at -- or `None` if `git` is missing, `path` is not inside a
+/// git working tree, or the process exits non-zero. Best-effort and
+/// shell-out only, same precedent as `compile::changed_repo_paths`.
+///
+/// `git rev-parse --git-common-dir` prints a path RELATIVE to `path` for a
+/// main worktree (typically just `.git`) but an ABSOLUTE one for a linked
+/// worktree (it points back at the main checkout's `.git`). Both forms are
+/// resolved against `path` before canonicalising, so a main worktree and any
+/// of its linked siblings canonicalise to the exact same `PathBuf` even
+/// though git reports the two differently.
+///
+/// Code review (issue #119, round 2): this used to back an authorization
+/// check in `dash/mod.rs` alone (its answer decided whether a spawn request
+/// got to run a real agent), so it must not trust an inherited environment
+/// that a request's own process could have set. `GIT_DIR`/`GIT_COMMON_DIR`/
+/// `GIT_WORK_TREE` (and `GIT_INDEX_FILE`, for the same family of override)
+/// all redirect where `git` looks for repo state regardless of `-C`'s
+/// argument; left inherited, any one of them set in the calling process
+/// would make `git` resolve to the SAME overridden value for two genuinely
+/// unrelated paths. Stripped here, at the one seam that shells out to `git`
+/// for this decision, rather than trusted to already be absent from the
+/// caller's environment -- a property every caller inherits for free,
+/// including `CodexAdapter::extra_writable_root_args` below.
+///
+/// Moved here from `dash/mod.rs` (2026-08-26, codex approval-posture round):
+/// `dash` already imports `adapters` (`policy_launch_args`, `LaunchMode`,
+/// ...), so `adapters` calling back into `dash` would be a cycle -- this is
+/// the shared home the one-directional import graph demands, used by
+/// `dash::accepted_spawn_cwd`'s eligibility check (issue #119) and by
+/// `CodexAdapter::extra_writable_root_args`'s writable-root computation
+/// (same issue, the other half: eligibility says a linked worktree pane may
+/// run, this says its shared git dir must actually be writable once it does).
+pub(crate) fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .arg("-C")
+        .arg(path)
+        .arg("rev-parse")
+        .arg("--git-common-dir")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let candidate = PathBuf::from(raw);
+    let resolved = if candidate.is_absolute() {
+        candidate
+    } else {
+        path.join(candidate)
+    };
+    std::fs::canonicalize(&resolved).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue "codex approval hell" (2026-08-26): before this, `-c
+    /// approval_policy=...`/`-c sandbox_mode=...` were invisible to
+    /// `flags_pin_policy`, so zirv's own computed config-override fallback
+    /// (`CodexAdapter::approval_suppression_args`) still landed after an
+    /// operator's own override and won outright (codex's config resolution
+    /// is last-value-wins). Both the split (`-c`/`--config` plus a following
+    /// `key=value` token) and the `=`-joined single-token forms must pin.
+    #[test]
+    fn flags_pin_policy_recognizes_codex_config_overrides_of_approval_or_sandbox_mode() {
+        assert!(flags_pin_policy(&[
+            "-c".to_string(),
+            "approval_policy=on-request".to_string()
+        ]));
+        assert!(flags_pin_policy(&[
+            "-c".to_string(),
+            "sandbox_mode=read-only".to_string()
+        ]));
+        assert!(flags_pin_policy(&[
+            "--config".to_string(),
+            "approval_policy=never".to_string()
+        ]));
+        assert!(flags_pin_policy(&[
+            "--config".to_string(),
+            "sandbox_mode=workspace-write".to_string()
+        ]));
+        assert!(flags_pin_policy(&[
+            "--config=approval_policy=on-request".to_string()
+        ]));
+        assert!(flags_pin_policy(&[
+            "--config=sandbox_mode=danger-full-access".to_string()
+        ]));
+    }
+
+    /// A bare `-c`/`--config` with no following token, or one overriding an
+    /// unrelated key, must not false-positive: this function's whole
+    /// contract is precision over coverage (see its own doc comment), and a
+    /// false positive here means silently *withholding* zirv's restriction.
+    #[test]
+    fn flags_pin_policy_ignores_unrelated_or_dangling_config_overrides() {
+        assert!(!flags_pin_policy(&[
+            "-c".to_string(),
+            "model=gpt-5.6-sol".to_string()
+        ]));
+        assert!(!flags_pin_policy(&["-c".to_string()]));
+        assert!(!flags_pin_policy(&["--config".to_string()]));
+        assert!(!flags_pin_policy(&[]));
+    }
+
+    /// One dimension pins the whole prefix, the same all-or-nothing
+    /// granularity a bare operator `--sandbox`/`--ask-for-approval` flag
+    /// already has (see the function's own doc comment): a `-c
+    /// approval_policy=...` override alone, with no accompanying
+    /// `sandbox_mode` override, still withholds zirv's entire computed
+    /// prefix rather than just the approval half.
+    #[test]
+    fn flags_pin_policy_config_override_pins_the_whole_prefix_not_just_one_dimension() {
+        let flags = vec!["-c".to_string(), "approval_policy=on-request".to_string()];
+        assert!(flags_pin_policy(&flags));
+        let cfg = CtxConfig::default();
+        let codex = codex::CodexAdapter::new(None)
+            .with_on_request_approval_forced(true)
+            .with_exec_ask_for_approval_forced(true);
+        assert!(
+            policy_launch_args(&cfg, &codex, &flags, LaunchMode::Headless).is_empty(),
+            "an operator's own -c approval_policy=... override must suppress zirv's entire \
+             computed prefix, not just the approval flag"
+        );
+    }
 
     /// The interactive/headless seam itself (2026-08-24, cross-harness
     /// permissions): the enum every real-launch call site now has to answer

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -205,10 +205,11 @@ pub fn flags_pin_policy(flags: &[String]) -> bool {
         // after the `f == "-c"` split form above so a bare `-c` still falls
         // through to that pairwise check rather than being consumed here
         // with an empty attached value.
-        if let Some(rest) = f.strip_prefix("-c") {
-            if !rest.is_empty() && names_a_config_override_key(rest) {
-                return true;
-            }
+        if let Some(rest) = f.strip_prefix("-c")
+            && !rest.is_empty()
+            && names_a_config_override_key(rest)
+        {
+            return true;
         }
         false
     })
@@ -2654,9 +2655,7 @@ mod tests {
         assert!(flags_pin_policy(&[
             "-capproval_policy=on-request".to_string()
         ]));
-        assert!(flags_pin_policy(&[
-            "-csandbox_mode=read-only".to_string()
-        ]));
+        assert!(flags_pin_policy(&["-csandbox_mode=read-only".to_string()]));
         // Precision still matters: an attached `-c` naming an unrelated key
         // must not false-positive, and `-c` itself (no attached value) is the
         // ordinary split form, already covered above.

--- a/src/commands/ctx/config.rs
+++ b/src/commands/ctx/config.rs
@@ -4495,7 +4495,7 @@ mod tests {
         let empty = env_map(&[]);
         let cfg = CtxConfig::load(repo.path(), &|k| empty.get(k).cloned()).expect("load");
         assert_eq!(cfg.policy.shell_exec, Stance::Ask);
-        assert_eq!(cfg.policy.network, Stance::Deny);
+        assert_eq!(cfg.policy.network, Some(Stance::Deny));
         assert_eq!(cfg.policy.repo_fs_write, Stance::Allow);
 
         let env = env_map(&[("ZIRV_CTX_POLICY_SHELL_EXEC", "deny")]);
@@ -4503,7 +4503,7 @@ mod tests {
         assert_eq!(cfg.policy.shell_exec, Stance::Deny);
         assert_eq!(
             cfg.policy.network,
-            Stance::Deny,
+            Some(Stance::Deny),
             "the home layer still applies under the env layer"
         );
     }
@@ -4537,7 +4537,7 @@ mod tests {
         let empty = env_map(&[]);
         let cfg = CtxConfig::load(repo.path(), &|k| empty.get(k).cloned()).expect("load");
         assert_eq!(cfg.policy.shell_exec, Stance::Deny);
-        assert_eq!(cfg.policy.network, Stance::Deny);
+        assert_eq!(cfg.policy.network, Some(Stance::Deny));
         assert_eq!(cfg.policy.approval, Stance::Ask);
     }
 

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -2153,60 +2153,6 @@ fn same_directory(a: &Path, b: &Path) -> bool {
     canon(a) == canon(b)
 }
 
-/// The canonicalised git "common dir" that owns `path` -- the shared `.git`
-/// directory a plain repo and every `git worktree add`-linked sibling of it
-/// all point back at -- or `None` if `git` is missing, `path` is not inside a
-/// git working tree, or the process exits non-zero. Best-effort and
-/// shell-out only, same precedent as `compile::changed_repo_paths`.
-///
-/// `git rev-parse --git-common-dir` prints a path RELATIVE to `path` for a
-/// main worktree (typically just `.git`) but an ABSOLUTE one for a linked
-/// worktree (it points back at the main checkout's `.git`). Both forms are
-/// resolved against `path` before canonicalising, so a main worktree and any
-/// of its linked siblings canonicalise to the exact same `PathBuf` even
-/// though git reports the two differently.
-///
-/// Code review (issue #119, round 2): this is an authorization check -- its
-/// answer decides whether a spawn request gets to run a real agent -- so it
-/// must not trust an inherited environment that a request's own process
-/// could have set. `GIT_DIR`/`GIT_COMMON_DIR`/`GIT_WORK_TREE` (and
-/// `GIT_INDEX_FILE`, for the same family of override) all redirect where
-/// `git` looks for repo state regardless of `-C`'s argument; left inherited,
-/// any one of them set in the dashboard's own process would make `git`
-/// resolve to the SAME overridden value for both `req_cwd` and `repo`,
-/// making the equality this function backs trivially true for two genuinely
-/// unrelated repos. Stripped here, at the one seam that shells out to `git`
-/// for this decision, rather than trusted to already be absent from the
-/// dashboard's environment.
-fn git_common_dir(path: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_COMMON_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .arg("-C")
-        .arg(path)
-        .arg("rev-parse")
-        .arg("--git-common-dir")
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let raw = String::from_utf8_lossy(&output.stdout);
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return None;
-    }
-    let candidate = PathBuf::from(raw);
-    let resolved = if candidate.is_absolute() {
-        candidate
-    } else {
-        path.join(candidate)
-    };
-    std::fs::canonicalize(&resolved).ok()
-}
-
 /// Whether a spawn request naming `req_cwd` may be fulfilled by a dashboard
 /// whose own repo is `repo`, and if so, the directory the freshly spawned
 /// pane should actually run in.
@@ -2234,7 +2180,10 @@ fn accepted_spawn_cwd(req_cwd: &Path, repo: &Path) -> Option<PathBuf> {
     if same_directory(req_cwd, repo) {
         return Some(req_cwd.to_path_buf());
     }
-    match (git_common_dir(req_cwd), git_common_dir(repo)) {
+    match (
+        adapters::git_common_dir(req_cwd),
+        adapters::git_common_dir(repo),
+    ) {
         (Some(a), Some(b)) if a == b => Some(req_cwd.to_path_buf()),
         _ => None,
     }
@@ -2277,13 +2226,25 @@ fn pane_launch_extra(
 /// only a lone `--model` pin (see `try_join_dashboard` in `agent.rs`) --
 /// there is no generic trailing-flags channel here for an operator to pin a
 /// conflicting `--sandbox`/`--ask-for-approval` through, so `flags_pin_
-/// policy` (inside `policy_launch_args`) is checked against an empty slice.
+/// policy` (inside `policy_launch_args`) is checked against an empty slice --
+/// which is also why `adapters::AgentAdapter::extra_writable_root_args`
+/// below is called unconditionally rather than gated on `flags_pin_policy`
+/// itself: with no trailing flags this pane can ever pin policy with, that
+/// gate is always open here (see task 3's own binding decision: the extra
+/// writable roots only apply "when the operator hasn't pinned policy").
+///
+/// `req.cwd` (issue #119) + `state.mail()` (`zirv ctx send` report-back) are
+/// the two writable roots `CodexAdapter::extra_writable_root_args` may add on
+/// top of `policy_launch_args`'s own sandbox baseline -- see that method's
+/// own doc comment for the mechanism and why they are not threaded through
+/// `policy_launch_args` itself.
 fn worker_pane_extra_args(
     req: &spawnreq::SpawnRequest,
     cfg: &CtxConfig,
     adapter: &dyn adapters::AgentAdapter,
     prompt_args: Vec<String>,
     session_id: &str,
+    state: &StateDir,
 ) -> Vec<String> {
     let mut extra = pane_model_args(req, cfg, adapter);
     extra.extend(adapters::policy_launch_args(
@@ -2299,6 +2260,7 @@ fn worker_pane_extra_args(
             adapters::LaunchMode::Headless
         },
     ));
+    extra.extend(adapter.extra_writable_root_args(&req.cwd, &state.mail()));
     extra.extend(pane_launch_extra(adapter, prompt_args, session_id));
     extra
 }
@@ -2834,7 +2796,7 @@ fn fulfill_spawn_request(
         fallback_is_safe,
     );
 
-    let extra = worker_pane_extra_args(req, cfg, adapter.as_ref(), prompt_args, &session_id);
+    let extra = worker_pane_extra_args(req, cfg, adapter.as_ref(), prompt_args, &session_id, state);
     let argv = flatten_command(adapter.interactive_cmd(Some(&effective_prompt), &extra));
     let spec = PaneSpec {
         agent_name: req.agent.clone(),
@@ -9766,6 +9728,7 @@ mod tests {
         let cfg = CtxConfig::default();
         let repo = tmp.path().to_path_buf();
         let req = spawn_request("do the work", &repo);
+        let state = StateDir::from_root(tmp.path().join("state"));
 
         let claude = super::super::adapters::claude::ClaudeAdapter::new(None);
         let claude_extra = worker_pane_extra_args(
@@ -9774,6 +9737,7 @@ mod tests {
             &claude,
             Vec::new(),
             "cccccccc-1111-4333-8444-555555555555",
+            &state,
         );
         assert!(
             claude_extra.contains(&"--permission-mode".to_string())
@@ -9795,6 +9759,7 @@ mod tests {
             &codex,
             Vec::new(),
             "cccccccc-2222-4333-8444-555555555555",
+            &state,
         );
         assert!(
             codex_extra
@@ -9829,6 +9794,7 @@ mod tests {
         let repo = tmp.path().to_path_buf();
         let mut req = spawn_request("do the work", &repo);
         req.interactive = false;
+        let state = StateDir::from_root(tmp.path().join("state"));
 
         let claude = super::super::adapters::claude::ClaudeAdapter::new(None);
         let extra = worker_pane_extra_args(
@@ -9837,6 +9803,7 @@ mod tests {
             &claude,
             Vec::new(),
             "dddddddd-1111-4333-8444-555555555555",
+            &state,
         );
         assert!(
             extra.contains(&"--permission-mode".to_string())
@@ -9861,6 +9828,7 @@ mod tests {
         };
         let repo = tmp.path().to_path_buf();
         let req = spawn_request("do the work", &repo);
+        let state = StateDir::from_root(tmp.path().join("state"));
         let codex = super::super::adapters::codex::CodexAdapter::new(None);
         let extra = worker_pane_extra_args(
             &req,
@@ -9868,6 +9836,7 @@ mod tests {
             &codex,
             Vec::new(),
             "cccccccc-3333-4333-8444-555555555555",
+            &state,
         );
         assert!(!extra.contains(&"--sandbox".to_string()), "got {extra:?}");
     }

--- a/src/commands/ctx/permissions.rs
+++ b/src/commands/ctx/permissions.rs
@@ -833,6 +833,24 @@ fn transcripts_root(agent: AuditAgent) -> Option<PathBuf> {
     }
 }
 
+/// Codex has no per-command permission-hook contract zirv can pin the way
+/// claude's `PreToolUse` hook is (`safety.rs`'s own doc comment): a codex
+/// launch never consults `[safety]` at all (`CodexAdapter::default_sandbox_
+/// args`'s own `let _ = (sandbox, safety);`, and `policy_args` reads only
+/// `[policy]`, never `[safety]`). So while `permissions compile` still
+/// writes real `[safety] allow` entries for a codex audit -- they are the
+/// honest record of what a codex session actually asked for, and claude
+/// reads them -- those entries change nothing about how *codex itself*
+/// launches. Printed on every codex `audit`/`compile` run (including the
+/// default `--agent codex`, `AuditArgs`/`CompileArgs`'s own `default_value`)
+/// so an operator does not read "compiled" as "codex now enforces this".
+/// Upstream `exec_permission_approvals`/`request_permissions_tool` (a
+/// per-command hook codex itself would consult) are still in development,
+/// not yet something this codebase can pin against.
+const CODEX_SAFETY_NO_OP_CAVEAT: &str = "caveat: compiled [safety] allow entries do not change codex's own launch posture -- \
+     codex has no per-command approval hook zirv can pin (upstream exec_permission_approvals \
+     / request_permissions_tool are still in development)";
+
 pub fn run_audit<W: Write>(args: &AuditArgs, w: &mut W) -> CtxResult<i32> {
     let files = transcripts_root(args.agent)
         .map(|root| super::optimize::newest_transcripts(&root, args.sessions))
@@ -845,6 +863,9 @@ pub fn run_audit<W: Write>(args: &AuditArgs, w: &mut W) -> CtxResult<i32> {
             serde_json::to_string_pretty(&report).unwrap_or_default()
         )?;
     } else {
+        if args.agent == AuditAgent::Codex {
+            writeln!(w, "{CODEX_SAFETY_NO_OP_CAVEAT}")?;
+        }
         write!(w, "{}", render_report(&report))?;
     }
     Ok(0)
@@ -935,6 +956,10 @@ pub fn run_compile<W: Write>(args: &CompileArgs, w: &mut W) -> CtxResult<i32> {
 
     let (eligible_patterns, skipped_protected, skipped_too_generic) =
         compile_eligibility(&report.groups);
+
+    if args.agent == AuditAgent::Codex {
+        writeln!(w, "{CODEX_SAFETY_NO_OP_CAVEAT}")?;
+    }
 
     let home = crate::utils::home_dir()?;
     let existing = crate::commands::setup::read_home_safety_allow(&home).unwrap_or_default();
@@ -1939,6 +1964,68 @@ mod tests {
             .to_string(),
         )
         .expect("write fixture");
+    }
+
+    /// Issue "codex approval hell" (2026-08-26): compiled `[safety] allow`
+    /// entries never change codex's own launch posture (codex has no
+    /// per-command hook zirv can pin), so both audit verbs must say so for a
+    /// codex run -- including via the default agent -- and must not print
+    /// the same caveat for a claude run, where the compiled entries DO
+    /// change what the `PreToolUse` hook allows.
+    #[test]
+    fn run_audit_prints_the_codex_safety_no_op_caveat_only_for_codex() {
+        let home = tempfile::tempdir().expect("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        write_codex_rollout_fixture(home.path(), "gh issue create --title x");
+
+        let codex_args = AuditArgs {
+            agent: AuditAgent::Codex,
+            sessions: 5,
+            json: false,
+        };
+        let mut out = Vec::new();
+        run_audit(&codex_args, &mut out).expect("run_audit");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            text.contains(CODEX_SAFETY_NO_OP_CAVEAT),
+            "codex audit must print the no-op caveat: {text}"
+        );
+
+        let claude_args = AuditArgs {
+            agent: AuditAgent::Claude,
+            sessions: 5,
+            json: false,
+        };
+        let mut out = Vec::new();
+        run_audit(&claude_args, &mut out).expect("run_audit");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            !text.contains(CODEX_SAFETY_NO_OP_CAVEAT),
+            "claude audit must not print codex's no-op caveat: {text}"
+        );
+    }
+
+    /// The default `--agent` value is codex (`AuditArgs`/`CompileArgs`'s own
+    /// `default_value = "codex"`), so a caller who never passes `--agent` at
+    /// all must still see the caveat.
+    #[test]
+    fn run_compile_prints_the_codex_safety_no_op_caveat_by_default() {
+        let home = tempfile::tempdir().expect("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        write_codex_rollout_fixture(home.path(), "gh issue create --title x");
+
+        let args = CompileArgs {
+            agent: AuditAgent::Codex,
+            sessions: 5,
+            dry_run: true,
+        };
+        let mut out = Vec::new();
+        run_compile(&args, &mut out).expect("run_compile");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            text.contains(CODEX_SAFETY_NO_OP_CAVEAT),
+            "compile with the default (codex) agent must print the no-op caveat: {text}"
+        );
     }
 
     #[test]

--- a/src/commands/ctx/policy.rs
+++ b/src/commands/ctx/policy.rs
@@ -197,82 +197,86 @@ impl Stance {
 /// report then says, per harness, which of them are real.
 ///
 /// **`network` is the one deliberate exception (2026-08-26, codex approval-
-/// posture round -- see [`Default`]'s own impl below).** Every other
-/// capability's `Allow` default means "zirv adds no argv, the harness's own
-/// native default governs" -- and every harness's own native default for the
-/// other six capabilities happens to already be permissive, so that reads as
-/// "no restriction". Network is different: codex's own native default under
-/// `--sandbox workspace-write` is *already closed* (verified: a real launch
-/// carries `network_access: false` with no zirv-added flag at all), so an
-/// `Allow` default here would not "add no restriction" -- it would flip
-/// `CodexAdapter::policy_args` into actively *widening* codex's own native
-/// default the moment that mapping was wired up, on every unconfigured
-/// install. `network` therefore defaults to [`Stance::Deny`], the only
-/// choice that keeps an unconfigured install's `[policy]` byte-for-byte
-/// consistent with what it has always actually done.
+/// posture round; refined again in the same round's correction pass --
+/// see below).** Every other capability's `Allow` default means "zirv adds
+/// no argv, the harness's own native default governs" -- and every harness's
+/// own native default for the other six capabilities happens to already be
+/// permissive, so that reads as "no restriction". Network is different:
+/// codex's own native default under `--sandbox workspace-write` is *already
+/// closed* (verified: a real launch carries `network_access: false` with no
+/// zirv-added flag at all), so treating an unconfigured `network` the same
+/// as the other six (a plain `Stance` defaulting to `Allow`) would either
+/// widen codex's own native default the moment that mapping was wired up
+/// (if defaulted to `Allow`), or falsely claim zirv itself is denying
+/// network on every unconfigured install (if defaulted to `Stance::Deny` --
+/// this module's own [`evaluate`] would then render a "network: deny" row
+/// nobody asked for, because *codex's own default* is what is closed here,
+/// not a zirv-imposed restriction). `network` is therefore `Option<Stance>`,
+/// not a plain `Stance`: `None` means "no operator layer has ever named
+/// network at all", which [`Default`] gives for free (an `Option`'s own
+/// default), which [`resolve`] preserves as `None` when both layers are
+/// silent (`resolve_network`'s own doc comment), and which [`evaluate`]
+/// reads as "omit this row" rather than reporting a stance zirv never
+/// actually chose. `Some(stance)` means an operator layer did name one, and
+/// is reported exactly like any other capability from there.
 ///
 /// `deny_unknown_fields`: a typo'd capability name hard-errors rather than
 /// silently leaving that capability at `Allow`, which is the failure mode a
 /// permissions surface can least afford.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct EffectivePolicy {
     pub repo_fs_write: Stance,
     pub outside_repo_fs_write: Stance,
     pub shell_exec: Stance,
-    pub network: Stance,
+    pub network: Option<Stance>,
     pub approval: Stance,
     pub git_push_destructive: Stance,
     pub tool_access: Stance,
 }
 
-/// Hand-written, not derived, for exactly one reason: `network` defaults to
-/// [`Stance::Deny`] rather than [`Stance::default()`] -- see the struct's own
-/// doc comment for why. Every other field keeps the ordinary
-/// `Stance::default()` (`Allow`).
-///
-/// This value is deliberately consistent with, but not itself the mechanism
-/// for, `resolve`'s own "nothing configured anywhere" answer for `network`
-/// (`resolve_network`'s `(None, None) => Deny` arm) -- the two are kept in
-/// sync by inspection, not by one calling the other, because `resolve`'s own
-/// fold does NOT read this `Default` impl for `network` at all (2026-08-26,
-/// correction round): see `resolve_network`'s own doc comment for why the
-/// ordinary `narrowed_by`/`Stance::default()` machinery every other
-/// capability uses is the wrong mechanism for this one field, and what
-/// replaces it.
-impl Default for EffectivePolicy {
-    fn default() -> Self {
-        EffectivePolicy {
-            repo_fs_write: Stance::default(),
-            outside_repo_fs_write: Stance::default(),
-            shell_exec: Stance::default(),
-            network: Stance::Deny,
-            approval: Stance::default(),
-            git_push_destructive: Stance::default(),
-            tool_access: Stance::default(),
-        }
-    }
-}
-
 impl EffectivePolicy {
+    /// For `Network`, projects the `Option<Stance>` field down to a plain
+    /// `Stance` by treating "no operator layer ever named it" (`None`) as
+    /// `Deny` -- the same closed answer `resolve_network`'s own "both
+    /// layers silent" case produces, and what codex's own native default
+    /// already does with no zirv-added flag at all. This is a convenience
+    /// for callers that only need "what does zirv want to hold this
+    /// harness to" (the `PolicyReport::render` baseline loop, principally);
+    /// callers that need to tell "never configured" apart from "explicitly
+    /// denied" (`evaluate`, to decide whether to render a row at all) must
+    /// read `self.network` directly instead, which is why `evaluate` does
+    /// not call this method for `Network`.
     pub fn stance(&self, capability: Capability) -> Stance {
         match capability {
             Capability::RepoFsWrite => self.repo_fs_write,
             Capability::OutsideRepoFsWrite => self.outside_repo_fs_write,
             Capability::ShellExec => self.shell_exec,
-            Capability::Network => self.network,
+            Capability::Network => self.network.unwrap_or(Stance::Deny),
             Capability::Approval => self.approval,
             Capability::GitPushDestructive => self.git_push_destructive,
             Capability::ToolAccess => self.tool_access,
         }
     }
 
+    /// No `Network` arm: `network`'s field type (`Option<Stance>`) cannot
+    /// yield a `&mut Stance`, and both callers below (`narrowed_by`'s fold,
+    /// `resolve`'s env-override loop) explicitly skip `Capability::Network`
+    /// and assign `.network` directly instead -- see each one's own doc
+    /// comment for why the ordinary per-capability mechanism is unsound for
+    /// this one field. Reachable only if a future caller adds `Network` to
+    /// one of those loops without also handling it specially first.
     fn stance_mut(&mut self, capability: Capability) -> &mut Stance {
         match capability {
             Capability::RepoFsWrite => &mut self.repo_fs_write,
             Capability::OutsideRepoFsWrite => &mut self.outside_repo_fs_write,
             Capability::ShellExec => &mut self.shell_exec,
-            Capability::Network => &mut self.network,
+            Capability::Network => {
+                unreachable!(
+                    "network has no plain Stance slot (Option<Stance>); callers must skip \
+                     Capability::Network and assign .network directly -- see resolve_network"
+                )
+            }
             Capability::Approval => &mut self.approval,
             Capability::GitPushDestructive => &mut self.git_push_destructive,
             Capability::ToolAccess => &mut self.tool_access,
@@ -285,9 +289,22 @@ impl EffectivePolicy {
     /// return the smaller of two values. This is the whole privilege-widening
     /// defense for the repo layer, and it is a property of `Stance`'s
     /// ordering rather than a check a future edit could drop.
+    ///
+    /// **`Network` is excluded from this loop** (2026-08-26, correction
+    /// round): the proof above depends on `Stance::default()` (`Allow`)
+    /// being both a layer's "I said nothing" value AND the loosest value
+    /// the type can express, which is exactly the property `network`'s own
+    /// `Option<Stance>` deliberately breaks (see `resolve_network`'s own doc
+    /// comment). `.network` is left exactly as `self` had it here; `resolve`
+    /// always overwrites it afterward with `resolve_network`'s own answer,
+    /// so a caller of `narrowed_by` alone (rather than through `resolve`)
+    /// must not read the result's `.network` as meaningful.
     pub fn narrowed_by(self, narrower: EffectivePolicy) -> EffectivePolicy {
         let mut out = self;
         for capability in Capability::ALL {
+            if capability == Capability::Network {
+                continue;
+            }
             let stance = self.stance(capability).max(narrower.stance(capability));
             *out.stance_mut(capability) = stance;
         }
@@ -309,7 +326,7 @@ impl EffectivePolicy {
             repo_fs_write: Stance::Deny,
             outside_repo_fs_write: Stance::Deny,
             shell_exec: Stance::Deny,
-            network: Stance::Deny,
+            network: Some(Stance::Deny),
             approval: Stance::Deny,
             git_push_destructive: Stance::Deny,
             tool_access: Stance::Deny,
@@ -345,7 +362,7 @@ impl EffectivePolicy {
             // the deny set is refused by rule.
             shell_exec: Stance::Ask,
             // `WebFetch`/`WebSearch` are pre-approved.
-            network: Stance::Allow,
+            network: Some(Stance::Allow),
             approval: Stance::Ask,
             // Force-push and history rewrites are in the built-in ask set.
             git_push_destructive: Stance::Ask,
@@ -390,7 +407,13 @@ pub fn resolve(
         .narrowed_by(parse_layer(repo, "<repo>/.zirv/ctx.toml")?);
     resolved.network = resolve_network(home_network, repo_network);
 
+    // `Network` is excluded from this loop and handled separately right
+    // below: its field is `Option<Stance>`, so `stance_mut` cannot name a
+    // `&mut Stance` slot for it (see that method's own doc comment).
     for capability in Capability::ALL {
+        if capability == Capability::Network {
+            continue;
+        }
         let Some(raw) = env(capability.env_var()) else {
             continue;
         };
@@ -402,6 +425,17 @@ pub fn resolve(
             .into());
         };
         *resolved.stance_mut(capability) = stance;
+    }
+
+    if let Some(raw) = env(Capability::Network.env_var()) {
+        let Some(stance) = Stance::parse(&raw) else {
+            return Err(format!(
+                "{}: expected allow, ask or deny, got '{raw}'",
+                Capability::Network.env_var()
+            )
+            .into());
+        };
+        resolved.network = Some(stance);
     }
 
     Ok(resolved)
@@ -445,38 +479,54 @@ fn parse_network_layer(layer: &Option<toml::Value>, origin: &str) -> CtxResult<O
     Ok(parsed.network)
 }
 
-/// `network`'s own home/repo combination (2026-08-26, correction round),
-/// replacing the ordinary `narrowed_by` fold for this one field -- see
-/// `resolve`'s own doc comment for why the shared `max`-based mechanism is
-/// unsound here.
+/// `network`'s own home/repo combination (2026-08-26, correction round;
+/// fixed again the same round -- see below), replacing the ordinary
+/// `narrowed_by` fold for this one field -- see `resolve`'s own doc comment
+/// for why the shared `max`-based mechanism is unsound here.
 ///
-/// The contract: effective `network` is `Allow` only when the OPERATOR
-/// (home, or the `ZIRV_CTX_POLICY_NETWORK` env override applied afterward in
-/// `resolve`) has explicitly said so, AND no layer has explicitly said
-/// `deny`. Concretely:
-/// - Both layers silent -> `Deny`: the safe default, applied HERE rather
-///   than baked into a layer's own parsed value, so "silent" and "explicitly
-///   denied" never collapse into the same input the way they would if this
-///   reused `EffectivePolicy`'s `Default`.
-/// - Repo explicitly `deny` -> `Deny`, regardless of what home said: the one
-///   thing a repo layer may always do is narrow.
-/// - Repo silent or repo explicitly `allow`, home explicitly `allow` ->
-///   `Allow`: home's own explicit choice survives repo's silence (the actual
-///   correction this round makes -- home no longer needs the repo's
-///   cooperation to be heard), and repo's own `allow` is a no-op agreement,
-///   never a grant of its own.
-/// - Repo silent or repo explicitly `allow`, home silent or home explicitly
-///   `deny`/`ask` -> home's own value if it named one (`ask`/`deny`,
-///   preserved for an honest report), else `Deny`: a repo can never grant
-///   network on its own, silent or not.
-fn resolve_network(home: Option<Stance>, repo: Option<Stance>) -> Stance {
-    if repo == Some(Stance::Deny) {
-        return Stance::Deny;
+/// Returns `None` only when NEITHER layer ever names `network` at all: that
+/// is "no operator opinion exists", which [`EffectivePolicy::default`]
+/// itself now represents the same way, and which [`evaluate`] reads as
+/// "omit the row" rather than a stance zirv chose. The moment either layer
+/// names `network`, the answer is `Some` from there on -- narrowing is
+/// always still possible (a repo naming `ask`/`deny` can still tighten a
+/// silent or `allow` home), but the *distinctness* of `ask` from `deny` is
+/// preserved rather than collapsed, because both feed the same `max` as
+/// home does.
+///
+/// **The bug this fixes (2026-08-26): the previous version only special-
+/// cased `repo == Some(Deny)`, so a repo's explicit `network = "ask"`
+/// fell through to `home`'s own value untouched** -- silently dropping the
+/// repo's narrowing the moment home said `allow` (e.g. home `allow` + repo
+/// `ask` resolved to `Allow`, when the repo layer explicitly asked for no
+/// more than `Ask`). A repo may always narrow, regardless of which
+/// non-`Deny` stance it names; treating `deny` as the only narrowing value
+/// a repo can express was the defect. The fix folds both layers through the
+/// same `Stance` ordering the other six capabilities already use, with each
+/// layer's *own* silent-value substituted before the `max`:
+/// `max(home.unwrap_or(Deny), repo.unwrap_or(Allow))`.
+///
+/// - Home's silence substitutes `Deny` (the operator never opted in, so
+///   nothing pulls the result toward `Allow` on its behalf) -- this is what
+///   keeps "nobody said anything" (`None, None`) from ever landing on
+///   `Allow`, without needing a separate case for it below.
+/// - Repo's silence substitutes `Allow` (a repo that names nothing has no
+///   opinion, so it must never pull the result toward `Deny`/`Ask` on its
+///   own) -- this is what lets home's own explicit `allow` survive a silent
+///   repo (`max(Allow, Allow) == Allow`), which the previous version could
+///   only do by special-casing "home said something" as an unconditional
+///   win; here it falls out of the same formula every other case uses.
+/// - Repo explicitly naming `ask` or `deny` now narrows exactly like the
+///   six generically-folded capabilities do: `max` with home's value can
+///   only move toward the repo's stricter stance, never away from it.
+fn resolve_network(home: Option<Stance>, repo: Option<Stance>) -> Option<Stance> {
+    if home.is_none() && repo.is_none() {
+        return None;
     }
-    match home {
-        Some(stance) => stance,
-        None => Stance::Deny,
-    }
+    Some(std::cmp::max(
+        home.unwrap_or(Stance::Deny),
+        repo.unwrap_or(Stance::Allow),
+    ))
 }
 
 /// What zirv can honestly promise for one capability on one harness. There is
@@ -684,6 +734,20 @@ impl PolicyReport {
 /// zirv is imposing nothing, so there is no mechanism to name and nothing an
 /// adapter could usefully say. That is also why every adapter's own
 /// `policy_support` may leave `Allow` to a catch-all arm -- it is never asked.
+///
+/// **`Network` renders no row at all when `policy.network` is `None`**
+/// (2026-08-26, correction round): `None` means no operator layer has ever
+/// named `network`, which is not a stance zirv chose to report -- unlike
+/// every other capability, whose `Stance::default()` (`Allow`) is itself a
+/// real, reportable answer ("operator-controlled, zirv imposes nothing").
+/// Before this, `EffectivePolicy::default()`'s own `network: Stance::Deny`
+/// meant an unconfigured install's report carried a "network: deny" line
+/// implying zirv itself was denying network, when the true state was "no
+/// opinion was ever expressed" -- codex's own native default happens to
+/// already be closed, with no zirv-added flag at all. This is why `Network`
+/// is handled here directly from `policy.network` rather than through the
+/// generic `policy.stance(capability)` call every other capability uses:
+/// `stance()` cannot express "omit this row", only a concrete `Stance`.
 pub fn evaluate(
     policy: &EffectivePolicy,
     adapter: &dyn AgentAdapter,
@@ -691,8 +755,12 @@ pub fn evaluate(
 ) -> PolicyReport {
     let outcomes = Capability::ALL
         .into_iter()
-        .map(|capability| {
-            let stance = policy.stance(capability);
+        .filter_map(|capability| {
+            let stance = if capability == Capability::Network {
+                policy.network?
+            } else {
+                policy.stance(capability)
+            };
             let descriptor = match stance {
                 Stance::Allow => CapabilityDescriptor::operator_controlled(
                     "zirv declares no restriction; the harness's own defaults and the operator's \
@@ -700,12 +768,12 @@ pub fn evaluate(
                 ),
                 _ => adapter.policy_support(capability, stance, mode),
             };
-            CapabilityOutcome {
+            Some(CapabilityOutcome {
                 capability,
                 stance,
                 support: descriptor.support,
                 mechanism: descriptor.mechanism,
-            }
+            })
         })
         .collect();
     PolicyReport {
@@ -741,7 +809,7 @@ mod tests {
         let baseline = EffectivePolicy::interactive_baseline();
         assert_eq!(baseline.repo_fs_write, Stance::Allow);
         assert_eq!(baseline.outside_repo_fs_write, Stance::Ask);
-        assert_eq!(baseline.network, Stance::Allow);
+        assert_eq!(baseline.network, Some(Stance::Allow));
         assert_eq!(baseline.shell_exec, Stance::Ask);
         assert_eq!(baseline.approval, Stance::Ask);
         assert_eq!(baseline.git_push_destructive, Stance::Ask);
@@ -773,6 +841,58 @@ mod tests {
                 expected.label()
             );
         }
+    }
+
+    /// The bug this round fixes (2026-08-26): before `network` became
+    /// `Option<Stance>`, `EffectivePolicy::default()`'s own `network:
+    /// Stance::Deny` meant `evaluate` always produced a `Network` outcome on
+    /// an unconfigured install, and its rendered line read "network access:
+    /// deny -- ..." -- implying zirv itself was denying network, when in
+    /// truth no operator layer had ever named it (codex's own native
+    /// default already denies it, with no zirv-added flag at all). A report
+    /// built from a wholly-default policy must contain no `Network` row and
+    /// no "network" text at all.
+    #[test]
+    fn a_default_policys_report_carries_no_spurious_network_row() {
+        let policy = EffectivePolicy::default();
+        let claude = ClaudeAdapter::new(None);
+        let codex = CodexAdapter::new(None);
+        for adapter in [&claude as &dyn AgentAdapter, &codex as &dyn AgentAdapter] {
+            let report = evaluate(&policy, adapter, adapters::LaunchMode::Headless);
+            assert!(
+                !report
+                    .outcomes
+                    .iter()
+                    .any(|outcome| outcome.capability == Capability::Network),
+                "{}: a default (unconfigured) policy must render no Network row at all",
+                report.adapter
+            );
+            assert!(
+                !report.render().contains("network"),
+                "{}: the rendered report must not mention network at all when unconfigured",
+                report.adapter
+            );
+        }
+    }
+
+    /// Once an operator layer explicitly names `network` (whatever the
+    /// stance), the row comes back -- `evaluate` only omits it for `None`,
+    /// never for a `Some` the operator chose, even `Some(Stance::Deny)`.
+    #[test]
+    fn an_explicitly_configured_network_stance_still_renders_its_row() {
+        let policy = EffectivePolicy {
+            network: Some(Stance::Deny),
+            ..EffectivePolicy::default()
+        };
+        let claude = ClaudeAdapter::new(None);
+        let report = evaluate(&policy, &claude, adapters::LaunchMode::Headless);
+        assert!(
+            report
+                .outcomes
+                .iter()
+                .any(|outcome| outcome.capability == Capability::Network),
+            "an operator-chosen network stance must still be reported"
+        );
     }
 
     /// A report says which posture it describes, and an interactive one shows
@@ -905,8 +1025,11 @@ mod tests {
     }
 
     /// `network` is the one deliberate exception (see `EffectivePolicy`'s own
-    /// `Default` impl): every other capability's default is `Allow`, "zirv
-    /// declares no restriction of its own".
+    /// doc comment): every other capability's default is `Allow`, "zirv
+    /// declares no restriction of its own"; `network`'s default is `None`,
+    /// "no operator layer has ever named it" -- distinct from `Some(Deny)`,
+    /// which would claim zirv itself denies network on an unconfigured
+    /// install.
     #[test]
     fn a_default_policy_declares_no_restriction_at_all_except_network() {
         let policy = EffectivePolicy::default();
@@ -922,25 +1045,31 @@ mod tests {
             );
         }
         assert_eq!(
-            policy.network,
-            Stance::Deny,
-            "network should default to deny, matching what an unwired install has always done"
+            policy.network, None,
+            "network should default to None -- no operator layer has ever named it, matching \
+             what an unwired install has always done without claiming zirv denies it"
         );
     }
 
     /// The privilege-widening defense, stated directly on the fold: whatever
     /// an untrusted layer says, the result is never looser than the operator's
     /// own stance. Deliberately an explicit all-`Allow` literal, not
-    /// `EffectivePolicy::default()`: `default()` is no longer the uniformly
-    /// loosest possible value (`network` defaults to `Deny`), so it would no
-    /// longer represent "an attempt to widen every capability to `Allow`".
+    /// `EffectivePolicy::default()`: `default()` is not the uniformly loosest
+    /// possible value (`network` defaults to `None`, outside the fold this
+    /// test exercises), so it would not represent "an attempt to widen every
+    /// capability to `Allow`". `network` is left at its own default (`None`)
+    /// on both sides here rather than given a value: it is deliberately
+    /// excluded from `narrowed_by`'s generic loop (see that method's own doc
+    /// comment) and has its own narrowing tests through `resolve`/
+    /// `resolve_network` below, so a value here would only assert that
+    /// `narrowed_by` leaves it untouched, not that anything narrows.
     #[test]
     fn narrowing_never_loosens_any_capability() {
         let operator = EffectivePolicy {
             repo_fs_write: Stance::Ask,
             outside_repo_fs_write: Stance::Deny,
             shell_exec: Stance::Deny,
-            network: Stance::Ask,
+            network: None,
             approval: Stance::Ask,
             git_push_destructive: Stance::Deny,
             tool_access: Stance::Ask,
@@ -949,7 +1078,7 @@ mod tests {
             repo_fs_write: Stance::Allow,
             outside_repo_fs_write: Stance::Allow,
             shell_exec: Stance::Allow,
-            network: Stance::Allow,
+            network: None,
             approval: Stance::Allow,
             git_push_destructive: Stance::Allow,
             tool_access: Stance::Allow,
@@ -957,22 +1086,24 @@ mod tests {
         assert_eq!(operator.narrowed_by(widening_attempt), operator);
     }
 
+    /// `network` is deliberately left at its own default (`None`) on both
+    /// sides: `narrowed_by` excludes it from the generic fold entirely (see
+    /// that method's own doc comment), so this test's job is the other six
+    /// capabilities. `network`'s own narrowing is exercised through
+    /// `resolve`/`resolve_network` in the tests below instead.
     #[test]
     fn narrowing_takes_the_stricter_of_the_two_per_capability() {
         let operator = EffectivePolicy {
             shell_exec: Stance::Ask,
-            network: Stance::Deny,
             ..EffectivePolicy::default()
         };
         let repo = EffectivePolicy {
             shell_exec: Stance::Deny,
-            network: Stance::Allow,
             repo_fs_write: Stance::Ask,
             ..EffectivePolicy::default()
         };
         let narrowed = operator.narrowed_by(repo);
         assert_eq!(narrowed.shell_exec, Stance::Deny);
-        assert_eq!(narrowed.network, Stance::Deny);
         assert_eq!(narrowed.repo_fs_write, Stance::Ask);
     }
 
@@ -1000,7 +1131,7 @@ mod tests {
         assert_eq!(resolved.repo_fs_write, Stance::Ask);
         assert_eq!(resolved.outside_repo_fs_write, Stance::Deny);
         assert_eq!(resolved.shell_exec, Stance::Deny);
-        assert_eq!(resolved.network, Stance::Deny);
+        assert_eq!(resolved.network, Some(Stance::Deny));
         assert_eq!(resolved.approval, Stance::Ask);
         assert_eq!(resolved.git_push_destructive, Stance::Deny);
         assert_eq!(resolved.tool_access, Stance::Ask);
@@ -1008,7 +1139,7 @@ mod tests {
 
     /// The other half of "may narrow, never widen": a repo tightening a stance
     /// the operator left loose is honored, because narrowing is always safe.
-    /// `network` stays `Deny` here, unlike every other untouched capability
+    /// `network` stays `None` here, unlike every other untouched capability
     /// (`repo_fs_write` etc., implicitly `Allow` via the assertions below) --
     /// but for a different reason than those six: nothing (neither home nor
     /// repo) ever names `network` at all here, which is `resolve_network`'s
@@ -1022,17 +1153,18 @@ mod tests {
         let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
         assert_eq!(resolved.shell_exec, Stance::Deny);
         assert_eq!(resolved.repo_fs_write, Stance::Allow);
-        assert_eq!(resolved.network, Stance::Deny);
+        assert_eq!(resolved.network, None);
     }
 
     /// Nothing anywhere ever names `network` -- `resolve_network`'s own
-    /// "both layers silent" case, applied as the one safe default rather
-    /// than baked into either layer's own parsed value.
+    /// "both layers silent" case: `None`, not a stance, since no operator
+    /// layer ever expressed an opinion (see `EffectivePolicy`'s own doc
+    /// comment for why `None` rather than a defaulted `Deny` matters here).
     #[test]
-    fn network_is_denied_when_nothing_is_configured_anywhere() {
+    fn network_resolves_to_none_when_nothing_is_configured_anywhere() {
         let vars = env_from(&[]);
         let resolved = resolve(None, None, &|k| vars.get(k).cloned()).expect("resolves");
-        assert_eq!(resolved.network, Stance::Deny);
+        assert_eq!(resolved.network, None);
     }
 
     /// The actual correction this round makes (2026-08-26): home's own
@@ -1047,7 +1179,7 @@ mod tests {
         let home = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
         let vars = env_from(&[]);
         let resolved = resolve(home, None, &|k| vars.get(k).cloned()).expect("resolves");
-        assert_eq!(resolved.network, Stance::Allow);
+        assert_eq!(resolved.network, Some(Stance::Allow));
     }
 
     /// A repo may still always narrow: its own explicit `network = "deny"`
@@ -1058,7 +1190,27 @@ mod tests {
         let repo = table("[policy]\nnetwork = \"deny\"\n").and_then(|v| v.get("policy").cloned());
         let vars = env_from(&[]);
         let resolved = resolve(home, repo, &|k| vars.get(k).cloned()).expect("resolves");
-        assert_eq!(resolved.network, Stance::Deny);
+        assert_eq!(resolved.network, Some(Stance::Deny));
+    }
+
+    /// The bug this round fixes (2026-08-26): a repo's explicit `network =
+    /// "ask"` must narrow a looser home stance exactly like `"deny"` does --
+    /// the previous `resolve_network` only special-cased `repo == Some(Deny)`
+    /// and fell through to home's own value for any other repo stance
+    /// (including `Ask`), so this scenario silently resolved to `Allow`,
+    /// dropping the repo's narrowing entirely. `max(home, repo)` treats every
+    /// repo stance as a potential narrowing input, not just `Deny`.
+    #[test]
+    fn network_ask_narrows_a_looser_home_allow() {
+        let home = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
+        let repo = table("[policy]\nnetwork = \"ask\"\n").and_then(|v| v.get("policy").cloned());
+        let vars = env_from(&[]);
+        let resolved = resolve(home, repo, &|k| vars.get(k).cloned()).expect("resolves");
+        assert_eq!(
+            resolved.network,
+            Some(Stance::Ask),
+            "the repo's explicit ask must narrow home's allow, not be dropped in favor of it"
+        );
     }
 
     /// The other half of "a repo may never widen, only narrow": a repo's own
@@ -1070,7 +1222,7 @@ mod tests {
         let repo = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
         let vars = env_from(&[]);
         let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
-        assert_eq!(resolved.network, Stance::Deny);
+        assert_eq!(resolved.network, Some(Stance::Deny));
     }
 
     /// When the repo's own `[policy]` table explicitly agrees (`network =
@@ -1083,7 +1235,7 @@ mod tests {
         let repo = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
         let vars = env_from(&[]);
         let resolved = resolve(home, repo, &|k| vars.get(k).cloned()).expect("resolves");
-        assert_eq!(resolved.network, Stance::Allow);
+        assert_eq!(resolved.network, Some(Stance::Allow));
     }
 
     /// The environment override sits above the fold entirely (`resolve`'s own
@@ -1095,7 +1247,7 @@ mod tests {
         let repo = table("[policy]\nnetwork = \"deny\"\n").and_then(|v| v.get("policy").cloned());
         let vars = env_from(&[("ZIRV_CTX_POLICY_NETWORK", "allow")]);
         let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
-        assert_eq!(resolved.network, Stance::Allow);
+        assert_eq!(resolved.network, Some(Stance::Allow));
     }
 
     /// The operator's escape hatch above the fold, mirroring
@@ -1108,7 +1260,7 @@ mod tests {
         let vars = env_from(&[("ZIRV_CTX_POLICY_SHELL_EXEC", "allow")]);
         let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
         assert_eq!(resolved.shell_exec, Stance::Allow);
-        assert_eq!(resolved.network, Stance::Deny);
+        assert_eq!(resolved.network, Some(Stance::Deny));
     }
 
     #[test]
@@ -1146,7 +1298,7 @@ mod tests {
     #[test]
     fn an_allow_stance_reports_as_operator_controlled_on_every_adapter() {
         let policy = EffectivePolicy {
-            network: Stance::Allow,
+            network: Some(Stance::Allow),
             ..EffectivePolicy::default()
         };
         for adapter in adapters::all(None) {
@@ -1172,6 +1324,10 @@ mod tests {
         for stance in [Stance::Ask, Stance::Deny] {
             let mut policy = EffectivePolicy::default();
             for capability in Capability::ALL {
+                if capability == Capability::Network {
+                    policy.network = Some(stance);
+                    continue;
+                }
                 *policy.stance_mut(capability) = stance;
             }
             for adapter in adapters::all(None) {
@@ -1438,7 +1594,7 @@ mod tests {
             // `Deny`): this test is about `repo_fs_write` alone, and network
             // at its own default would also show up as claude-unenforced
             // (advisory-only), which is not what this test pins.
-            network: Stance::Allow,
+            network: Some(Stance::Allow),
             ..EffectivePolicy::default()
         };
         let claude = ClaudeAdapter::new(None);
@@ -1466,7 +1622,7 @@ mod tests {
     #[test]
     fn unenforced_lists_exactly_the_stances_zirv_cannot_hold_the_harness_to() {
         let policy = EffectivePolicy {
-            network: Stance::Deny,
+            network: Some(Stance::Deny),
             shell_exec: Stance::Deny,
             ..EffectivePolicy::default()
         };
@@ -1489,7 +1645,7 @@ mod tests {
         let policy = EffectivePolicy {
             tool_access: Stance::Deny,
             approval: Stance::Deny,
-            network: Stance::Deny,
+            network: Some(Stance::Deny),
             ..EffectivePolicy::default()
         };
         let claude = ClaudeAdapter::new(None);

--- a/src/commands/ctx/policy.rs
+++ b/src/commands/ctx/policy.rs
@@ -196,10 +196,25 @@ impl Stance {
 /// what it was. An operator opts in by naming the stances they want; the
 /// report then says, per harness, which of them are real.
 ///
+/// **`network` is the one deliberate exception (2026-08-26, codex approval-
+/// posture round -- see [`Default`]'s own impl below).** Every other
+/// capability's `Allow` default means "zirv adds no argv, the harness's own
+/// native default governs" -- and every harness's own native default for the
+/// other six capabilities happens to already be permissive, so that reads as
+/// "no restriction". Network is different: codex's own native default under
+/// `--sandbox workspace-write` is *already closed* (verified: a real launch
+/// carries `network_access: false` with no zirv-added flag at all), so an
+/// `Allow` default here would not "add no restriction" -- it would flip
+/// `CodexAdapter::policy_args` into actively *widening* codex's own native
+/// default the moment that mapping was wired up, on every unconfigured
+/// install. `network` therefore defaults to [`Stance::Deny`], the only
+/// choice that keeps an unconfigured install's `[policy]` byte-for-byte
+/// consistent with what it has always actually done.
+///
 /// `deny_unknown_fields`: a typo'd capability name hard-errors rather than
 /// silently leaving that capability at `Allow`, which is the failure mode a
 /// permissions surface can least afford.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct EffectivePolicy {
     pub repo_fs_write: Stance,
@@ -209,6 +224,34 @@ pub struct EffectivePolicy {
     pub approval: Stance,
     pub git_push_destructive: Stance,
     pub tool_access: Stance,
+}
+
+/// Hand-written, not derived, for exactly one reason: `network` defaults to
+/// [`Stance::Deny`] rather than [`Stance::default()`] -- see the struct's own
+/// doc comment for why. Every other field keeps the ordinary
+/// `Stance::default()` (`Allow`).
+///
+/// This value is deliberately consistent with, but not itself the mechanism
+/// for, `resolve`'s own "nothing configured anywhere" answer for `network`
+/// (`resolve_network`'s `(None, None) => Deny` arm) -- the two are kept in
+/// sync by inspection, not by one calling the other, because `resolve`'s own
+/// fold does NOT read this `Default` impl for `network` at all (2026-08-26,
+/// correction round): see `resolve_network`'s own doc comment for why the
+/// ordinary `narrowed_by`/`Stance::default()` machinery every other
+/// capability uses is the wrong mechanism for this one field, and what
+/// replaces it.
+impl Default for EffectivePolicy {
+    fn default() -> Self {
+        EffectivePolicy {
+            repo_fs_write: Stance::default(),
+            outside_repo_fs_write: Stance::default(),
+            shell_exec: Stance::default(),
+            network: Stance::Deny,
+            approval: Stance::default(),
+            git_push_destructive: Stance::default(),
+            tool_access: Stance::default(),
+        }
+    }
 }
 
 impl EffectivePolicy {
@@ -321,13 +364,31 @@ impl EffectivePolicy {
 /// hard error rather than a silent fall back to `Allow`: quietly widening a
 /// permissions surface because a value was misspelled is the one outcome this
 /// module exists to prevent.
+///
+/// **`network` is folded separately (2026-08-26, correction round), never
+/// through `narrowed_by`'s ordinary `max`.** The six other capabilities all
+/// share one property `narrowed_by`'s safety proof depends on: `Stance::
+/// default()` (`Allow`) is both a layer's "I said nothing" value AND the
+/// loosest value the type can express, so a layer's silence is provably a
+/// no-op against the fold (`max(x, Allow) == x` always). `network`'s default
+/// answer is `Deny`, not `Allow` -- the loosest value in the type -- so
+/// reusing the same trick (an unmentioned key silently deserializing to
+/// `Stance::Deny` via `EffectivePolicy`'s own `Default`) breaks that proof:
+/// a repo layer that mentions nothing would contribute `Deny` for network
+/// exactly as if it had explicitly denied it, defeating an operator's own
+/// home-level `network = "allow"` even when the repo took no position at
+/// all. `resolve_network` below is the fix -- see its own doc comment.
 pub fn resolve(
     home: Option<toml::Value>,
     repo: Option<toml::Value>,
     env: EnvLookup<'_>,
 ) -> CtxResult<EffectivePolicy> {
+    let home_network = parse_network_layer(&home, "~/.zirv/ctx.toml")?;
+    let repo_network = parse_network_layer(&repo, "<repo>/.zirv/ctx.toml")?;
+
     let mut resolved = parse_layer(home, "~/.zirv/ctx.toml")?
         .narrowed_by(parse_layer(repo, "<repo>/.zirv/ctx.toml")?);
+    resolved.network = resolve_network(home_network, repo_network);
 
     for capability in Capability::ALL {
         let Some(raw) = env(capability.env_var()) else {
@@ -353,6 +414,69 @@ fn parse_layer(layer: Option<toml::Value>, origin: &str) -> CtxResult<EffectiveP
     layer
         .try_into()
         .map_err(|e| format!("{origin}: invalid [policy] section: {e}").into())
+}
+
+/// One `[policy]` layer's raw, unresolved opinion on `network` alone --
+/// `None` when the layer's table (or the whole layer) never mentions the key
+/// at all, distinct from an explicit `network = "allow"`/`"deny"`/`"ask"`.
+/// `EffectivePolicy`/`Stance` cannot carry this distinction (a bare `Stance`
+/// field always deserializes to *some* concrete value, `Stance::default()`
+/// when the key is absent -- see `resolve`'s own doc comment for why that
+/// collapse is exactly the bug this exists to avoid for `network`), so this
+/// is a second, narrow, `Option`-shaped deserialization of the SAME raw TOML
+/// value `parse_layer` already validates -- deliberately not the primary
+/// error path: a malformed layer already fails loudly through `parse_layer`
+/// (called right after this, in `resolve`, with the identical `origin`), so
+/// a parse failure here is either that same error about to be raised again
+/// or genuinely unreachable, never a chance to report something new.
+fn parse_network_layer(layer: &Option<toml::Value>, origin: &str) -> CtxResult<Option<Stance>> {
+    #[derive(Deserialize, Default)]
+    #[serde(default)]
+    struct NetworkOnly {
+        network: Option<Stance>,
+    }
+    let Some(layer) = layer else {
+        return Ok(None);
+    };
+    let parsed: NetworkOnly = layer
+        .clone()
+        .try_into()
+        .map_err(|e| format!("{origin}: invalid [policy] section: {e}"))?;
+    Ok(parsed.network)
+}
+
+/// `network`'s own home/repo combination (2026-08-26, correction round),
+/// replacing the ordinary `narrowed_by` fold for this one field -- see
+/// `resolve`'s own doc comment for why the shared `max`-based mechanism is
+/// unsound here.
+///
+/// The contract: effective `network` is `Allow` only when the OPERATOR
+/// (home, or the `ZIRV_CTX_POLICY_NETWORK` env override applied afterward in
+/// `resolve`) has explicitly said so, AND no layer has explicitly said
+/// `deny`. Concretely:
+/// - Both layers silent -> `Deny`: the safe default, applied HERE rather
+///   than baked into a layer's own parsed value, so "silent" and "explicitly
+///   denied" never collapse into the same input the way they would if this
+///   reused `EffectivePolicy`'s `Default`.
+/// - Repo explicitly `deny` -> `Deny`, regardless of what home said: the one
+///   thing a repo layer may always do is narrow.
+/// - Repo silent or repo explicitly `allow`, home explicitly `allow` ->
+///   `Allow`: home's own explicit choice survives repo's silence (the actual
+///   correction this round makes -- home no longer needs the repo's
+///   cooperation to be heard), and repo's own `allow` is a no-op agreement,
+///   never a grant of its own.
+/// - Repo silent or repo explicitly `allow`, home silent or home explicitly
+///   `deny`/`ask` -> home's own value if it named one (`ask`/`deny`,
+///   preserved for an honest report), else `Deny`: a repo can never grant
+///   network on its own, silent or not.
+fn resolve_network(home: Option<Stance>, repo: Option<Stance>) -> Stance {
+    if repo == Some(Stance::Deny) {
+        return Stance::Deny;
+    }
+    match home {
+        Some(stance) => stance,
+        None => Stance::Deny,
+    }
 }
 
 /// What zirv can honestly promise for one capability on one harness. There is
@@ -625,9 +749,10 @@ mod tests {
     }
 
     /// SECURITY: the baseline is a REPORTED fact, never a fold input.
-    /// `EffectivePolicy::default()` must stay all-`Allow` -- it is what
-    /// `narrowed_by`'s widening defense and `resolve`'s fold rest on, and
-    /// what makes `ZIRV_CTX_POLICY_*` able to loosen at all.
+    /// `EffectivePolicy::default()` must stay all-`Allow` except `network`
+    /// (its own documented exception, `EffectivePolicy`'s `Default` impl) --
+    /// the rest is what `narrowed_by`'s widening defense and `resolve`'s fold
+    /// rest on, and what makes `ZIRV_CTX_POLICY_*` able to loosen at all.
     #[test]
     fn the_interactive_baseline_does_not_touch_the_default_or_the_fold() {
         assert_ne!(
@@ -635,11 +760,17 @@ mod tests {
             EffectivePolicy::default()
         );
         for capability in Capability::ALL {
+            let expected = if capability == Capability::Network {
+                Stance::Deny
+            } else {
+                Stance::Allow
+            };
             assert_eq!(
                 EffectivePolicy::default().stance(capability),
-                Stance::Allow,
-                "{} must still default to allow",
-                capability.key()
+                expected,
+                "{} must still default to {}",
+                capability.key(),
+                expected.label()
             );
         }
     }
@@ -773,10 +904,16 @@ mod tests {
         assert_ne!(closed, EffectivePolicy::default());
     }
 
+    /// `network` is the one deliberate exception (see `EffectivePolicy`'s own
+    /// `Default` impl): every other capability's default is `Allow`, "zirv
+    /// declares no restriction of its own".
     #[test]
-    fn a_default_policy_declares_no_restriction_at_all() {
+    fn a_default_policy_declares_no_restriction_at_all_except_network() {
         let policy = EffectivePolicy::default();
         for capability in Capability::ALL {
+            if capability == Capability::Network {
+                continue;
+            }
             assert_eq!(
                 policy.stance(capability),
                 Stance::Allow,
@@ -784,11 +921,19 @@ mod tests {
                 capability.key()
             );
         }
+        assert_eq!(
+            policy.network,
+            Stance::Deny,
+            "network should default to deny, matching what an unwired install has always done"
+        );
     }
 
     /// The privilege-widening defense, stated directly on the fold: whatever
     /// an untrusted layer says, the result is never looser than the operator's
-    /// own stance.
+    /// own stance. Deliberately an explicit all-`Allow` literal, not
+    /// `EffectivePolicy::default()`: `default()` is no longer the uniformly
+    /// loosest possible value (`network` defaults to `Deny`), so it would no
+    /// longer represent "an attempt to widen every capability to `Allow`".
     #[test]
     fn narrowing_never_loosens_any_capability() {
         let operator = EffectivePolicy {
@@ -800,7 +945,15 @@ mod tests {
             git_push_destructive: Stance::Deny,
             tool_access: Stance::Ask,
         };
-        let widening_attempt = EffectivePolicy::default();
+        let widening_attempt = EffectivePolicy {
+            repo_fs_write: Stance::Allow,
+            outside_repo_fs_write: Stance::Allow,
+            shell_exec: Stance::Allow,
+            network: Stance::Allow,
+            approval: Stance::Allow,
+            git_push_destructive: Stance::Allow,
+            tool_access: Stance::Allow,
+        };
         assert_eq!(operator.narrowed_by(widening_attempt), operator);
     }
 
@@ -855,6 +1008,12 @@ mod tests {
 
     /// The other half of "may narrow, never widen": a repo tightening a stance
     /// the operator left loose is honored, because narrowing is always safe.
+    /// `network` stays `Deny` here, unlike every other untouched capability
+    /// (`repo_fs_write` etc., implicitly `Allow` via the assertions below) --
+    /// but for a different reason than those six: nothing (neither home nor
+    /// repo) ever names `network` at all here, which is `resolve_network`'s
+    /// own "both layers silent" case, not a per-field default -- see that
+    /// function's own doc comment.
     #[test]
     fn a_repo_policy_table_may_tighten_a_stance_the_operator_left_loose() {
         let repo =
@@ -862,6 +1021,80 @@ mod tests {
         let vars = env_from(&[]);
         let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
         assert_eq!(resolved.shell_exec, Stance::Deny);
+        assert_eq!(resolved.repo_fs_write, Stance::Allow);
+        assert_eq!(resolved.network, Stance::Deny);
+    }
+
+    /// Nothing anywhere ever names `network` -- `resolve_network`'s own
+    /// "both layers silent" case, applied as the one safe default rather
+    /// than baked into either layer's own parsed value.
+    #[test]
+    fn network_is_denied_when_nothing_is_configured_anywhere() {
+        let vars = env_from(&[]);
+        let resolved = resolve(None, None, &|k| vars.get(k).cloned()).expect("resolves");
+        assert_eq!(resolved.network, Stance::Deny);
+    }
+
+    /// The actual correction this round makes (2026-08-26): home's own
+    /// explicit `network = "allow"` must survive a repo whose `[policy]`
+    /// table never mentions `network` at all -- the repo's silence carries
+    /// no opinion of its own, so it cannot defeat the operator's. Before this
+    /// round, a bare `Stance` field made "repo said nothing" and "repo
+    /// explicitly denied" indistinguishable, so this used to (wrongly)
+    /// resolve to `Deny`.
+    #[test]
+    fn network_opens_when_home_allows_it_and_the_repo_says_nothing_at_all() {
+        let home = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
+        let vars = env_from(&[]);
+        let resolved = resolve(home, None, &|k| vars.get(k).cloned()).expect("resolves");
+        assert_eq!(resolved.network, Stance::Allow);
+    }
+
+    /// A repo may still always narrow: its own explicit `network = "deny"`
+    /// defeats home's `allow`, exactly like every other capability.
+    #[test]
+    fn network_stays_denied_when_the_repo_explicitly_denies_it_even_though_home_allows_it() {
+        let home = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
+        let repo = table("[policy]\nnetwork = \"deny\"\n").and_then(|v| v.get("policy").cloned());
+        let vars = env_from(&[]);
+        let resolved = resolve(home, repo, &|k| vars.get(k).cloned()).expect("resolves");
+        assert_eq!(resolved.network, Stance::Deny);
+    }
+
+    /// The other half of "a repo may never widen, only narrow": a repo's own
+    /// bare `network = "allow"`, with home silent, must NOT grant network on
+    /// its own -- only the operator (home or env) can ever move `network`
+    /// toward `Allow`.
+    #[test]
+    fn network_stays_denied_when_only_the_repo_explicitly_allows_it_and_home_says_nothing() {
+        let repo = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
+        let vars = env_from(&[]);
+        let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
+        assert_eq!(resolved.network, Stance::Deny);
+    }
+
+    /// When the repo's own `[policy]` table explicitly agrees (`network =
+    /// "allow"`), home's own explicit `allow` is what actually carries --
+    /// repo's matching `allow` is a no-op agreement, never a grant of its
+    /// own (see the "repo alone" test above, which pins that half).
+    #[test]
+    fn network_opens_when_home_and_repo_both_explicitly_allow_it() {
+        let home = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
+        let repo = table("[policy]\nnetwork = \"allow\"\n").and_then(|v| v.get("policy").cloned());
+        let vars = env_from(&[]);
+        let resolved = resolve(home, repo, &|k| vars.get(k).cloned()).expect("resolves");
+        assert_eq!(resolved.network, Stance::Allow);
+    }
+
+    /// The environment override sits above the fold entirely (`resolve`'s own
+    /// doc comment), so it is the one path guaranteed to open `network`
+    /// regardless of what any repo says -- including a repo that actively
+    /// tries to deny it.
+    #[test]
+    fn env_can_open_network_regardless_of_what_the_repo_says() {
+        let repo = table("[policy]\nnetwork = \"deny\"\n").and_then(|v| v.get("policy").cloned());
+        let vars = env_from(&[("ZIRV_CTX_POLICY_NETWORK", "allow")]);
+        let resolved = resolve(None, repo, &|k| vars.get(k).cloned()).expect("resolves");
         assert_eq!(resolved.network, Stance::Allow);
     }
 
@@ -906,10 +1139,16 @@ mod tests {
 
     /// The honesty rule at its most load-bearing: an `Allow` capability is
     /// never reported as something zirv enforces, because zirv is not
-    /// restricting anything.
+    /// restricting anything. `network` is pinned explicitly to `Allow` here
+    /// rather than left at `EffectivePolicy::default()`'s own `Deny`: this
+    /// test is about the `Allow` stance specifically, on every capability,
+    /// not about the default policy.
     #[test]
     fn an_allow_stance_reports_as_operator_controlled_on_every_adapter() {
-        let policy = EffectivePolicy::default();
+        let policy = EffectivePolicy {
+            network: Stance::Allow,
+            ..EffectivePolicy::default()
+        };
         for adapter in adapters::all(None) {
             let report = evaluate(&policy, adapter.as_ref(), adapters::LaunchMode::Headless);
             for outcome in &report.outcomes {
@@ -1195,6 +1434,11 @@ mod tests {
     fn one_policy_evaluates_differently_against_claude_and_codex() {
         let policy = EffectivePolicy {
             repo_fs_write: Stance::Deny,
+            // Pinned explicitly to `Allow` (not left at `default()`'s own
+            // `Deny`): this test is about `repo_fs_write` alone, and network
+            // at its own default would also show up as claude-unenforced
+            // (advisory-only), which is not what this test pins.
+            network: Stance::Allow,
             ..EffectivePolicy::default()
         };
         let claude = ClaudeAdapter::new(None);


### PR DESCRIPTION
Companion to #147's approval-hell investigation, codex side. Version 2.30.0 → 2.32.0.

Implements and gates config-override pinning, writable roots, and network knob for codex approval posture:
- `flags_pin_policy` now recognizes operator `-c approval_policy=…`/`-c sandbox_mode=…` (both split and joined forms) so zirv never appends its own posture args after an operator override.
- `extra_writable_root_args`: dash-spawned codex panes get one merged `-c sandbox_workspace_write.writable_roots=[…]` naming the linked-worktree git common dir and the zirv state mail dir (report-back delivery).
- New operator-owned `[policy] network` knob → `-c sandbox_workspace_write.network_access=true` for codex when allowed.
- `permissions audit/compile --agent codex` prints a caveat that compiled `[safety] allow` entries do not affect codex launches.

## Status
All review findings fixed with named regression tests (d00f663); CI green; ready for approval. The PR is undrafted and mergeable.
