### PR TITLE
perf(workflow): delta re-review and stop-on-no-new-findings (#155 phase 4, engine half)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.30.1"
+version = "2.36.0"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.30.1"
+version = "2.36.0"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/src/commands/workflow/review.rs
+++ b/src/commands/workflow/review.rs
@@ -1990,4 +1990,87 @@ checksum = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f80"
         assert_eq!(package.diff_base_sha, package.base_sha);
         assert_eq!(package.head_sha.len(), 40);
     }
+
+    /// Integration level, on top of the `delta_base` unit tests above:
+    /// `delta_base` proves the SHA selection in isolation, but this proves
+    /// `package()` actually wires that sha into `git_diff_capped`. The
+    /// content assertions are the ones that would catch a future regression
+    /// where `git_diff_capped` is called against `base_sha` again (or the
+    /// wrong sha) while `diff_is_delta` still reports `true` -- a reviewer
+    /// told "this is a delta" while actually holding the full diff, or the
+    /// wrong slice of it, is a silent correctness bug this field exists to
+    /// rule out. Round 1's change and round 2's fix live in separate files so
+    /// the two diffs have zero textual overlap: a plain `.contains` check on
+    /// the diff string is enough to prove which bytes it actually carries.
+    #[test]
+    fn package_with_an_intact_chain_diffs_only_the_post_round_one_change() {
+        let repo = tempdir().unwrap();
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .args([
+                    "-c",
+                    "user.email=t@example.com",
+                    "-c",
+                    "user.name=t",
+                    "-c",
+                    "commit.gpgsign=false",
+                ])
+                .args(args)
+                .current_dir(repo.path())
+                .status()
+                .expect("run git");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        std::fs::write(repo.path().join("file_a.txt"), "base\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "base"]);
+
+        // The change round 1 actually reviewed.
+        std::fs::write(repo.path().join("file_a.txt"), "first change\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "first change"]);
+
+        // The NEW change made in response to round 1's review, in a
+        // different file so it cannot be confused with round 1's change in
+        // the diff text below.
+        std::fs::write(repo.path().join("file_b.txt"), "fix after review\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "fix after review"]);
+
+        let shas = git_log_shas(repo.path()); // [base, first change, fix after review]
+        let mut state = running_review_state(repo.path(), &shas[0]);
+        state.review_evidence.push(ReviewRunEvidence {
+            id: "ev-1".to_string(),
+            change_fingerprint: 1,
+            adapter: "codex".to_string(),
+            review_round: 1,
+            completed_at: 10,
+            head_sha: Some(shas[1].clone()),
+        });
+        let state_dir =
+            StateDir::from_root(tempfile::tempdir().expect("tempdir").path().to_path_buf());
+
+        let package = package(&state_dir, &state, Some(&shas[0])).expect("package");
+
+        assert!(
+            package.diff_is_delta,
+            "round 2 with an intact evidence chain is a delta"
+        );
+        assert_eq!(
+            package.diff_base_sha, shas[1],
+            "diffs from the sha round 1 actually reviewed, not the workflow base"
+        );
+        assert!(
+            package.diff.contains("fix after review"),
+            "the delta must contain round 2's new change; got {:?}",
+            package.diff
+        );
+        assert!(
+            !package.diff.contains("first change"),
+            "the delta must NOT contain round 1's already-reviewed change -- \
+             that would mean the reviewer is silently under- or over-reviewing; got {:?}",
+            package.diff
+        );
+    }
 }

--- a/src/commands/workflow/review.rs
+++ b/src/commands/workflow/review.rs
@@ -118,6 +118,39 @@ fn has_repeated_meaningful_finding(findings: &[ReviewFinding]) -> bool {
         .any(|key| !seen.insert(key))
 }
 
+/// How many of `incoming` are findings this workflow has not already
+/// recorded, by the same `finding_key` identity `has_repeated_meaningful_
+/// finding` uses -- path:line where a path exists, whitespace-normalised
+/// lowercased summary otherwise. One identity across this module, so the
+/// stop rule and the escalation rule can never disagree about whether a
+/// finding recurred.
+pub fn new_finding_count(existing: &[ReviewFinding], incoming: &[ReviewFinding]) -> usize {
+    let seen: BTreeSet<String> = existing.iter().map(finding_key).collect();
+    let mut fresh = BTreeSet::new();
+    incoming
+        .iter()
+        .map(finding_key)
+        .filter(|key| !seen.contains(key) && fresh.insert(key.clone()))
+        .count()
+}
+
+/// What one completed review round concluded. `converged` is the code
+/// enforcement of the rule `HARNESS_PROMPT` could only ask for: a round that
+/// surfaced nothing new ends the loop successfully, whatever budget remains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoundOutcome {
+    pub new_findings: usize,
+    pub converged: bool,
+}
+
+/// The exit code for a completed review round. A converged round is success
+/// regardless of the reviewer's own exit code -- `HARNESS_PROMPT`'s stop rule
+/// is enforced here, in code, rather than left for a caller to reinterpret
+/// prose about when to stop asking for another round.
+fn round_exit_code(outcome: &RoundOutcome, reviewer_code: i32) -> i32 {
+    if outcome.converged { 0 } else { reviewer_code }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReviewRunEvidence {
     pub id: String,
@@ -890,20 +923,15 @@ fn parse_reviewer_output(output: &str) -> CtxResult<Vec<ReviewerFinding>> {
     Ok(response.findings)
 }
 
-fn append_reviewer_findings(
-    state: &mut WorkflowState,
-    findings: Vec<ReviewerFinding>,
-) -> CtxResult<()> {
-    if state.review_findings.len().saturating_add(findings.len()) > MAX_REVIEW_FINDINGS {
-        return Err(format!(
-            "review results would exceed the workflow limit of {MAX_REVIEW_FINDINGS} findings"
-        )
-        .into());
-    }
-    let created_at = now_secs();
-    state
-        .review_findings
-        .extend(findings.into_iter().map(|finding| ReviewFinding {
+/// Builds the persisted `ReviewFinding`s a reviewer's raw structured output
+/// becomes. Split out of `append_reviewer_findings` so `run_independent_
+/// review` can run `new_finding_count` against the same `ReviewFinding` shape
+/// -- before the findings are merged into `state.review_findings` -- instead
+/// of reasoning about identity twice, once per finding representation.
+fn build_review_findings(findings: Vec<ReviewerFinding>, created_at: u64) -> Vec<ReviewFinding> {
+    findings
+        .into_iter()
+        .map(|finding| ReviewFinding {
             id: uuid::Uuid::new_v4().to_string(),
             severity: finding.severity,
             summary: finding.summary.trim().to_string(),
@@ -912,7 +940,21 @@ fn append_reviewer_findings(
             disposition: FindingDisposition::Open,
             recommended_disposition: finding.recommended_disposition,
             created_at,
-        }));
+        })
+        .collect()
+}
+
+fn append_reviewer_findings(
+    state: &mut WorkflowState,
+    findings: Vec<ReviewFinding>,
+) -> CtxResult<()> {
+    if state.review_findings.len().saturating_add(findings.len()) > MAX_REVIEW_FINDINGS {
+        return Err(format!(
+            "review results would exceed the workflow limit of {MAX_REVIEW_FINDINGS} findings"
+        )
+        .into());
+    }
+    state.review_findings.extend(findings);
     Ok(())
 }
 
@@ -1100,14 +1142,35 @@ fn run_independent_review(
         Vec::new()
     };
     let mut state = engine::load(&state_dir, &state.repo, &args.id)?;
+    // `records_evidence` -- not dashboard-spawned, exit 0, fingerprint intact
+    // -- is exactly "did this round actually complete a review". Only a
+    // completed round can have converged; a dashboard ack or a failed launch
+    // reviewed nothing, so it is never mistaken for zero new findings.
+    let recorded = records_evidence(&run, fingerprint_unchanged);
+    let incoming_findings = build_review_findings(parsed_findings, now_secs());
+    // Computed against the state loaded above, before `append_reviewer_
+    // findings` merges `incoming_findings` into it -- otherwise every finding
+    // would trivially count as "already recorded".
+    let new_findings = if recorded {
+        new_finding_count(&state.review_findings, &incoming_findings)
+    } else {
+        0
+    };
+    let outcome = RoundOutcome {
+        new_findings,
+        converged: recorded && new_findings == 0,
+    };
     if run.dashboard_spawn {
         writeln!(
             writer,
             "the review was spawned as a dashboard pane; review evidence requires a completed \
              run, so none was recorded"
         )?;
-    } else if records_evidence(&run, fingerprint_unchanged) {
-        append_reviewer_findings(&mut state, parsed_findings)?;
+    } else if recorded {
+        // The evidence push, telemetry event and finding merge all still
+        // happen on a converged round: convergence is a stopping rule, not a
+        // skip. What changes is only whether another round is demanded.
+        append_reviewer_findings(&mut state, incoming_findings)?;
         state.review_evidence.push(ReviewRunEvidence {
             id: uuid::Uuid::new_v4().to_string(),
             change_fingerprint: package.change_fingerprint,
@@ -1125,6 +1188,17 @@ fn run_independent_review(
         }
         state.updated_at = now_secs();
         save_state(&state_dir, &state)?;
+        if outcome.converged {
+            let unused_rounds = MAX_FIX_REVIEW_ROUNDS.saturating_sub(package.review_round);
+            writeln!(
+                writer,
+                "round {} surfaced no findings not already recorded in review state; the \
+                 independent review loop is complete ({unused_rounds} of {MAX_FIX_REVIEW_ROUNDS} \
+                 round{} unused)",
+                package.review_round,
+                if unused_rounds == 1 { "" } else { "s" },
+            )?;
+        }
     }
     let (total, meaningful, dismissed) = super::telemetry::finding_counts(&state.review_findings);
     let mut event =
@@ -1137,7 +1211,7 @@ fn run_independent_review(
     event.work_domain = Some(state.classification.work_domain.domain);
     event.duration_ms = Some(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX));
     event.adapter = Some(args.agent.clone());
-    event.succeeded = Some(records_evidence(&run, fingerprint_unchanged));
+    event.succeeded = Some(recorded);
     event.findings_total = total;
     event.findings_meaningful = meaningful;
     event.findings_dismissed = dismissed;
@@ -1154,7 +1228,7 @@ fn run_independent_review(
             "the change set changed during review; review evidence was not recorded".into(),
         );
     }
-    Ok(code)
+    Ok(round_exit_code(&outcome, code))
 }
 
 pub fn run(args: &ReviewArgs, writer: &mut impl Write) -> CtxResult<i32> {
@@ -1880,6 +1954,167 @@ checksum = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f80"
         assert_eq!(required_independent_reviews_for(&state), 2);
         state.review_findings[1].disposition = FindingDisposition::Dismissed;
         assert_eq!(required_independent_reviews_for(&state), 1);
+    }
+
+    /// Builds a `ReviewFinding` at a fixed path:line -- the identity
+    /// `new_finding_count` and `has_repeated_meaningful_finding` both key on.
+    fn finding_at(path: &str, line: u32, summary: &str) -> ReviewFinding {
+        ReviewFinding {
+            id: uuid::Uuid::new_v4().to_string(),
+            severity: FindingSeverity::Major,
+            summary: summary.to_string(),
+            path: Some(PathBuf::from(path)),
+            line: Some(line),
+            disposition: FindingDisposition::Open,
+            recommended_disposition: None,
+            created_at: now_secs(),
+        }
+    }
+
+    /// Builds a pathless `ReviewFinding`, whose identity falls back to the
+    /// whitespace-normalised, lowercased summary.
+    fn finding_without_path(summary: &str) -> ReviewFinding {
+        ReviewFinding {
+            id: uuid::Uuid::new_v4().to_string(),
+            severity: FindingSeverity::Major,
+            summary: summary.to_string(),
+            path: None,
+            line: None,
+            disposition: FindingDisposition::Open,
+            recommended_disposition: None,
+            created_at: now_secs(),
+        }
+    }
+
+    /// Issue #155, Phase 4(c): "stop when a round yields no new findings" was
+    /// prompt text only. A converged change still burned rounds 2 and 3 --
+    /// each one a full reviewer launch over a 96 KiB diff.
+    #[test]
+    fn a_round_with_no_new_findings_converges() {
+        let existing = vec![finding_at("src/lib.rs", 10, "off-by-one in the loop bound")];
+        let repeat = vec![finding_at(
+            "src/lib.rs",
+            10,
+            "off by one in the loop bound!!",
+        )];
+        assert_eq!(
+            new_finding_count(&existing, &repeat),
+            0,
+            "the same path:line is the same finding, whatever the wording"
+        );
+
+        let fresh = vec![finding_at("src/other.rs", 3, "unchecked unwrap")];
+        assert_eq!(new_finding_count(&existing, &fresh), 1);
+        assert_eq!(new_finding_count(&existing, &[]), 0);
+    }
+
+    /// "New" must mean the same thing here as everywhere else in this module,
+    /// or the stop rule and the escalation rule will disagree about whether a
+    /// finding recurred. Both go through `finding_key`.
+    #[test]
+    fn convergence_uses_the_same_identity_as_the_escalation_rule() {
+        let pathless_a = finding_without_path("the error message is swallowed");
+        let pathless_b = finding_without_path("the  error   message is swallowed");
+        assert_eq!(
+            new_finding_count(std::slice::from_ref(&pathless_a), &[pathless_b]),
+            0,
+            "finding_key normalises whitespace for a pathless finding"
+        );
+    }
+
+    /// A converged round is a SUCCESS, not an exhausted budget: it must not
+    /// consume the remaining rounds and must not report failure.
+    #[test]
+    fn a_converged_round_ends_the_loop_successfully_with_rounds_left() {
+        let outcome = RoundOutcome {
+            new_findings: 0,
+            converged: true,
+        };
+        assert!(outcome.converged);
+        assert_eq!(
+            round_exit_code(&outcome, 0),
+            0,
+            "convergence with a zero reviewer exit is success"
+        );
+    }
+
+    /// A non-converged round (genuinely new findings) must keep reporting the
+    /// reviewer's own exit code -- convergence is never allowed to mask a
+    /// real blocking result.
+    #[test]
+    fn a_non_converged_round_keeps_the_reviewers_own_exit_code() {
+        let outcome = RoundOutcome {
+            new_findings: 1,
+            converged: false,
+        };
+        assert_eq!(round_exit_code(&outcome, 0), 0);
+        assert_eq!(round_exit_code(&outcome, 7), 7);
+    }
+
+    /// End-to-end: a round whose reviewer reports only an already-recorded
+    /// finding must still push evidence and merge the finding (convergence is
+    /// a stopping rule, not a skip), but must tell the operator the loop is
+    /// complete and must exit 0.
+    #[test]
+    fn run_independent_review_converges_when_nothing_new_is_reported() {
+        let repo = git_repo();
+        let root = tempdir().unwrap();
+        // SAFETY: this suite runs single-threaded (`--test-threads=1`).
+        unsafe {
+            std::env::set_var(crate::commands::ctx::state::STATE_ENV, root.path());
+        }
+        let state_dir = StateDir::from_root(root.path().to_path_buf());
+        let mut state = review_workflow(repo.path(), &state_dir);
+        state
+            .review_findings
+            .push(finding_at("src/lib.rs", 10, "off-by-one in the loop bound"));
+        engine::save(&state_dir, &state, true).unwrap();
+
+        let args = RunReviewArgs {
+            id: state.id.clone(),
+            agent: "claude".into(),
+            base: None,
+            repo: Some(repo.path().to_path_buf()),
+        };
+        let mut out = Vec::new();
+        // The reviewer reports the exact same finding again, just reworded --
+        // still the same `finding_key`, so still zero NEW findings.
+        let code = run_independent_review(&args, &mut out, &|_, _| {
+            Ok(ReviewerRun {
+                code: 0,
+                dashboard_spawn: false,
+                output: Some(format!(
+                    "{REVIEW_RESULT_PREFIX}{{\"findings\":[{{\"severity\":\"major\",\
+                     \"summary\":\"off by one in the loop bound!!\",\"path\":\"src/lib.rs\",\
+                     \"line\":10}}]}}"
+                )),
+            })
+        });
+        unsafe {
+            std::env::remove_var(crate::commands::ctx::state::STATE_ENV);
+        }
+        assert_eq!(
+            code.expect("the review runs"),
+            0,
+            "a converged round is a success exit"
+        );
+        let stdout = String::from_utf8(out).unwrap();
+        assert!(
+            stdout.contains("no findings") && stdout.contains("complete"),
+            "the operator is told the loop converged; got {stdout:?}"
+        );
+
+        let stored = engine::load(&state_dir, repo.path(), &state.id).unwrap();
+        assert_eq!(
+            stored.review_evidence.len(),
+            1,
+            "a converged round is still a completed, recorded review"
+        );
+        assert_eq!(
+            stored.review_findings.len(),
+            2,
+            "the finding merge still happens -- convergence is a stopping rule, not a skip"
+        );
     }
 
     #[test]

--- a/src/commands/workflow/review.rs
+++ b/src/commands/workflow/review.rs
@@ -125,6 +125,11 @@ pub struct ReviewRunEvidence {
     pub adapter: String,
     pub review_round: u8,
     pub completed_at: u64,
+    /// The HEAD sha this reviewer actually reviewed. `None` for evidence
+    /// written before this field existed -- an older zirv -- which
+    /// `delta_base` reads as a broken chain and falls back to the full diff.
+    #[serde(default)]
+    pub head_sha: Option<String>,
 }
 
 pub fn depth_for_risk(risk: RiskBand) -> ReviewDepth {
@@ -175,6 +180,14 @@ pub struct ReviewPackage {
     pub escalation_reason: Option<String>,
     pub base_sha: String,
     pub head_sha: String,
+    /// The sha the packaged `diff` is actually computed against: `base_sha`
+    /// on round 1 or whenever the evidence chain is broken, otherwise the
+    /// sha the previous round's reviewer actually reviewed.
+    pub diff_base_sha: String,
+    /// Whether `diff` is a delta since `diff_base_sha` rather than the full
+    /// change since `base_sha`. A reviewer must never mistake one for the
+    /// other.
+    pub diff_is_delta: bool,
     pub change_fingerprint: u64,
     pub changed_paths: Vec<PathBuf>,
     pub diff: String,
@@ -206,6 +219,41 @@ fn review_round(state: &WorkflowState, current_fingerprint: u64) -> u8 {
         .unwrap_or(0)
         .saturating_add(1);
     evidence_round.max(attempt_round)
+}
+
+/// The sha a later review round should diff FROM: the HEAD the most recent
+/// completed reviewer actually reviewed.
+///
+/// `None` -- meaning "send the full diff against the workflow's base_sha,
+/// exactly as before" -- whenever the chain cannot be proven intact: round 1,
+/// no evidence at all, evidence written before `head_sha` existed, or a
+/// recorded sha that no longer resolves in this repository (a rebase, a
+/// reset, a fresh clone). A reviewer that silently receives LESS than the
+/// change it is judging is a worse outcome than an expensive review, so
+/// every ambiguous case falls back.
+fn delta_base(state: &WorkflowState, repo: &Path, review_round: u8) -> Option<String> {
+    if review_round <= 1 {
+        return None;
+    }
+    let sha = state
+        .review_evidence
+        .iter()
+        .max_by_key(|evidence| (evidence.review_round, evidence.completed_at))?
+        .head_sha
+        .clone()?;
+    // Must still resolve to a commit in THIS repository, or the diff below
+    // would fail outright rather than degrade.
+    git(
+        repo,
+        &[
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            &format!("{sha}^{{commit}}"),
+        ],
+    )
+    .ok()?;
+    Some(sha)
 }
 
 fn git(repo: &Path, args: &[&str]) -> CtxResult<String> {
@@ -588,10 +636,26 @@ pub fn package(
         None => default_base(&state.repo)?,
     };
     let head_sha = git(&state.repo, &["rev-parse", "HEAD"])?;
+    let current_fingerprint = verification::change_fingerprint(&state.repo)?;
+    let review_round = review_round(state, current_fingerprint);
+    if review_round > MAX_FIX_REVIEW_ROUNDS {
+        return Err(format!(
+            "review/fix loop reached the bounded limit of {MAX_FIX_REVIEW_ROUNDS} rounds; record residual dispositions or start a new workflow"
+        )
+        .into());
+    }
+    // Round 1, or any break in the evidence chain, packages the full diff
+    // against `base_sha` exactly as before. A later round with an intact
+    // chain packages only what changed since the last reviewed sha -- the
+    // reviewer still gets `changed_paths` (against `base_sha`, below) and
+    // `existing_findings` for full context.
+    let diff_base_sha =
+        delta_base(state, &state.repo, review_round).unwrap_or_else(|| base_sha.clone());
+    let diff_is_delta = diff_base_sha != base_sha;
     // `git diff <base>` includes committed branch changes plus current staged
     // and unstaged edits. Git omits untracked files, so include bounded file
     // bodies for those explicitly and union them into the changed path list.
-    let (mut diff, mut diff_truncated) = git_diff_capped(&state.repo, &base_sha)?;
+    let (mut diff, mut diff_truncated) = git_diff_capped(&state.repo, &diff_base_sha)?;
     let untracked: Vec<PathBuf> =
         git(&state.repo, &["ls-files", "--others", "--exclude-standard"])?
             .lines()
@@ -599,6 +663,9 @@ pub fn package(
             .map(PathBuf::from)
             .collect();
     append_untracked(&mut diff, &mut diff_truncated, &state.repo, &untracked)?;
+    // Always the full set of files touched since `base_sha`, never just the
+    // delta -- a reviewer holding a partial diff still needs to know the
+    // complete surface this change reaches.
     let mut changed_paths: BTreeSet<PathBuf> =
         git(&state.repo, &["diff", "--name-only", &base_sha])?
             .lines()
@@ -607,16 +674,8 @@ pub fn package(
             .collect();
     changed_paths.extend(untracked);
     let changed_paths = changed_paths.into_iter().collect();
-    let current_fingerprint = verification::change_fingerprint(&state.repo)?;
     let verification = verification::load_latest(state_dir, &state.repo)?
         .map(|report| VerificationEvidence::from_report(report, current_fingerprint));
-    let review_round = review_round(state, current_fingerprint);
-    if review_round > MAX_FIX_REVIEW_ROUNDS {
-        return Err(format!(
-            "review/fix loop reached the bounded limit of {MAX_FIX_REVIEW_ROUNDS} rounds; record residual dispositions or start a new workflow"
-        )
-        .into());
-    }
     let required_reviews = required_independent_reviews_for(state);
     let escalated = required_reviews > required_independent_reviews(state.classification.risk);
     Ok(ReviewPackage {
@@ -635,6 +694,8 @@ pub fn package(
         }),
         base_sha,
         head_sha,
+        diff_base_sha,
+        diff_is_delta,
         change_fingerprint: current_fingerprint,
         changed_paths,
         diff,
@@ -940,8 +1001,19 @@ fn records_evidence(run: &ReviewerRun, fingerprint_unchanged: bool) -> bool {
 
 fn launch_reviewer(agent: &str, package: &ReviewPackage) -> CtxResult<ReviewerRun> {
     let argv = reviewer_argv(agent)?;
+    // A delta package must never read as a whole change: a reviewer told
+    // "this is the whole diff" when it is only what changed since the last
+    // reviewed commit will report false findings about code it cannot see.
+    let delta_notice = if package.diff_is_delta {
+        format!(
+            "This `diff` covers only what changed since the previously reviewed commit {}; it is NOT the full change. `changed_paths` lists every file this change touches, and `existing_findings` lists what earlier rounds already recorded -- consult those instead of assuming this diff is complete.\n\n",
+            package.diff_base_sha
+        )
+    } else {
+        String::new()
+    };
     let prompt = format!(
-        "Review the following compact Zirv review package. Do not modify files. Return exactly one single-line result prefixed `{REVIEW_RESULT_PREFIX}` followed by JSON shaped as {{\"findings\":[{{\"severity\":\"major\",\"summary\":\"concrete reasoning\",\"path\":\"src/file.rs\",\"line\":12,\"recommended_disposition\":\"accepted\"}}]}}. Use an empty findings array when no concrete issue exists. Do not emit another result line.\n\n{}",
+        "{delta_notice}Review the following compact Zirv review package. Do not modify files. Return exactly one single-line result prefixed `{REVIEW_RESULT_PREFIX}` followed by JSON shaped as {{\"findings\":[{{\"severity\":\"major\",\"summary\":\"concrete reasoning\",\"path\":\"src/file.rs\",\"line\":12,\"recommended_disposition\":\"accepted\"}}]}}. Use an empty findings array when no concrete issue exists. Do not emit another result line.\n\n{}",
         serde_json::to_string(package)?
     );
     let mut child = Command::new(std::env::current_exe()?)
@@ -1042,6 +1114,7 @@ fn run_independent_review(
             adapter: args.agent.clone(),
             review_round: package.review_round,
             completed_at: now_secs(),
+            head_sha: Some(package.head_sha.clone()),
         });
         let overflow = state
             .review_evidence
@@ -1207,6 +1280,13 @@ mod tests {
     /// A repository with one commit, so `package` has a real base, diff and
     /// fingerprint to read.
     fn git_repo() -> tempfile::TempDir {
+        git_repo_with_commits(&["base"])
+    }
+
+    /// A repository with one commit per message, applied in order to the same
+    /// tracked file, so a test can build a deterministic multi-commit history
+    /// and read the shas back with `git_log_shas`.
+    fn git_repo_with_commits(messages: &[&str]) -> tempfile::TempDir {
         let repo = tempdir().unwrap();
         let git = |args: &[&str]| {
             let status = Command::new("git")
@@ -1225,13 +1305,36 @@ mod tests {
             assert!(status.success(), "git {args:?} failed");
         };
         git(&["init", "-q"]);
-        std::fs::write(repo.path().join("tracked.txt"), "one\n").unwrap();
-        git(&["add", "."]);
-        git(&["commit", "-q", "-m", "base"]);
+        for message in messages {
+            std::fs::write(repo.path().join("tracked.txt"), format!("{message}\n")).unwrap();
+            git(&["add", "."]);
+            git(&["commit", "-q", "-m", message]);
+        }
         repo
     }
 
-    fn review_workflow(repo: &Path, state_dir: &StateDir) -> WorkflowState {
+    /// Commit shas on the current branch, oldest first -- the same order
+    /// `messages` was applied in by `git_repo_with_commits`.
+    fn git_log_shas(repo: &Path) -> Vec<String> {
+        let output = Command::new("git")
+            .args(["log", "--reverse", "--format=%H"])
+            .current_dir(repo)
+            .output()
+            .expect("run git log");
+        assert!(output.status.success(), "git log failed");
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// A `WorkflowState` at `WorkflowStatus::Running` on a
+    /// `WorkflowPhase::Review` step, for `repo`. `base` is not read back out
+    /// of the state -- there is no field for it -- it exists so a test's
+    /// intent ("this workflow's change is measured from `base`") is legible
+    /// at the call site rather than an unexplained bare repo path.
+    fn running_review_state(repo: &Path, base: &str) -> WorkflowState {
         let classification = super::super::classify::Classification {
             intent: super::super::classify::Intent::Review,
             complexity: super::super::classify::Complexity::Trivial,
@@ -1244,14 +1347,18 @@ mod tests {
             risk_measurement: super::super::classify::RiskMeasurement::Measured,
             reasons: vec![],
         };
-        let state = WorkflowState::start(
+        WorkflowState::start(
             repo.to_path_buf(),
-            "review change".into(),
+            format!("review change since {base}"),
             super::super::engine::WorkflowKind::Review,
             None,
             true,
             classification,
-        );
+        )
+    }
+
+    fn review_workflow(repo: &Path, state_dir: &StateDir) -> WorkflowState {
+        let state = running_review_state(repo, "HEAD");
         engine::save(state_dir, &state, true).unwrap();
         state
     }
@@ -1788,6 +1895,7 @@ checksum = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f80"
             adapter: "claude".into(),
             review_round: 1,
             completed_at: now_secs(),
+            head_sha: None,
         });
         assert_eq!(review_round(&state, 10), 1);
         assert_eq!(review_round(&state, 11), 2);
@@ -1797,7 +1905,89 @@ checksum = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f80"
             adapter: "codex".into(),
             review_round: 2,
             completed_at: now_secs(),
+            head_sha: None,
         });
         assert_eq!(review_round(&state, 12), 3);
+    }
+
+    /// Issue #155, Phase 4(b): round 2 of a fix loop re-sent every byte round
+    /// 1 already sent -- the full diff against the workflow's fixed base_sha,
+    /// to every reviewer, every round, capped at 96 KiB (~24k tokens). Round
+    /// 2 onward diffs from the sha the LAST reviewer actually reviewed.
+    #[test]
+    fn a_later_round_diffs_from_the_last_reviewed_sha_not_the_workflow_base() {
+        let repo = git_repo_with_commits(&["base", "first change", "fix after review"]);
+        let shas = git_log_shas(repo.path()); // oldest first
+        let mut state = running_review_state(repo.path(), &shas[0]);
+        state.review_evidence.push(ReviewRunEvidence {
+            id: "ev-1".to_string(),
+            change_fingerprint: 1,
+            adapter: "codex".to_string(),
+            review_round: 1,
+            completed_at: 10,
+            head_sha: Some(shas[1].clone()),
+        });
+
+        let base = delta_base(&state, repo.path(), 2).expect("a delta base for round 2");
+        assert_eq!(base, shas[1], "the sha round 1 actually reviewed");
+        assert_eq!(
+            delta_base(&state, repo.path(), 1),
+            None,
+            "round 1 has nothing to delta against and must send the full diff"
+        );
+    }
+
+    /// Every way the chain can break must fall back to the FULL diff. A
+    /// reviewer that silently receives less than it needs is a worse outcome
+    /// than an expensive review.
+    #[test]
+    fn a_broken_evidence_chain_falls_back_to_the_full_diff() {
+        let repo = git_repo_with_commits(&["base", "first change"]);
+        let shas = git_log_shas(repo.path());
+        let base_state = running_review_state(repo.path(), &shas[0]);
+
+        // (1) evidence with no recorded sha -- written by an older zirv.
+        let mut no_sha = base_state.clone();
+        no_sha.review_evidence.push(ReviewRunEvidence {
+            id: "ev-1".to_string(),
+            change_fingerprint: 1,
+            adapter: "codex".to_string(),
+            review_round: 1,
+            completed_at: 10,
+            head_sha: None,
+        });
+        assert_eq!(delta_base(&no_sha, repo.path(), 2), None);
+
+        // (2) a recorded sha that no longer resolves -- a rebase or a reset.
+        let mut gone = base_state.clone();
+        gone.review_evidence.push(ReviewRunEvidence {
+            id: "ev-1".to_string(),
+            change_fingerprint: 1,
+            adapter: "codex".to_string(),
+            review_round: 1,
+            completed_at: 10,
+            head_sha: Some("0".repeat(40)),
+        });
+        assert_eq!(delta_base(&gone, repo.path(), 2), None);
+
+        // (3) no evidence at all.
+        assert_eq!(delta_base(&base_state, repo.path(), 2), None);
+    }
+
+    /// The package states plainly which diff a reviewer is holding. A
+    /// reviewer told "this is the whole change" when it is a delta will
+    /// report false findings about code it cannot see.
+    #[test]
+    fn the_package_declares_whether_its_diff_is_a_delta() {
+        let repo = git_repo_with_commits(&["base", "first change"]);
+        let shas = git_log_shas(repo.path());
+        let state = running_review_state(repo.path(), &shas[0]);
+        let state_dir =
+            StateDir::from_root(tempfile::tempdir().expect("tempdir").path().to_path_buf());
+
+        let package = package(&state_dir, &state, Some(&shas[0])).expect("package");
+        assert!(!package.diff_is_delta, "round 1 is never a delta");
+        assert_eq!(package.diff_base_sha, package.base_sha);
+        assert_eq!(package.head_sha.len(), 40);
     }
 }


### PR DESCRIPTION
**Status: DRAFT — the engine half of Phase 4 is complete and review-clean; prompt-text + version tasks land at stack time.** Phase 4 of #155: make the review train converge instead of replaying — one task can currently pay for 2–6 full-diff review transmissions.

Landed, each through an independent review gate + fix rounds:
- **4.2** (`17901b9`, `086a67d`) — delta re-review: review evidence records the reviewed HEAD sha; rounds ≥2 with an intact fingerprint chain package only the diff since the last reviewed sha (full-diff fallback on ANY chain break); an end-to-end test pins that the delta diff content excludes already-reviewed changes. The 96KiB-capped full diff is no longer resent to every reviewer every round.
- **4.3** (`7743224`) — stop-on-no-new-findings enforced in code: a recorded round whose findings are all already known (by the existing `finding_key` identity) terminates the loop successfully; escalation rules and the 3-round hard cap unchanged. Parked follow-up (reviewed, ruled): `path:line` key collisions can soften the convergence message — findings are still merged, nothing is lost.

Deliberately NOT here (stack-time work per the parallelization plan): 4.1 (the HARNESS_PROMPT/adapter guard text ending stacked review mandates — touches prompt.rs shared with other phases), 4.4 version bump (2.36.0 after renumbering), 4.5 phase gates.

Based directly on `main` (temporary integration base for parallel development); restacks onto the phase train before merge. Merge order: #154 → #153 → #156 → P2 → P3 → this.
