### PR TITLE
fix(ctx): approval-surface residuals from the #147 security review (#160)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "2.33.0"
+version = "2.33.1"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "2.33.0"
+version = "2.33.1"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -4014,6 +4014,63 @@ fn partition_restore_selection(
     (to_spawn, deferred)
 }
 
+/// Builds the `turn_env` a restored dashboard pane spawns with -- everything
+/// `spawn_restored_pane` pushes ahead of `Pane::spawn`: the base env `build_
+/// turn_env` produces, a fresh spawn-request channel of its own (Security
+/// review Finding 1), the roster's group binding when the candidate carried
+/// one (Security review Finding 6), and the durable interactive-launch pin
+/// (issue #160 finding 1). Factored out of `spawn_restored_pane` so the exact
+/// fields it adds are pinned directly, independent of a real pty spawn's
+/// behavior -- the same reasoning `spawn_launch_mode_pin`'s own doc comment
+/// gives for testing that pin as a pure function rather than reading a real
+/// spawned child's own environment back.
+///
+/// Returns the built `turn_env` alongside the freshly minted pane channel
+/// path: `spawn_restored_pane` needs both, the env to spawn with and the
+/// path to hand the spawned `Pane` via `set_intake_dir`.
+fn restored_pane_turn_env(
+    cfg: &CtxConfig,
+    state: &StateDir,
+    repo: &Path,
+    candidate: &roster::RosterPane,
+    requests_dir: &Path,
+    errors: &mut Vec<String>,
+) -> (Vec<(String, String)>, PathBuf) {
+    let (mut turn_env, turn_env_err) =
+        build_turn_env(cfg, state, repo, &candidate.agent, &candidate.session_id);
+    if let Some(e) = turn_env_err {
+        push_error(errors, e);
+    }
+    // Security review Finding 1: a restored pane is a pane like any other and
+    // gets its own channel -- a fresh token, since the one it carried before
+    // the quit died with that dashboard's token directory.
+    let pane_channel = mint_pane_channel(requests_dir, errors);
+    turn_env.push((
+        spawnreq::DASH_REQUESTS_ENV.to_string(),
+        pane_channel.display().to_string(),
+    ));
+    // Security review Finding 6: and the group binding travels back with it,
+    // the same pair `fulfill_spawn_request` pushes for a fresh spawn -- a
+    // restore that dropped it left the pane's own further delegations
+    // ungrouped, outside the child limit and the token ceiling its batch was
+    // launched under.
+    if let Some(group_id) = &candidate.work_group_id {
+        turn_env.push((super::agent::WORK_GROUP_ENV.to_string(), group_id.clone()));
+    }
+    // Issue #160 finding 1: a restored pane is a pane the operator is
+    // watching in the dashboard, exactly like the dashboard's own first
+    // (orchestrator) pane -- see `run_dashboard`'s identical push for that
+    // pane's own rationale -- so it gets the same unconditional durable
+    // interactive-launch pin, never conditioned on a request that does not
+    // exist for this pane. Without this a restored pane came back
+    // classified headless and fell back to the fail-closed approval posture
+    // on every dashboard restart.
+    if let Some((key, value)) = adapters::launch_mode_pin_env(adapters::LaunchMode::Interactive) {
+        turn_env.push((key, value));
+    }
+    (turn_env, pane_channel)
+}
+
 /// Spawns one roster candidate back as a fresh pane: resolves its
 /// adapter (re-checked against the live gate, same "data, never authority"
 /// discipline `fulfill_spawn_request` already holds a spawn request to --
@@ -4068,27 +4125,8 @@ fn spawn_restored_pane(
         title: candidate.title.clone(),
     };
 
-    let (mut turn_env, turn_env_err) =
-        build_turn_env(cfg, state, repo, &candidate.agent, &candidate.session_id);
-    if let Some(e) = turn_env_err {
-        push_error(errors, e);
-    }
-    // Security review Finding 1: a restored pane is a pane like any other and
-    // gets its own channel -- a fresh token, since the one it carried before
-    // the quit died with that dashboard's token directory.
-    let pane_channel = mint_pane_channel(requests_dir, errors);
-    turn_env.push((
-        spawnreq::DASH_REQUESTS_ENV.to_string(),
-        pane_channel.display().to_string(),
-    ));
-    // Security review Finding 6: and the group binding travels back with it,
-    // the same pair `fulfill_spawn_request` pushes for a fresh spawn -- a
-    // restore that dropped it left the pane's own further delegations
-    // ungrouped, outside the child limit and the token ceiling its batch was
-    // launched under.
-    if let Some(group_id) = &candidate.work_group_id {
-        turn_env.push((super::agent::WORK_GROUP_ENV.to_string(), group_id.clone()));
-    }
+    let (turn_env, pane_channel) =
+        restored_pane_turn_env(cfg, state, repo, candidate, requests_dir, errors);
 
     match Pane::spawn(
         spec,
@@ -14044,6 +14082,41 @@ mod tests {
             written.panes,
             vec![live_one],
             "a held-back candidate is offered again next launch, not destroyed"
+        );
+    }
+
+    /// Issue #160 finding 1: a restored dashboard pane is a pane the operator
+    /// is watching, exactly like the dashboard's own first (orchestrator)
+    /// pane -- which `run_dashboard` unconditionally pins to `LaunchMode::
+    /// Interactive` (see that push's own doc comment). Before this fix
+    /// `spawn_restored_pane` built its `turn_env` from `build_turn_env` plus
+    /// the fresh spawn-request channel and group binding, but never pushed
+    /// the durable interactive-launch pin, so a restored pane a human was
+    /// looking at right there in the dashboard classified as headless and
+    /// fell back to the fail-closed approval posture on every restart.
+    #[test]
+    fn restored_pane_turn_env_carries_the_interactive_launch_mode_pin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("mkdir repo");
+        let requests_dir = state.dash().join("aaaa1111-token").join("requests");
+        std::fs::create_dir_all(&requests_dir).expect("mkdir requests");
+
+        let candidate = restore_pane("cccc3333", "33333333-2222-4333-8444-555555555555");
+        let cfg = CtxConfig::default();
+        let mut errors = Vec::new();
+
+        let (turn_env, _pane_channel) =
+            restored_pane_turn_env(&cfg, &state, &repo, &candidate, &requests_dir, &mut errors);
+
+        assert!(
+            turn_env.contains(&(
+                super::super::adapters::LAUNCH_MODE_ENV.to_string(),
+                super::super::adapters::LAUNCH_MODE_INTERACTIVE_VALUE.to_string()
+            )),
+            "a restored pane must carry the durable interactive-launch pin, same as the \
+             dashboard's own first pane: {turn_env:?}"
         );
     }
 

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -1236,6 +1236,12 @@ fn on_quit(
             // Finding 6: and the group it belongs to, so the restore can put
             // it back inside the same one.
             work_group_id: pane.work_group_id().map(str::to_string),
+            // Issue #160 finding 1, review round (2026-08-28): the launch
+            // mode this pane was ACTUALLY spawned with (`Pane::launch_mode`),
+            // so a restore can relaunch it on the same terms rather than
+            // unconditionally pinning `Interactive` -- see `restored_pane_
+            // turn_env`'s own doc comment.
+            interactive: pane.launch_mode() == adapters::LaunchMode::Interactive,
         })
         .collect();
     let panes_for_roster = merge_unoffered(live, unoffered);
@@ -1956,13 +1962,29 @@ fn turn_signal_capable_for(cfg: &CtxConfig, agent_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Builds a fresh pane's `turn_env`: the adapter's own turn-signal
+/// registration (or its resolution-failure fallback), the pane's session
+/// identity, and -- security review round (2026-08-28), review of issue
+/// #160's own fix -- the durable interactive-launch pin, ALWAYS pushed here
+/// rather than left to each of the three call sites to remember on their
+/// own. Before this, `fulfill_spawn_request`, `run_dashboard`'s first pane,
+/// and `spawn_restored_pane` each pushed `adapters::launch_mode_pin_env`
+/// separately after calling this function -- three independent chances to
+/// forget the pin, and issue #160 finding 1 was exactly that: the third
+/// occurrence of the forgotten-pin bug class. `mode` is now a MANDATORY
+/// parameter so a call site that forgets to decide it is a compile error,
+/// not a silently-headless pane; `LaunchMode::Headless` already reads as
+/// "no pin" through `launch_mode_pin_env`, so no separate `Option` is
+/// needed to make "no pin" explicit -- the enum already has that variant.
 fn build_turn_env(
     cfg: &CtxConfig,
     state: &StateDir,
     repo: &Path,
     agent_name: &str,
     session_id: &str,
+    mode: adapters::LaunchMode,
 ) -> (Vec<(String, String)>, Option<String>) {
+    let pin = adapters::launch_mode_pin_env(mode);
     match adapters::select(Some(agent_name), &[], cfg) {
         Ok(adapter) => {
             let socket = state.socket_for(session_id);
@@ -1991,14 +2013,23 @@ fn build_turn_env(
             if !env.iter().any(|(k, _)| k == adapters::SESSION_ENV) {
                 env.push((adapters::SESSION_ENV.to_string(), session_id.to_string()));
             }
+            if let Some(pair) = pin {
+                env.push(pair);
+            }
             (env, None)
         }
-        Err(e) => (
-            vec![(adapters::AGENT_ENV.to_string(), agent_name.to_string())],
-            Some(format!(
-                "dashboard: could not resolve adapter '{agent_name}' for turn signals: {e}"
-            )),
-        ),
+        Err(e) => {
+            let mut env = vec![(adapters::AGENT_ENV.to_string(), agent_name.to_string())];
+            if let Some(pair) = pin {
+                env.push(pair);
+            }
+            (
+                env,
+                Some(format!(
+                    "dashboard: could not resolve adapter '{agent_name}' for turn signals: {e}"
+                )),
+            )
+        }
     }
 }
 
@@ -2335,10 +2366,10 @@ fn worker_pane_extra_args(
     extra
 }
 
-/// The env pair, if any, [`fulfill_spawn_request`] pushes into a fresh
-/// worker pane's `turn_env` for the durable interactive-launch pin
-/// (`adapters::LAUNCH_MODE_ENV`, issue #147 amendment). `trusted_interactive`
-/// is the ONLY input -- deliberately not `SpawnRequest.interactive`, which is
+/// The `LaunchMode` [`fulfill_spawn_request`] feeds to `build_turn_env` for
+/// a fresh worker pane's durable interactive-launch pin (`adapters::
+/// LAUNCH_MODE_ENV`, issue #147 amendment). `trusted_interactive` is the
+/// ONLY input -- deliberately not `SpawnRequest.interactive`, which is
 /// untrusted JSON any process able to write into the requests directory can
 /// forge (review round 1, 2026-08-27, Important). Pure and directly testable
 /// so the security property ("a forged request can never produce the pin")
@@ -2346,12 +2377,18 @@ fn worker_pane_extra_args(
 /// behavior; see `fulfill_spawn_request`'s own doc comment for which callers
 /// pass `true` (only the dashboard's own in-process Spawn overlay) versus
 /// `false` (everything else, including every file-dropped request).
-fn spawn_launch_mode_pin(trusted_interactive: bool) -> Option<(String, String)> {
-    adapters::launch_mode_pin_env(if trusted_interactive {
+///
+/// Security review round (2026-08-28), issue #160 finding 2: used to push
+/// the env pair itself (`Option<(String, String)>`); now just resolves the
+/// `LaunchMode` and leaves the actual pin-pushing to `build_turn_env`,
+/// which every call site now routes through -- see that function's own doc
+/// comment for why the push moved there.
+fn trusted_launch_mode(trusted_interactive: bool) -> adapters::LaunchMode {
+    if trusted_interactive {
         adapters::LaunchMode::Interactive
     } else {
         adapters::LaunchMode::Headless
-    })
+    }
 }
 
 /// The `trusted_interactive` [`handle_spawn_requests`] always passes to
@@ -2466,7 +2503,7 @@ pub(crate) fn depth_refusal(
 
 /// The PARENT session's role for [`depth_refusal`], resolved from data this
 /// dashboard already trusts -- never from anything `req` itself claims about
-/// its own lineage. Mirrors `spawn_launch_mode_pin`'s own discipline (see its
+/// its own lineage. Mirrors `trusted_launch_mode`'s own discipline (see its
 /// doc comment): a spawn request is untrusted JSON any process that can reach
 /// the requests directory can hand-write, so `req.parent_session` is used
 /// only as a KEY into this dashboard's own live pane list, never trusted as
@@ -3209,7 +3246,22 @@ fn fulfill_spawn_request(
         title: format!("wrk {}", req.agent),
     };
 
-    let (mut turn_env, turn_env_err) = build_turn_env(cfg, state, repo, &req.agent, &session_id);
+    // Issue #147 amendment, review round 1 (2026-08-27) correction, and
+    // issue #160 finding 2 (2026-08-28): the durable interactive-launch pin
+    // is decided by `trusted_launch_mode`, which is `trusted_interactive`-
+    // only and never reads `req.interactive` (see both that function's and
+    // this one's own doc comments for the full security reasoning), and
+    // pushed by `build_turn_env` itself -- this call site no longer pushes
+    // it separately, closing off the "forgot the pin" bug class at this
+    // call site for good.
+    let (mut turn_env, turn_env_err) = build_turn_env(
+        cfg,
+        state,
+        repo,
+        &req.agent,
+        &session_id,
+        trusted_launch_mode(trusted_interactive),
+    );
     if let Some(e) = turn_env_err {
         push_error(errors, e);
     }
@@ -3223,19 +3275,12 @@ fn fulfill_spawn_request(
     // Issue #170: a work-group binding travels by lineage, not convention --
     // this pane's own child inherits `agent::WORK_GROUP_ENV` in its real
     // process environment, so any further `zirv agent` call it makes with no
-    // `--group` of its own (`agent::resolve_group_binding`'s env fallback)
-    // lands in the SAME group automatically, and every process THAT spawns
-    // inherits it in turn via ordinary environment inheritance -- no
-    // additional plumbing needed past this one seam.
+    // `--group` of its own (`agent::resolve_group_binding`'s own env
+    // fallback) lands in the SAME group automatically, and every process
+    // THAT spawns inherits it in turn via ordinary environment inheritance
+    // -- no additional plumbing needed past this one seam.
     if let Some(group_id) = &req.work_group_id {
         turn_env.push((super::agent::WORK_GROUP_ENV.to_string(), group_id.clone()));
-    }
-    // Issue #147 amendment, review round 1 (2026-08-27) correction: routed
-    // through `spawn_launch_mode_pin`, which is `trusted_interactive`-only
-    // and never reads `req.interactive` -- see both that function's and
-    // this one's own doc comments for the full security reasoning.
-    if let Some((key, value)) = spawn_launch_mode_pin(trusted_interactive) {
-        turn_env.push((key, value));
     }
 
     // T10: the same launch-time pacing gate `wrap::run_with`/this dashboard's
@@ -4016,14 +4061,27 @@ fn partition_restore_selection(
 
 /// Builds the `turn_env` a restored dashboard pane spawns with -- everything
 /// `spawn_restored_pane` pushes ahead of `Pane::spawn`: the base env `build_
-/// turn_env` produces, a fresh spawn-request channel of its own (Security
-/// review Finding 1), the roster's group binding when the candidate carried
-/// one (Security review Finding 6), and the durable interactive-launch pin
-/// (issue #160 finding 1). Factored out of `spawn_restored_pane` so the exact
-/// fields it adds are pinned directly, independent of a real pty spawn's
-/// behavior -- the same reasoning `spawn_launch_mode_pin`'s own doc comment
-/// gives for testing that pin as a pure function rather than reading a real
-/// spawned child's own environment back.
+/// turn_env` produces (including the durable interactive-launch pin, when
+/// `candidate` carried one), a fresh spawn-request channel of its own
+/// (Security review Finding 1), and the roster's group binding when the
+/// candidate carried one (Security review Finding 6). Factored out of
+/// `spawn_restored_pane` so the exact fields it adds are pinned directly,
+/// independent of a real pty spawn's behavior -- the same reasoning
+/// `trusted_launch_mode`'s own doc comment gives for testing a launch-mode
+/// decision as a pure function rather than reading a real spawned child's
+/// own environment back.
+///
+/// Issue #160 finding 1, review round (2026-08-28): a restore used to
+/// unconditionally pin `LaunchMode::Interactive`, which handed every worker
+/// pane that survived a dashboard quit+restore cycle an interactive posture
+/// it may have been explicitly REFUSED at spawn time (a file-dropped spawn
+/// request is untrusted and always launches `Headless` --
+/// `FILE_DROP_TRUSTED_INTERACTIVE`). The correct rule (issue #160: "on the
+/// same terms as a freshly spawned one") is to restore whatever launch mode
+/// the pane ORIGINALLY had, recorded on the roster entry at quit time
+/// (`RosterPane::interactive`, `#[serde(default)]` so an old-format roster
+/// entry with the field absent restores fail-closed -- no pin, today's
+/// pre-fix-round behavior -- rather than defaulting to the permissive side).
 ///
 /// Returns the built `turn_env` alongside the freshly minted pane channel
 /// path: `spawn_restored_pane` needs both, the env to spawn with and the
@@ -4036,8 +4094,19 @@ fn restored_pane_turn_env(
     requests_dir: &Path,
     errors: &mut Vec<String>,
 ) -> (Vec<(String, String)>, PathBuf) {
-    let (mut turn_env, turn_env_err) =
-        build_turn_env(cfg, state, repo, &candidate.agent, &candidate.session_id);
+    let mode = if candidate.interactive {
+        adapters::LaunchMode::Interactive
+    } else {
+        adapters::LaunchMode::Headless
+    };
+    let (mut turn_env, turn_env_err) = build_turn_env(
+        cfg,
+        state,
+        repo,
+        &candidate.agent,
+        &candidate.session_id,
+        mode,
+    );
     if let Some(e) = turn_env_err {
         push_error(errors, e);
     }
@@ -4056,17 +4125,6 @@ fn restored_pane_turn_env(
     // launched under.
     if let Some(group_id) = &candidate.work_group_id {
         turn_env.push((super::agent::WORK_GROUP_ENV.to_string(), group_id.clone()));
-    }
-    // Issue #160 finding 1: a restored pane is a pane the operator is
-    // watching in the dashboard, exactly like the dashboard's own first
-    // (orchestrator) pane -- see `run_dashboard`'s identical push for that
-    // pane's own rationale -- so it gets the same unconditional durable
-    // interactive-launch pin, never conditioned on a request that does not
-    // exist for this pane. Without this a restored pane came back
-    // classified headless and fell back to the fail-closed approval posture
-    // on every dashboard restart.
-    if let Some((key, value)) = adapters::launch_mode_pin_env(adapters::LaunchMode::Interactive) {
-        turn_env.push((key, value));
     }
     (turn_env, pane_channel)
 }
@@ -4952,20 +5010,25 @@ pub fn run_dashboard(
         None => agent_name.clone(),
     };
     let session_id = first.session_id.clone();
-    let (mut turn_env, turn_env_err) = build_turn_env(cfg, state, repo, &agent_name, &session_id);
-    if let Some(e) = turn_env_err {
-        push_error(&mut errors, e);
-    }
     // Issue #147 amendment: the dashboard's own first (orchestrator) pane is
     // unconditionally the human-attended session the operator is looking
     // at -- the same fact `dash_orchestrator_pane`'s hardcoded `LaunchMode::
     // Interactive` already encodes for this pane's own `policy_launch_args`
     // call -- so the durable interactive-launch pin is always set here,
     // never conditioned on a request that does not exist for this pane.
-    if let Some((key, value)) =
-        super::adapters::launch_mode_pin_env(super::adapters::LaunchMode::Interactive)
-    {
-        turn_env.push((key, value));
+    // Issue #160 finding 2 (2026-08-28): `build_turn_env` itself now pushes
+    // the pin from the `LaunchMode` passed in, so this call site no longer
+    // pushes it separately.
+    let (mut turn_env, turn_env_err) = build_turn_env(
+        cfg,
+        state,
+        repo,
+        &agent_name,
+        &session_id,
+        super::adapters::LaunchMode::Interactive,
+    );
+    if let Some(e) = turn_env_err {
+        push_error(&mut errors, e);
     }
     // The seat this pane sits in, for the `zirv ctx hook pretool` guard
     // running inside it. This `turn_env` belongs to the first pane and only
@@ -9412,7 +9475,14 @@ mod tests {
         let cfg = CtxConfig::default();
         let session_id = "11112222-3333-4444-8555-666677778888";
 
-        let (env, err) = build_turn_env(&cfg, &state, &repo, "codex", session_id);
+        let (env, err) = build_turn_env(
+            &cfg,
+            &state,
+            &repo,
+            "codex",
+            session_id,
+            adapters::LaunchMode::Headless,
+        );
 
         assert!(err.is_none(), "codex resolves fine, so no error: {err:?}");
         assert!(
@@ -9436,7 +9506,14 @@ mod tests {
         let cfg = CtxConfig::default();
         let session_id = "22223333-4444-5555-8666-777788889999";
 
-        let (env, err) = build_turn_env(&cfg, &state, &repo, "claude", session_id);
+        let (env, err) = build_turn_env(
+            &cfg,
+            &state,
+            &repo,
+            "claude",
+            session_id,
+            adapters::LaunchMode::Headless,
+        );
 
         assert!(err.is_none());
         let matches: Vec<_> = env
@@ -9447,6 +9524,53 @@ mod tests {
             matches.len(),
             1,
             "exactly one SESSION_ENV entry, not duplicated: {env:?}"
+        );
+    }
+
+    /// Issue #160 finding 2 (2026-08-28): `build_turn_env` now pushes the
+    /// durable interactive-launch pin itself, from the mandatory `mode`
+    /// parameter, rather than leaving it to each of its three call sites --
+    /// this pins that push at its actual source, independent of any one
+    /// call site remembering to add it separately.
+    #[test]
+    fn build_turn_env_pushes_the_interactive_launch_mode_pin_only_when_asked() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let repo = tmp.path().to_path_buf();
+        let cfg = CtxConfig::default();
+        let session_id = "33334444-5555-6666-8777-888899990000";
+
+        let (interactive_env, _) = build_turn_env(
+            &cfg,
+            &state,
+            &repo,
+            "claude",
+            session_id,
+            adapters::LaunchMode::Interactive,
+        );
+        assert!(
+            interactive_env.contains(&(
+                adapters::LAUNCH_MODE_ENV.to_string(),
+                adapters::LAUNCH_MODE_INTERACTIVE_VALUE.to_string()
+            )),
+            "LaunchMode::Interactive must push the pin: {interactive_env:?}"
+        );
+
+        let (headless_env, _) = build_turn_env(
+            &cfg,
+            &state,
+            &repo,
+            "claude",
+            session_id,
+            adapters::LaunchMode::Headless,
+        );
+        assert!(
+            !headless_env
+                .iter()
+                .any(|(k, _)| k == adapters::LAUNCH_MODE_ENV),
+            "LaunchMode::Headless must never push the pin: {headless_env:?}"
         );
     }
 
@@ -13445,34 +13569,39 @@ mod tests {
     /// JSON -- any process able to reach the requests directory
     /// (capability-protected by a token in its path, not authenticated) can
     /// write a `req-*.json` claiming `"interactive": true` regardless of
-    /// whether a human is actually watching any dashboard. `spawn_launch_
-    /// mode_pin` (what `fulfill_spawn_request` actually keys the durable
-    /// interactive-launch pin on) takes `trusted_interactive` as its ONLY
-    /// input, so a forged `req.interactive: true` can never produce the pin
-    /// through `handle_spawn_requests` (the file-drop consumer, which always
-    /// passes `false`) -- only the dashboard's own in-process Spawn overlay,
-    /// which passes `true`, can. Deliberately a pure decision-function test,
-    /// not a real-process env capture: this codebase's own established
-    /// pattern for exactly this class of question (see `worker_pane_extra_
-    /// args_fails_closed_to_headless_for_a_non_interactive_request`,
-    /// `wrap::tests::launch_mode_from_interactive_maps_the_boolean_to_the_
-    /// right_mode`) -- deterministic regardless of host PTY/console
-    /// behavior, unlike reading a real spawned child's own environment back.
+    /// whether a human is actually watching any dashboard. `trusted_launch_
+    /// mode` (what `fulfill_spawn_request` actually keys the durable
+    /// interactive-launch pin on, via `build_turn_env`) takes
+    /// `trusted_interactive` as its ONLY input, so a forged `req.interactive:
+    /// true` can never produce the pin through `handle_spawn_requests` (the
+    /// file-drop consumer, which always passes `false`) -- only the
+    /// dashboard's own in-process Spawn overlay, which passes `true`, can.
+    /// Deliberately a pure decision-function test, not a real-process env
+    /// capture: this codebase's own established pattern for exactly this
+    /// class of question (see `worker_pane_extra_args_fails_closed_to_
+    /// headless_for_a_non_interactive_request`, `wrap::tests::launch_mode_
+    /// from_interactive_maps_the_boolean_to_the_right_mode`) -- deterministic
+    /// regardless of host PTY/console behavior, unlike reading a real
+    /// spawned child's own environment back.
+    ///
+    /// Issue #160 finding 2 (2026-08-28): this used to assert the pushed env
+    /// PAIR directly (`Option<(String, String)>`); now `trusted_launch_mode`
+    /// only resolves the `LaunchMode` and `build_turn_env` does the actual
+    /// pushing (see that function's own doc comment), so this asserts the
+    /// mode instead -- the security property under test (forged `req.
+    /// interactive` never wins) is unchanged.
     #[test]
-    fn spawn_launch_mode_pin_ignores_req_interactive_and_only_trusts_the_caller() {
+    fn trusted_launch_mode_ignores_req_interactive_and_only_trusts_the_caller() {
         assert_eq!(
-            spawn_launch_mode_pin(false),
-            None,
+            trusted_launch_mode(false),
+            super::super::adapters::LaunchMode::Headless,
             "an untrusted spawn -- every file-dropped request, `handle_spawn_requests`'s own \
              call site -- must never receive the pin, regardless of what a forged \
              `SpawnRequest.interactive` claims"
         );
         assert_eq!(
-            spawn_launch_mode_pin(true),
-            Some((
-                super::super::adapters::LAUNCH_MODE_ENV.to_string(),
-                super::super::adapters::LAUNCH_MODE_INTERACTIVE_VALUE.to_string()
-            )),
+            trusted_launch_mode(true),
+            super::super::adapters::LaunchMode::Interactive,
             "only the dashboard's own in-process Spawn overlay, which passes `true`, may pin \
              Interactive"
         );
@@ -14085,17 +14214,17 @@ mod tests {
         );
     }
 
-    /// Issue #160 finding 1: a restored dashboard pane is a pane the operator
-    /// is watching, exactly like the dashboard's own first (orchestrator)
-    /// pane -- which `run_dashboard` unconditionally pins to `LaunchMode::
-    /// Interactive` (see that push's own doc comment). Before this fix
-    /// `spawn_restored_pane` built its `turn_env` from `build_turn_env` plus
-    /// the fresh spawn-request channel and group binding, but never pushed
-    /// the durable interactive-launch pin, so a restored pane a human was
-    /// looking at right there in the dashboard classified as headless and
-    /// fell back to the fail-closed approval posture on every restart.
+    /// Issue #160 finding 1, review round (2026-08-28): a restore must
+    /// relaunch a pane "on the same terms as a freshly spawned one" -- a
+    /// worker pane that WAS interactive-pinned at its original spawn
+    /// (`RosterPane::interactive == true`, recorded from `Pane::launch_mode`
+    /// at quit time) gets the pin back on restore. Also FINDING 3: asserts
+    /// all three env pairs `restored_pane_turn_env`'s own doc comment claims
+    /// are pinned directly -- `DASH_REQUESTS_ENV` and `WORK_GROUP_ENV` had
+    /// zero coverage before this round even though the doc comment claimed
+    /// otherwise.
     #[test]
-    fn restored_pane_turn_env_carries_the_interactive_launch_mode_pin() {
+    fn restored_pane_turn_env_pins_interactive_when_the_original_pane_was_interactive() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let state = StateDir::from_root(tmp.path().join("state"));
         let repo = tmp.path().join("repo");
@@ -14103,11 +14232,13 @@ mod tests {
         let requests_dir = state.dash().join("aaaa1111-token").join("requests");
         std::fs::create_dir_all(&requests_dir).expect("mkdir requests");
 
-        let candidate = restore_pane("cccc3333", "33333333-2222-4333-8444-555555555555");
+        let mut candidate = restore_pane("cccc3333", "33333333-2222-4333-8444-555555555555");
+        candidate.interactive = true;
+        candidate.work_group_id = Some("wg-42".to_string());
         let cfg = CtxConfig::default();
         let mut errors = Vec::new();
 
-        let (turn_env, _pane_channel) =
+        let (turn_env, pane_channel) =
             restored_pane_turn_env(&cfg, &state, &repo, &candidate, &requests_dir, &mut errors);
 
         assert!(
@@ -14115,8 +14246,70 @@ mod tests {
                 super::super::adapters::LAUNCH_MODE_ENV.to_string(),
                 super::super::adapters::LAUNCH_MODE_INTERACTIVE_VALUE.to_string()
             )),
-            "a restored pane must carry the durable interactive-launch pin, same as the \
-             dashboard's own first pane: {turn_env:?}"
+            "a restored pane that was originally interactive-pinned must carry the durable \
+             interactive-launch pin again: {turn_env:?}"
+        );
+        assert!(
+            turn_env.contains(&(
+                spawnreq::DASH_REQUESTS_ENV.to_string(),
+                pane_channel.display().to_string()
+            )),
+            "a restored pane gets its own fresh spawn-request channel: {turn_env:?}"
+        );
+        assert!(
+            turn_env.contains(&(
+                super::super::agent::WORK_GROUP_ENV.to_string(),
+                "wg-42".to_string()
+            )),
+            "the roster's group binding must travel back with the restored pane: {turn_env:?}"
+        );
+    }
+
+    /// The other half of issue #160 finding 1: a worker pane that was
+    /// spawned `Headless` (every file-dropped spawn request --
+    /// `FILE_DROP_TRUSTED_INTERACTIVE` -- is always `Headless`, regardless
+    /// of what a forged `SpawnRequest.interactive` claims) must NOT gain the
+    /// interactive pin just by surviving a dashboard quit+restore cycle.
+    /// Before this fix `spawn_restored_pane` unconditionally pinned
+    /// `LaunchMode::Interactive`, which would have handed every ordinary
+    /// delegated worker an interactive posture it was explicitly refused at
+    /// spawn time.
+    #[test]
+    fn restored_pane_turn_env_restores_without_the_pin_for_a_non_interactive_worker_pane() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("mkdir repo");
+        let requests_dir = state.dash().join("aaaa1111-token").join("requests");
+        std::fs::create_dir_all(&requests_dir).expect("mkdir requests");
+
+        // `restore_pane` leaves `interactive` at its `Default` (`false`) --
+        // an ordinary delegated worker pane, never trusted-interactive.
+        let candidate = restore_pane("dddd4444", "44444444-2222-4333-8444-555555555555");
+        assert!(
+            !candidate.interactive,
+            "sanity: the fixture is non-interactive"
+        );
+        let cfg = CtxConfig::default();
+        let mut errors = Vec::new();
+
+        let (turn_env, pane_channel) =
+            restored_pane_turn_env(&cfg, &state, &repo, &candidate, &requests_dir, &mut errors);
+
+        assert!(
+            !turn_env
+                .iter()
+                .any(|(k, _)| k == super::super::adapters::LAUNCH_MODE_ENV),
+            "a worker pane that was never interactive-pinned must not gain the pin on \
+             restore: {turn_env:?}"
+        );
+        assert!(
+            turn_env.contains(&(
+                spawnreq::DASH_REQUESTS_ENV.to_string(),
+                pane_channel.display().to_string()
+            )),
+            "the fresh spawn-request channel is still pushed regardless of launch mode: \
+             {turn_env:?}"
         );
     }
 

--- a/src/commands/ctx/dash/pane.rs
+++ b/src/commands/ctx/dash/pane.rs
@@ -816,6 +816,17 @@ pub struct Pane {
     /// [`INJECTION_SUBMIT_DELAY`]'s own doc comment for why this replaced an
     /// inline sleep.
     pending_submit: Option<Instant>,
+    /// Issue #160 finding 1, review round (2026-08-28): the `LaunchMode`
+    /// this pane was ACTUALLY spawned with, derived from `turn_env` itself
+    /// (whether it carried the durable interactive-launch pin,
+    /// `adapters::LAUNCH_MODE_ENV`/`LAUNCH_MODE_INTERACTIVE_VALUE`) rather
+    /// than trusted as a separate parameter that could drift out of sync
+    /// with what the child actually inherited. `dash::mod::on_quit` reads
+    /// this back (`launch_mode()`) to roster `RosterPane::interactive`, so a
+    /// restore can relaunch the pane on the same terms it originally had --
+    /// see `restored_pane_turn_env`'s own doc comment for why an
+    /// unconditional restore-as-Interactive was wrong.
+    launch_mode: super::super::adapters::LaunchMode,
 }
 
 impl Pane {
@@ -897,6 +908,20 @@ impl Pane {
         command.cwd(cwd);
 
         sessions::scrub_supervision_env(&mut command);
+        // Issue #160 finding 1, review round (2026-08-28): derived from
+        // `turn_env`'s own content rather than a separate parameter -- the
+        // single source of truth for what this pane's child actually
+        // inherits is the same `turn_env` slice `command.env` is fed from
+        // below, so there is no second copy that could ever say something
+        // different. See `Pane::launch_mode`'s own doc comment.
+        let launch_mode = if turn_env.iter().any(|(k, v)| {
+            k == super::super::adapters::LAUNCH_MODE_ENV
+                && v == super::super::adapters::LAUNCH_MODE_INTERACTIVE_VALUE
+        }) {
+            super::super::adapters::LaunchMode::Interactive
+        } else {
+            super::super::adapters::LaunchMode::Headless
+        };
         for (key, value) in turn_env {
             command.env(key, value);
         }
@@ -998,6 +1023,7 @@ impl Pane {
             work_group_id: None,
             report_reminder_sent: false,
             pending_submit: None,
+            launch_mode,
         })
     }
 
@@ -1476,6 +1502,16 @@ impl Pane {
         self.role
     }
 
+    /// The `LaunchMode` this pane was ACTUALLY spawned with (issue #160
+    /// finding 1) -- derived once, at `Pane::spawn`, from whether `turn_env`
+    /// carried the durable interactive-launch pin. `dash::mod::on_quit`
+    /// reads this back to roster `RosterPane::interactive`, so a restore
+    /// can relaunch this pane on the same terms it originally had, rather
+    /// than unconditionally as `Interactive`.
+    pub fn launch_mode(&self) -> super::super::adapters::LaunchMode {
+        self.launch_mode
+    }
+
     /// The sidebar's one-line preview: the bottom-most non-blank row of this
     /// pane's current screen.
     pub fn last_line(&self) -> String {
@@ -1697,6 +1733,16 @@ impl Pane {
                 .chain(command.get_args().map(|a| a.to_string_lossy().to_string()))
                 .collect()
         };
+        // NON-GOAL residual (2026-08-28, filed rather than silently
+        // omitted): `handover::build_turn_env` does not push the durable
+        // interactive-launch pin, so `self.launch_mode` still reads this
+        // pane's ORIGINAL spawn mode after a handover even though the
+        // successor child below never actually receives the pin either
+        // way. Out of scope for issue #160's fix round, which named exactly
+        // three call sites (`fulfill_spawn_request`, `run_dashboard`'s
+        // first pane, `restored_pane_turn_env`), all in `dash::mod`, not
+        // this one -- a pane that both underwent a handover AND survives a
+        // later dashboard restore is the only case this residual reaches.
         let turn_env = super::super::handover::build_turn_env(
             new_adapter.as_ref(),
             self.server.as_ref(),

--- a/src/commands/ctx/dash/roster.rs
+++ b/src/commands/ctx/dash/roster.rs
@@ -70,6 +70,24 @@ pub struct RosterPane {
     /// same reasoning as `report_to`.
     #[serde(default)]
     pub work_group_id: Option<String>,
+    /// Issue #160 finding 1, review round (2026-08-28): whether this pane
+    /// carried the durable interactive-launch pin (`adapters::LAUNCH_MODE_
+    /// ENV`/`LaunchMode::Interactive`) at quit time -- `dash::mod::on_quit`
+    /// reads it off `Pane::launch_mode()`. A restore must relaunch a pane
+    /// "on the same terms as a freshly spawned one" (issue #160): a worker
+    /// pane spawned through the untrusted file-dropped request channel is
+    /// ALWAYS launched `Headless` (`FILE_DROP_TRUSTED_INTERACTIVE`), so
+    /// restoring it as `Interactive` regardless would hand it a posture it
+    /// was explicitly refused at spawn time. `#[serde(default)]`, same
+    /// reasoning as `report_to`/`work_group_id` above -- but note the
+    /// direction: a roster entry written by an OLDER build, before this
+    /// field existed, has no way to say what its pane's launch mode
+    /// actually was, so absence must default to the FAIL-CLOSED reading
+    /// (`false`, no pin) rather than the permissive one. That is also
+    /// exactly today's pre-this-round behavior for such an entry, so an
+    /// old roster restores no worse than it already did.
+    #[serde(default)]
+    pub interactive: bool,
 }
 
 /// A full dashboard's worth of panes, stamped with the time it was written
@@ -218,6 +236,7 @@ mod tests {
                     report_to: None,
                     report_reminder_sent: false,
                     work_group_id: None,
+                    interactive: true,
                 },
                 RosterPane {
                     agent: "codex".to_string(),
@@ -228,6 +247,7 @@ mod tests {
                     report_to: Some("aaaa1111".to_string()),
                     report_reminder_sent: true,
                     work_group_id: Some("wg-1".to_string()),
+                    interactive: false,
                 },
             ],
         }
@@ -260,6 +280,14 @@ mod tests {
     /// absence read as `None`/`false` rather than a hard parse failure that
     /// would silently drop the whole roster (`take_roster`'s own `.ok()?`
     /// chain turns any parse error into "nothing to restore").
+    ///
+    /// Issue #160 finding 1, review round (2026-08-28): the identical
+    /// back-compat requirement now also covers `interactive` -- a build that
+    /// predates it wrote no such key either, and `#[serde(default)]` must
+    /// read that absence as `false` (no pin, the FAIL-CLOSED side), not
+    /// `true`. Defaulting to `true` here would have handed every pane
+    /// restored from a pre-upgrade roster the permissive interactive
+    /// posture with no record it was ever actually spawned that way.
     #[test]
     fn an_old_style_roster_entry_with_no_report_back_fields_loads_with_none_and_false() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -285,6 +313,11 @@ mod tests {
         assert_eq!(got.panes.len(), 1);
         assert_eq!(got.panes[0].report_to, None);
         assert!(!got.panes[0].report_reminder_sent);
+        assert!(
+            !got.panes[0].interactive,
+            "an old-format entry with no `interactive` key must default to fail-closed \
+             (no pin), not the permissive side"
+        );
     }
 
     #[test]

--- a/src/commands/ctx/safety.rs
+++ b/src/commands/ctx/safety.rs
@@ -4382,6 +4382,22 @@ fn resolve_lexical_path_components(path: &str) -> Vec<&str> {
 /// this classifier cannot know whether the launch's own working directory
 /// is itself at or above a sensitive root, the same non-goal
 /// `generated_path` already documents for the identical reason.
+///
+/// Issue #160 finding 2, option (a) (2026-08-28): this is a DELIBERATE
+/// ruling, recorded here rather than left implicit. A relative starting
+/// point (`find ..`, `find .`, `find some/subdir`) is out of scope for the
+/// root-wide-scan rule on purpose -- resolving it against the real cwd
+/// would need filesystem/process state this text-only classifier
+/// deliberately never touches (`evaluate`'s own doc comment: "Pure: no
+/// clock, filesystem or environment access"). The alternative considered
+/// and rejected was escalating every relative `find` to `Ask`, which would
+/// have turned the overwhelmingly common bounded case (`find . -name
+/// '*.rs'`, `find ./src -name '*.rs'`) into constant unprompted friction for
+/// no proven safety gain -- a relative token can, of course, still walk
+/// above the cwd (`find ..`), but this classifier has no way to know
+/// whether that lands it at or above a sensitive root either. See
+/// `find_dot_dot_relative_scan_is_deliberately_out_of_the_root_wide_rules_
+/// scope` for the pinning regression test.
 fn is_root_wide_or_whole_home_path(token: &str) -> bool {
     if let Some(rest) = token.strip_prefix('~') {
         return match rest.split_once('/') {
@@ -4419,6 +4435,11 @@ fn is_root_wide_or_whole_home_path(token: &str) -> bool {
 /// see that function's own doc comment for why `//`, `/.`, `/./`, `/..`,
 /// `/../`, and a bare `~user` all had to close in one pass rather than as
 /// individually enumerated literals.
+///
+/// Issue #160 finding 2, option (a): a relative starting point (`find ..
+/// -iname id_rsa`, `find . -iname id_rsa`) is deliberately never treated as
+/// root-wide here -- see [`is_root_wide_or_whole_home_path`]'s own doc
+/// comment for the recorded ruling and its rationale.
 fn is_root_wide_find_scan(command: &str) -> bool {
     let Some(tokens) = sql_tokens(&collapse_whitespace(command)) else {
         return false;
@@ -8988,6 +9009,33 @@ mod tests {
         assert!(
             text.contains(r#""permissionDecision":"allow""#),
             "a genuinely bounded absolute subtree must still escape silently: got {text}"
+        );
+    }
+
+    /// Issue #160 finding 2, option (a) (2026-08-28): PINS the deliberate
+    /// ruling recorded on `is_root_wide_or_whole_home_path`/`is_root_wide_
+    /// find_scan`'s own doc comments -- a relative starting-point (no
+    /// leading `/` or `~`) is left OUT of the root-wide-scan rule's scope on
+    /// purpose, because this text-only classifier cannot know whether the
+    /// launch's own working directory is itself at or above a sensitive
+    /// root (the same non-goal `generated_path` documents for the identical
+    /// reason). `find .. -iname id_rsa` therefore is NOT escalated by the
+    /// root-wide-scan rule; it rides the seeded `find *` family straight to
+    /// `Allow` on the interactive default, exactly like the pre-existing
+    /// `find ./src -name '*.rs'` relative case the sibling test above
+    /// already pins for the absolute-subtree side. This is a decision
+    /// record, not a bug report: a future change that starts resolving `..`
+    /// against the real cwd would need to update this pin deliberately, not
+    /// discover the behavior by accident.
+    #[test]
+    fn find_dot_dot_relative_scan_is_deliberately_out_of_the_root_wide_rules_scope() {
+        let policy = SafetyPolicy::default();
+        let outcome = evaluate(&policy, "find .. -iname id_rsa", LaunchMode::Interactive);
+        assert_eq!(
+            outcome.verdict,
+            Verdict::Allow,
+            "a relative `..` starting point is deliberately out of scope for the root-wide-scan \
+             rule (issue #160 finding 2, option a): got {outcome:?}"
         );
     }
 

--- a/src/commands/ctx/safety.rs
+++ b/src/commands/ctx/safety.rs
@@ -7641,6 +7641,50 @@ mod tests {
         );
     }
 
+    /// Issue #160 finding 3: a commit message body containing path-like
+    /// text (`~/`, `/../`) and a redirection-looking character (`>`) must
+    /// not be denied just because it superficially resembles a home-relative
+    /// path, a directory-traversal segment, or an output redirection --
+    /// `redact_opaque_message` replaces the ENTIRE message body with
+    /// `OPAQUE_MESSAGE_PLACEHOLDER` before any other classifier (root-wide
+    /// path checks, `contains_unquoted_redirection`, etc.) ever sees it, so
+    /// none of those text shapes inside the message prose can escalate the
+    /// verdict. The fix already existed (`redact_opaque_message`, applied at
+    /// both `push_executable_candidate` and `normalize_segments`'s own raw
+    /// candidate); this pins it against the specific acceptance criteria the
+    /// issue named.
+    #[test]
+    fn a_commit_message_containing_path_like_text_and_a_redirection_character_is_allowed() {
+        let policy = SafetyPolicy::default();
+        let command = "git commit -m \"backup notes: see ~/.config and /../etc, redirect with >\"";
+        let outcome = evaluate(&policy, command, LaunchMode::Interactive);
+        assert_eq!(
+            outcome.verdict,
+            Verdict::Allow,
+            "path-like text and a redirection character inside commit message prose is \
+             documentation, not code: {outcome:?}"
+        );
+    }
+
+    /// The same acceptance criteria, but the message arrives through a
+    /// single-quoted heredoc (`$(cat <<'EOF' ...prose... EOF)`) -- the
+    /// same POSIX-literal shape `a_heredoc_built_commit_message_naming_
+    /// denied_primitives_is_allowed` above already pins for denied
+    /// primitives, here carrying the path-like/redirection text instead.
+    #[test]
+    fn a_heredoc_built_commit_message_containing_path_like_text_and_a_redirection_character_is_allowed()
+     {
+        let policy = SafetyPolicy::default();
+        let command = "git commit -m \"$(cat <<'EOF'\nbackup notes: see ~/.config and /../etc, redirect with >\nEOF\n)\"";
+        let outcome = evaluate(&policy, command, LaunchMode::Interactive);
+        assert_eq!(
+            outcome.verdict,
+            Verdict::Allow,
+            "a heredoc-built message with path-like/redirection text is still documentation, \
+             not code: {outcome:?}"
+        );
+    }
+
     /// The same carve-out for every other message-bearing invocation and
     /// argument spelling this scanner recognizes: `--message=`, the attached
     /// `-m<value>` short form, `git tag -m`, `git notes -m`, and `hg commit


### PR DESCRIPTION
Closes #160.

## What

All three residuals from the #154 security review train:

1. **Restored dashboard panes now restore their original launch mode.** `Pane` carries a `launch_mode` field derived at spawn time from the actual `turn_env` handed to the child (so it can never drift from what the child inherits); `on_quit` rosters it as `RosterPane::interactive` (`#[serde(default)]` → `false`, fail-closed for pre-upgrade roster files); `spawn_restored_pane` restores the pane with the launch mode it originally had. A restored orchestrator pane a human is watching classifies interactive again; a worker pane spawned headless stays headless across quit+restore — no escalation.
2. **The relative-path scope of `is_root_wide_find_scan` is recorded as a deliberate ruling** (issue #160 finding 2, option (a)): doc comments on `is_root_wide_or_whole_home_path`/`is_root_wide_find_scan` state the non-goal explicitly, and a pinning test documents that `find .. -iname id_rsa` is deliberately outside the root-wide rule's scope.
3. **Regression tests for opaque commit messages**: a `git commit -m` (and heredoc-built) message containing `~/`, `/../`, and a redirection-looking character is not classified on its message text (pins the PR #140 `redact_opaque_message` fix per the issue's acceptance criteria).

Structural hardening from the review round: `build_turn_env` now takes a mandatory `LaunchMode` parameter and pushes the `ZIRV_CTX_LAUNCH_MODE` pin itself (both success and adapter-resolution-failure branches), so a future spawn path that forgets the pin is a compile error instead of a silent headless classification — this PR was the third occurrence of that bug class.

Known residual (documented in-code, out of scope): `handover::build_turn_env` does not push the pin, so `Pane::launch_mode()` can go stale across a handover.

## Verification

- Windows: `cargo build`, `cargo nextest run --no-fail-fast`, serial `cargo test`, `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings` — all green; failing-name diff vs the machine baseline is empty (only the known #180 flake and the documented `wrap::win` baseline failure).
- Linux (`rust:1-bookworm`, non-root, `git -c core.autocrlf=false archive` export): `cargo clippy --all-targets -- -D warnings` clean; `cargo test --bin zirv dash::` 368/368.
- Review: medium-effort review round (3 confirmed findings, all fixed — the unconditional-interactive-pin escalation, the pin-at-call-sites bug class, missing env-pair coverage) plus a clean delta re-review.

https://claude.ai/code/session_017QEYoGbDzvGYAT2LJgUZBQ
