### PR TITLE
fix(ctx): harden cross-harness fallback

### DIFF
--- a/src/commands/ctx/agent.rs
+++ b/src/commands/ctx/agent.rs
@@ -378,7 +378,7 @@ fn flags_pin_model(flags: &[String]) -> bool {
 /// flag may mean something different (or be invalid) on codex and vice versa.
 /// Empty passthrough is safe, and a model-only passthrough can be replaced by
 /// the verified equivalent tier. Anything else declines automatic routing.
-fn translated_route_flags(
+pub(crate) fn translated_route_flags(
     flags: &[String],
     target: &dyn AgentAdapter,
     target_model: &str,
@@ -934,18 +934,15 @@ pub fn run_with<W: Write>(
         tool_calls: args.max_tool_calls,
     };
 
-    let route = super::fallback::route_new_delegation(
-        &state,
-        &cfg,
-        super::fallback::RouteRequest {
-            requested: &args.name,
-            source_model: requested_model,
-            source_model_explicit,
-            bounds,
-            now,
-        },
-        args.force,
-    );
+    let route_request = super::fallback::RouteRequest {
+        requested: &args.name,
+        source_model: requested_model,
+        source_model_explicit,
+        bounds,
+        now,
+    };
+    let route =
+        super::fallback::route_new_delegation(&state, &cfg, route_request, args.force);
     let mut routed_args = args.clone();
     let mut route_applied = None;
     if let Some(route) = route
@@ -974,17 +971,43 @@ pub fn run_with<W: Write>(
         route_applied = Some(route);
     }
 
+    // If no harness can run immediately, select the admissible seat whose
+    // hard gate clears first. A deferred cross-harness choice still obeys the
+    // same argv portability rule as an immediate reroute; if vendor-specific
+    // flags cannot be translated, waiting stays on the requested harness.
+    let mut deferred_reset = None;
+    if route_applied.is_none()
+        && !args.force
+        && let Some(choice) =
+            super::fallback::earliest_reset_choice(&state, &cfg, route_request, &[])
+    {
+        if choice.is_cross_harness() {
+            if let Some(model) = choice.model.as_deref()
+                && let Ok(target_adapter) =
+                    adapters::select(Some(&choice.selected), &[], &cfg)
+                && let Some(flags) =
+                    translated_route_flags(&args.flags, target_adapter.as_ref(), model)
+            {
+                routed_args.name = choice.selected.clone();
+                routed_args.flags = flags;
+                deferred_reset = Some(choice);
+            }
+        } else {
+            deferred_reset = Some(choice);
+        }
+    }
+
     // The ordinary spawn gate still owns the final decision for whichever
-    // harness will actually launch. If cross-harness translation was unsafe
-    // (for example vendor-specific passthrough flags), this is the requested
-    // harness and today's refusal behavior remains intact.
+    // harness will actually launch. A deferred reset is the one exception:
+    // the headless exec pacing gate below will wait until that exact seat is
+    // usable rather than treating the hard gate as a permanent refusal.
     let provider = adapters::provider_for_agent_name(Some(&routed_args.name));
     let (collector, estimator) = pace::current_windows(&state, &cfg.pace, now, provider);
     let gate = pace::spawn_gate(&collector, estimator.as_ref(), now, &cfg.pace);
     if let Some(note) = pace::describe_spawn_gate(&gate) {
         eprintln!("zirv ctx agent: {note}");
     }
-    if spawn_blocked(&gate, args.force) {
+    if spawn_blocked(&gate, args.force) && deferred_reset.is_none() {
         let fallback_note = if route_applied.is_none() && cfg.fallback.enabled {
             " No admissible fallback harness had enough trusted/assumed headroom."
         } else {
@@ -995,6 +1018,24 @@ pub fn run_with<W: Write>(
              reset, or pass --force to spend anyway.{fallback_note}"
         )
         .into());
+    }
+    if let Some(choice) = deferred_reset.as_ref() {
+        let detail = choice.detail();
+        let parent_session =
+            super::mail::session_identity(env).unwrap_or_else(|| "delegation".to_string());
+        let _ = super::log::append(
+            &state,
+            &super::log::Decision {
+                ts: now,
+                session: &parent_session,
+                verb: "agent",
+                verdict: "wait",
+                score: 0,
+                action: "harness-reset-wait",
+                detail: &detail,
+            },
+        );
+        eprintln!("zirv ctx agent: {detail}; pacing until that seat is available");
     }
 
     // Issue #170: resolved once, here, before the dashboard-join fork below,
@@ -1019,15 +1060,17 @@ pub fn run_with<W: Write>(
         }
     };
 
-    if let Some(result) = try_join_dashboard(
-        args,
-        &prompt,
-        w,
-        repo,
-        env,
-        DASH_ACK_TIMEOUT,
-        DASH_CLAIM_EXTENSION,
-    ) {
+    if deferred_reset.is_none()
+        && let Some(result) = try_join_dashboard(
+            args,
+            &prompt,
+            w,
+            repo,
+            env,
+            DASH_ACK_TIMEOUT,
+            DASH_CLAIM_EXTENSION,
+        )
+    {
         // Finding 4: the dashboard answered definitively, and only `Ok(0)`
         // (`answer_for_ack`'s spawned-a-pane arm) means work actually
         // started. A refusal spawned nothing, so a group minted for it

--- a/src/commands/ctx/agent.rs
+++ b/src/commands/ctx/agent.rs
@@ -1131,8 +1131,8 @@ pub fn run_with<W: Write>(
     // permanently burn the group's admission slot for a child that never
     // ran. `state` is the same handle resolved above for the spawn gate,
     // unused since; reused here rather than re-resolved.
-    let code = match exec::run_with(&exec_args, w, repo, &env) {
-        Ok(code) => code,
+    let (code, execution_report) = match exec::run_with_report(&exec_args, w, repo, &env) {
+        Ok(result) => result,
         Err(e) => {
             if let Some(id) = &args.group {
                 super::group::rollback_admission(&state, id);
@@ -1171,51 +1171,67 @@ pub fn run_with<W: Write>(
     }
 
     // Best effort throughout: a delegation that ran must never fail because
-    // its accounting could not be written (issue #155, Phase 2).
+    // its accounting could not be written (issue #155, Phase 2). Issue #186
+    // hardening: exec now reports every vendor-backed segment of one logical
+    // delegation, so a cross-harness continuation is neither charged to the
+    // wrong agent nor omitted from the cost tree.
     if let Ok(state_dir) = super::state::StateDir::resolve(&env) {
-        let usage = std::fs::read_to_string(adapter.transcript_path(&super::event::SessionRef {
-            id: SessionId::parse(&worker_session),
-            cwd: repo.to_path_buf(),
-        }))
-        .ok()
-        .and_then(|body| adapter.transcript_usage(&body))
-        .unwrap_or_default();
         let parent_session = super::mail::session_identity(&env).unwrap_or_default();
         let outcome = delegation_outcome(code);
+        let mut total = TranscriptUsage::default();
+        let mut route = Vec::new();
+
+        for segment in &execution_report.segments {
+            total.input_tokens = total.input_tokens.saturating_add(segment.usage.input_tokens);
+            total.cache_creation_input_tokens = total
+                .cache_creation_input_tokens
+                .saturating_add(segment.usage.cache_creation_input_tokens);
+            total.cache_read_input_tokens = total
+                .cache_read_input_tokens
+                .saturating_add(segment.usage.cache_read_input_tokens);
+            total.output_tokens = total.output_tokens.saturating_add(segment.usage.output_tokens);
+            route.push(match segment.model.as_deref() {
+                Some(model) => format!("{} ({model})", segment.agent),
+                None => format!("{} (default model)", segment.agent),
+            });
+
+            let _ = super::log::append_delegation(
+                &state_dir,
+                &super::log::Delegation {
+                    ts: super::state::now_secs(),
+                    session: &segment.session,
+                    parent_session: &parent_session,
+                    work_group_id: args.group.as_deref(),
+                    agent: &segment.agent,
+                    model: segment.model.as_deref(),
+                    input_tokens: segment.usage.input_tokens,
+                    cache_creation_input_tokens: segment.usage.cache_creation_input_tokens,
+                    cache_read_input_tokens: segment.usage.cache_read_input_tokens,
+                    output_tokens: segment.usage.output_tokens,
+                    wall_ms: segment.wall_ms,
+                    exit_code: code,
+                    outcome,
+                },
+            );
+        }
+
+        let route = if route.is_empty() {
+            format!(
+                "{} ({})",
+                args.name,
+                model.as_deref().unwrap_or("default worker model")
+            )
+        } else {
+            route.join(" -> ")
+        };
         let detail = format!(
-            "{} ({}): {} in / {} cache-creation / {} cache-read / {} out in {}ms -- {}",
-            args.name,
-            model.as_deref().unwrap_or("default worker model"),
-            usage.input_tokens,
-            usage.cache_creation_input_tokens,
-            usage.cache_read_input_tokens,
-            usage.output_tokens,
+            "{route}: {} in / {} cache-creation / {} cache-read / {} out in {}ms -- {}",
+            total.input_tokens,
+            total.cache_creation_input_tokens,
+            total.cache_read_input_tokens,
+            total.output_tokens,
             wall_ms,
             outcome,
-        );
-        let _ = super::log::append_delegation(
-            &state_dir,
-            &super::log::Delegation {
-                ts: super::state::now_secs(),
-                session: &worker_session,
-                parent_session: &parent_session,
-                // Issue #155 review finding D2: this used to be hardcoded
-                // `None`, so a completed headless delegation never recorded
-                // the group it actually ran under -- `zirv ctx status`'s
-                // group tree (`status::group_tree_lines`) renders every such
-                // delegation as ungrouped even though `--group` traveled all
-                // the way through `resolve_worker_budget` above.
-                work_group_id: args.group.as_deref(),
-                agent: &args.name,
-                model: model.as_deref(),
-                input_tokens: usage.input_tokens,
-                cache_creation_input_tokens: usage.cache_creation_input_tokens,
-                cache_read_input_tokens: usage.cache_read_input_tokens,
-                output_tokens: usage.output_tokens,
-                wall_ms,
-                exit_code: code,
-                outcome,
-            },
         );
         let _ = super::log::append(
             &state_dir,

--- a/src/commands/ctx/agent.rs
+++ b/src/commands/ctx/agent.rs
@@ -1221,42 +1221,22 @@ pub fn run_with<W: Write>(
     if let Ok(state_dir) = super::state::StateDir::resolve(&env) {
         let parent_session = super::mail::session_identity(&env).unwrap_or_default();
         let outcome = delegation_outcome(code);
-        let mut total = TranscriptUsage::default();
-        let mut route = Vec::new();
-
-        for segment in &execution_report.segments {
-            total.input_tokens = total.input_tokens.saturating_add(segment.usage.input_tokens);
-            total.cache_creation_input_tokens = total
-                .cache_creation_input_tokens
-                .saturating_add(segment.usage.cache_creation_input_tokens);
-            total.cache_read_input_tokens = total
-                .cache_read_input_tokens
-                .saturating_add(segment.usage.cache_read_input_tokens);
-            total.output_tokens = total.output_tokens.saturating_add(segment.usage.output_tokens);
-            route.push(match segment.model.as_deref() {
+        let total = append_execution_segments(
+            &state_dir,
+            &execution_report,
+            &parent_session,
+            args.group.as_deref(),
+            code,
+            outcome,
+        );
+        let route: Vec<String> = execution_report
+            .segments
+            .iter()
+            .map(|segment| match segment.model.as_deref() {
                 Some(model) => format!("{} ({model})", segment.agent),
                 None => format!("{} (default model)", segment.agent),
-            });
-
-            let _ = super::log::append_delegation(
-                &state_dir,
-                &super::log::Delegation {
-                    ts: super::state::now_secs(),
-                    session: &segment.session,
-                    parent_session: &parent_session,
-                    work_group_id: args.group.as_deref(),
-                    agent: &segment.agent,
-                    model: segment.model.as_deref(),
-                    input_tokens: segment.usage.input_tokens,
-                    cache_creation_input_tokens: segment.usage.cache_creation_input_tokens,
-                    cache_read_input_tokens: segment.usage.cache_read_input_tokens,
-                    output_tokens: segment.usage.output_tokens,
-                    wall_ms: segment.wall_ms,
-                    exit_code: code,
-                    outcome,
-                },
-            );
-        }
+            })
+            .collect();
 
         let route = if route.is_empty() {
             format!(
@@ -1291,6 +1271,46 @@ pub fn run_with<W: Write>(
     }
 
     Ok(code)
+}
+
+fn append_execution_segments(
+    state: &super::state::StateDir,
+    report: &exec::ExecutionReport,
+    parent_session: &str,
+    work_group_id: Option<&str>,
+    exit_code: i32,
+    outcome: &'static str,
+) -> TranscriptUsage {
+    let mut total = TranscriptUsage::default();
+    for segment in &report.segments {
+        total.input_tokens = total.input_tokens.saturating_add(segment.usage.input_tokens);
+        total.cache_creation_input_tokens = total
+            .cache_creation_input_tokens
+            .saturating_add(segment.usage.cache_creation_input_tokens);
+        total.cache_read_input_tokens = total
+            .cache_read_input_tokens
+            .saturating_add(segment.usage.cache_read_input_tokens);
+        total.output_tokens = total.output_tokens.saturating_add(segment.usage.output_tokens);
+        let _ = super::log::append_delegation(
+            state,
+            &super::log::Delegation {
+                ts: super::state::now_secs(),
+                session: &segment.session,
+                parent_session,
+                work_group_id,
+                agent: &segment.agent,
+                model: segment.model.as_deref(),
+                input_tokens: segment.usage.input_tokens,
+                cache_creation_input_tokens: segment.usage.cache_creation_input_tokens,
+                cache_read_input_tokens: segment.usage.cache_read_input_tokens,
+                output_tokens: segment.usage.output_tokens,
+                wall_ms: segment.wall_ms,
+                exit_code,
+                outcome,
+            },
+        );
+    }
+    total
 }
 
 pub fn run<W: Write>(args: &AgentArgs, w: &mut W) -> CtxResult<i32> {
@@ -2377,6 +2397,52 @@ mod tests {
             0,
             "--quiet must not change the outcome"
         );
+    }
+
+    #[test]
+    fn cross_harness_execution_segments_are_both_persisted_and_summed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = crate::commands::ctx::state::StateDir::from_root(tmp.path().join("state"));
+        let report = exec::ExecutionReport {
+            segments: vec![
+                exec::ExecutionSegment {
+                    session: "aaaaaaaa-1111-4111-8111-111111111111".to_string(),
+                    agent: "claude".to_string(),
+                    model: Some("sonnet".to_string()),
+                    usage: TranscriptUsage {
+                        input_tokens: 10,
+                        cache_creation_input_tokens: 20,
+                        cache_read_input_tokens: 30,
+                        output_tokens: 40,
+                    },
+                    wall_ms: 100,
+                },
+                exec::ExecutionSegment {
+                    session: "bbbbbbbb-2222-4222-8222-222222222222".to_string(),
+                    agent: "codex".to_string(),
+                    model: Some("gpt-5.6-terra".to_string()),
+                    usage: TranscriptUsage {
+                        input_tokens: 1,
+                        cache_creation_input_tokens: 2,
+                        cache_read_input_tokens: 3,
+                        output_tokens: 4,
+                    },
+                    wall_ms: 200,
+                },
+            ],
+        };
+
+        let total = append_execution_segments(&state, &report, "parent", Some("wg-1"), 0, "ok");
+        assert_eq!(total.input_tokens, 11);
+        assert_eq!(total.cache_creation_input_tokens, 22);
+        assert_eq!(total.cache_read_input_tokens, 33);
+        assert_eq!(total.output_tokens, 44);
+
+        let rows = crate::commands::ctx::log::tail_delegations(&state, 10).expect("rows");
+        assert_eq!(rows.len(), 2, "both vendor segments must be visible");
+        assert!(rows.iter().any(|row| row.contains("\"agent\":\"claude\"")));
+        assert!(rows.iter().any(|row| row.contains("\"agent\":\"codex\"")));
+        assert!(rows.iter().any(|row| row.contains("gpt-5.6-terra")));
     }
 
     /// Issue #155, Phase 2: the end-to-end write, against a real

--- a/src/commands/ctx/config.rs
+++ b/src/commands/ctx/config.rs
@@ -5578,6 +5578,71 @@ mod tests {
     /// silent" rule `reject_untrusted_keys` follows, applied to a section
     /// where a silent default is a permission grant.
     #[test]
+    fn malformed_home_fallback_enabled_fails_instead_of_becoming_true() {
+        let home = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(home.path().join(".zirv")).expect("mkdir");
+        std::fs::write(
+            home.path().join(".zirv/ctx.toml"),
+            "[fallback]\nenabled = \"false\"\n",
+        )
+        .expect("write home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let repo = tempfile::tempdir().expect("repo");
+        let empty = env_map(&[]);
+
+        let err = CtxConfig::load(repo.path(), &|k| empty.get(k).cloned())
+            .expect_err("a string must never silently become fallback.enabled = true");
+        assert!(err.to_string().contains("fallback.enabled"), "got {err}");
+        assert!(err.to_string().contains("boolean"), "got {err}");
+    }
+
+    #[test]
+    fn malformed_repo_fallback_value_fails_instead_of_becoming_a_default() {
+        let home = tempfile::tempdir().expect("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join(".zirv")).expect("mkdir");
+        std::fs::write(
+            repo.path().join(".zirv/ctx.toml"),
+            "[fallback]\nunknown_headroom_pct = \"0\"\n",
+        )
+        .expect("write repo");
+        let empty = env_map(&[]);
+
+        let err = CtxConfig::load(repo.path(), &|k| empty.get(k).cloned())
+            .expect_err("a string zero must not become the permissive default assumption");
+        assert!(
+            err.to_string().contains("fallback.unknown_headroom_pct"),
+            "got {err}"
+        );
+        assert!(err.to_string().contains("number"), "got {err}");
+    }
+
+    #[test]
+    fn strict_fallback_extractors_reject_partial_arrays_and_negative_limits() {
+        assert!(
+            fallback_string_array_at(
+                Some(toml::Value::Array(vec![
+                    toml::Value::String("claude".into()),
+                    toml::Value::Integer(7),
+                ])),
+                "order",
+            )
+            .is_err()
+        );
+        assert!(
+            fallback_u64_at(Some(toml::Value::Integer(-1)), "small_task_max_tokens").is_err()
+        );
+        assert!(
+            fallback_u32_at(
+                Some(toml::Value::Integer(-1)),
+                "small_task_max_tool_calls",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn fallback_defaults_are_conservative_and_enabled() {
         let cfg = FallbackConfig::default();
         assert!(cfg.enabled);

--- a/src/commands/ctx/config.rs
+++ b/src/commands/ctx/config.rs
@@ -1570,6 +1570,67 @@ fn float_at(value: Option<toml::Value>) -> Option<f64> {
     })
 }
 
+/// Issue #186 hardening: fallback values are lifted out of their source
+/// layers before the ordinary serde pass, so malformed values must be
+/// rejected here rather than converted to None and silently replaced by
+/// defaults. Each helper names the exact operator-facing key in its error.
+fn fallback_bool_at(value: Option<toml::Value>, key: &str) -> CtxResult<Option<bool>> {
+    match value {
+        None => Ok(None),
+        Some(toml::Value::Boolean(v)) => Ok(Some(v)),
+        Some(_) => Err(format!("fallback.{key}: expected a boolean").into()),
+    }
+}
+
+fn fallback_float_at(value: Option<toml::Value>, key: &str) -> CtxResult<Option<f64>> {
+    match value {
+        None => Ok(None),
+        Some(toml::Value::Float(v)) => Ok(Some(v)),
+        Some(toml::Value::Integer(v)) => Ok(Some(v as f64)),
+        Some(_) => Err(format!("fallback.{key}: expected a number").into()),
+    }
+}
+
+fn fallback_string_array_at(
+    value: Option<toml::Value>,
+    key: &str,
+) -> CtxResult<Option<Vec<String>>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let toml::Value::Array(values) = value else {
+        return Err(format!("fallback.{key}: expected an array of strings").into());
+    };
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        let toml::Value::String(value) = value else {
+            return Err(format!("fallback.{key}: expected an array of strings").into());
+        };
+        out.push(value);
+    }
+    Ok(Some(out))
+}
+
+fn fallback_u64_at(value: Option<toml::Value>, key: &str) -> CtxResult<Option<u64>> {
+    match value {
+        None => Ok(None),
+        Some(toml::Value::Integer(v)) => u64::try_from(v)
+            .map(Some)
+            .map_err(|_| format!("fallback.{key}: expected a non-negative integer").into()),
+        Some(_) => Err(format!("fallback.{key}: expected a non-negative integer").into()),
+    }
+}
+
+fn fallback_u32_at(value: Option<toml::Value>, key: &str) -> CtxResult<Option<u32>> {
+    match value {
+        None => Ok(None),
+        Some(toml::Value::Integer(v)) => u32::try_from(v)
+            .map(Some)
+            .map_err(|_| format!("fallback.{key}: expected an integer from 0 to {}", u32::MAX).into()),
+        Some(_) => Err(format!("fallback.{key}: expected an integer from 0 to {}", u32::MAX).into()),
+    }
+}
+
 /// T9: the repo-narrowing fold for `pace.enabled`, mirroring `policy::
 /// EffectivePolicy::narrowed_by`'s own `Stance::max` -- `true` (the gate is
 /// on) is the stricter value, so it wins regardless of which layer set it.
@@ -2214,30 +2275,30 @@ impl CtxConfig {
         // Issue #186: every fallback field is lifted before the repo merge.
         // The repo may only narrow automatic vendor steering; see the
         // re-insertion below for each field's strict direction.
-        let home_fallback_enabled = bool_at(take_nested(&mut merged, "fallback", "enabled"));
-        let home_fallback_order = string_array_at(take_nested(&mut merged, "fallback", "order"));
-        let home_fallback_predictive = float_at(take_nested(
-            &mut merged,
-            "fallback",
+        let home_fallback_enabled =
+            fallback_bool_at(take_nested(&mut merged, "fallback", "enabled"), "enabled")?;
+        let home_fallback_order =
+            fallback_string_array_at(take_nested(&mut merged, "fallback", "order"), "order")?;
+        let home_fallback_predictive = fallback_float_at(
+            take_nested(&mut merged, "fallback", "predictive_headroom_pct"),
             "predictive_headroom_pct",
-        ));
-        let home_fallback_min_candidate = float_at(take_nested(
-            &mut merged,
-            "fallback",
+        )?;
+        let home_fallback_min_candidate = fallback_float_at(
+            take_nested(&mut merged, "fallback", "min_candidate_headroom_pct"),
             "min_candidate_headroom_pct",
-        ));
-        let home_fallback_unknown =
-            float_at(take_nested(&mut merged, "fallback", "unknown_headroom_pct"));
-        let home_fallback_small_tokens = integer_at(take_nested(
-            &mut merged,
-            "fallback",
+        )?;
+        let home_fallback_unknown = fallback_float_at(
+            take_nested(&mut merged, "fallback", "unknown_headroom_pct"),
+            "unknown_headroom_pct",
+        )?;
+        let home_fallback_small_tokens = fallback_u64_at(
+            take_nested(&mut merged, "fallback", "small_task_max_tokens"),
             "small_task_max_tokens",
-        ));
-        let home_fallback_small_tools = integer_at(take_nested(
-            &mut merged,
-            "fallback",
+        )?;
+        let home_fallback_small_tools = fallback_u32_at(
+            take_nested(&mut merged, "fallback", "small_task_max_tool_calls"),
             "small_task_max_tool_calls",
-        ));
+        )?;
 
         // Read on its own first: the repo layer is the one layer that comes
         // from a checkout rather than from the operator.
@@ -2273,34 +2334,32 @@ impl CtxConfig {
             "supervise",
             "heavy_command_patterns",
         ));
-        let repo_fallback_enabled = bool_at(take_nested(&mut repo_layer, "fallback", "enabled"));
-        let repo_fallback_order =
-            string_array_at(take_nested(&mut repo_layer, "fallback", "order"));
-        let repo_fallback_predictive = float_at(take_nested(
-            &mut repo_layer,
-            "fallback",
+        let repo_fallback_enabled =
+            fallback_bool_at(take_nested(&mut repo_layer, "fallback", "enabled"), "enabled")?;
+        let repo_fallback_order = fallback_string_array_at(
+            take_nested(&mut repo_layer, "fallback", "order"),
+            "order",
+        )?;
+        let repo_fallback_predictive = fallback_float_at(
+            take_nested(&mut repo_layer, "fallback", "predictive_headroom_pct"),
             "predictive_headroom_pct",
-        ));
-        let repo_fallback_min_candidate = float_at(take_nested(
-            &mut repo_layer,
-            "fallback",
+        )?;
+        let repo_fallback_min_candidate = fallback_float_at(
+            take_nested(&mut repo_layer, "fallback", "min_candidate_headroom_pct"),
             "min_candidate_headroom_pct",
-        ));
-        let repo_fallback_unknown = float_at(take_nested(
-            &mut repo_layer,
-            "fallback",
+        )?;
+        let repo_fallback_unknown = fallback_float_at(
+            take_nested(&mut repo_layer, "fallback", "unknown_headroom_pct"),
             "unknown_headroom_pct",
-        ));
-        let repo_fallback_small_tokens = integer_at(take_nested(
-            &mut repo_layer,
-            "fallback",
+        )?;
+        let repo_fallback_small_tokens = fallback_u64_at(
+            take_nested(&mut repo_layer, "fallback", "small_task_max_tokens"),
             "small_task_max_tokens",
-        ));
-        let repo_fallback_small_tools = integer_at(take_nested(
-            &mut repo_layer,
-            "fallback",
+        )?;
+        let repo_fallback_small_tools = fallback_u32_at(
+            take_nested(&mut repo_layer, "fallback", "small_task_max_tool_calls"),
             "small_task_max_tool_calls",
-        ));
+        )?;
         merge(&mut merged, repo_layer);
 
         // Re-inserted after the merge, before env: env (below) must still be
@@ -2386,10 +2445,9 @@ impl CtxConfig {
                     .min(repo_fallback_unknown.unwrap_or(f64::INFINITY)),
             ),
         );
-        let home_small_tokens = home_fallback_small_tokens
-            .and_then(|v| u64::try_from(v).ok())
-            .unwrap_or(default_fallback.small_task_max_tokens);
-        let repo_small_tokens = repo_fallback_small_tokens.and_then(|v| u64::try_from(v).ok());
+        let home_small_tokens =
+            home_fallback_small_tokens.unwrap_or(default_fallback.small_task_max_tokens);
+        let repo_small_tokens = repo_fallback_small_tokens;
         insert_path(
             &mut merged,
             &["fallback", "small_task_max_tokens"],
@@ -2400,10 +2458,9 @@ impl CtxConfig {
                     .unwrap_or(i64::MAX),
             ),
         );
-        let home_small_tools = home_fallback_small_tools
-            .and_then(|v| u32::try_from(v).ok())
-            .unwrap_or(default_fallback.small_task_max_tool_calls);
-        let repo_small_tools = repo_fallback_small_tools.and_then(|v| u32::try_from(v).ok());
+        let home_small_tools =
+            home_fallback_small_tools.unwrap_or(default_fallback.small_task_max_tool_calls);
+        let repo_small_tools = repo_fallback_small_tools;
         insert_path(
             &mut merged,
             &["fallback", "small_task_max_tool_calls"],

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -3053,6 +3053,57 @@ fn fulfill_spawn_request(
     if let Some(reason) = cfg.agents.refusal(&req.agent) {
         return Err(SpawnRefusal::policy(reason));
     }
+    let requested_adapter = adapters::select(Some(&req.agent), &[], cfg)
+        .map_err(|e| SpawnRefusal::policy(e.to_string()))?;
+
+    // Issue #186 hardening: the dashboard's own Spawn overlay reaches this
+    // authority-side path directly, without passing through agent::run_with.
+    // Reuse the same fallback selector here so a root dashboard delegation
+    // does not hard-refuse an exhausted requested seat while another enabled
+    // harness has safe equivalent capacity.
+    let source_model = req.model.clone().or_else(|| {
+        let model_args = adapters::worker_model_args(cfg, &req.agent, requested_adapter.as_ref());
+        adapters::last_model_flag(&model_args).map(str::to_string)
+    });
+    let now = super::state::now_secs();
+    let route = super::fallback::route_new_delegation(
+        state,
+        cfg,
+        super::fallback::RouteRequest {
+            requested: &req.agent,
+            source_model: source_model.as_deref(),
+            source_model_explicit: req.model.is_some(),
+            bounds: super::fallback::TaskBounds {
+                tokens: None,
+                tool_calls: None,
+            },
+            now,
+        },
+        req.force,
+    );
+    let mut effective_req = req.clone();
+    if let Some(route) = route {
+        effective_req.agent = route.selected.clone();
+        effective_req.model = Some(route.model.clone());
+        let detail = route.detail();
+        let _ = super::log::append(
+            state,
+            &super::log::Decision {
+                ts: now,
+                session: &req.requested_by,
+                verb: "dash",
+                verdict: "reroute",
+                score: 0,
+                action: "harness-reroute",
+                detail: &detail,
+            },
+        );
+        push_error(errors, format!("dashboard spawn automatically routed {detail}"));
+    }
+    let req = &effective_req;
+    if let Some(reason) = cfg.agents.refusal(&req.agent) {
+        return Err(SpawnRefusal::policy(reason));
+    }
     let adapter = adapters::select(Some(&req.agent), &[], cfg)
         .map_err(|e| SpawnRefusal::policy(e.to_string()))?;
 
@@ -3084,7 +3135,6 @@ fn fulfill_spawn_request(
     // headless fallback would route straight around the gate (the headless
     // path is gated too, by the identical check in `agent::run_with`), the
     // same reasoning the pane cap and the depth cap above already apply.
-    let now = super::state::now_secs();
     let (collector, estimator) =
         super::pace::current_windows(state, &cfg.pace, now, adapter.provider());
     let gate = super::pace::spawn_gate(&collector, estimator.as_ref(), now, &cfg.pace);

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -10383,6 +10383,104 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dashboard_spawn_reroutes_an_exhausted_requested_harness_before_admission() {
+        let repo = std::env::current_dir().expect("cwd");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let now = crate::commands::ctx::state::now_secs();
+
+        crate::commands::ctx::window::store_for(
+            &state,
+            "anthropic",
+            &crate::commands::ctx::window::UsageWindows {
+                five_hour: Some(crate::commands::ctx::window::Window {
+                    used_percentage: 100.0,
+                    resets_at: now + 3_600,
+                    observed_at: now,
+                }),
+                seven_day: None,
+            },
+        )
+        .expect("store claude usage");
+        crate::commands::ctx::window::store_for(
+            &state,
+            "openai",
+            &crate::commands::ctx::window::UsageWindows {
+                five_hour: Some(crate::commands::ctx::window::Window {
+                    used_percentage: 10.0,
+                    resets_at: now + 3_600,
+                    observed_at: now,
+                }),
+                seven_day: None,
+            },
+        )
+        .expect("store codex usage");
+
+        let group = crate::commands::ctx::group::WorkGroup {
+            work_group_id: "wg-routing-stop".to_string(),
+            parent_session_id: String::new(),
+            scope: "test batch".to_string(),
+            child_limit: 0,
+            token_budget: None,
+            deadline_secs: None,
+            completion_contract: String::new(),
+            created_at: 0,
+            closed_at: None,
+            admitted_children: 0,
+            sub_orchestrator_session: None,
+        };
+        crate::commands::ctx::group::create(&state, &group).expect("create group");
+
+        let mut cfg = CtxConfig::default();
+        cfg.agent_bin = Some(
+            std::env::current_exe()
+                .expect("current test executable")
+                .display()
+                .to_string(),
+        );
+        cfg.pace.estimator = false;
+
+        let mut req = spawn_request("do the work", &repo);
+        req.agent = "claude".to_string();
+        req.work_group_id = Some("wg-routing-stop".to_string());
+        let mut panes: Vec<Pane> = Vec::new();
+        let mut queues: Vec<VecDeque<String>> = Vec::new();
+        let mut errors = Vec::new();
+
+        let refusal = fulfill_spawn_request(
+            &req,
+            true,
+            None,
+            &mut panes,
+            &mut queues,
+            &cfg,
+            &state,
+            &repo,
+            (80, 24),
+            &tmp.path().join("requests"),
+            &mut errors,
+        )
+        .expect_err("the full group stops the request after routing");
+
+        assert!(refusal.reason.contains("wg-routing-stop"), "got {}", refusal.reason);
+        assert!(
+            errors
+                .iter()
+                .any(|line| line.contains("dashboard spawn automatically routed claude -> codex")),
+            "the dashboard must expose its fallback decision: {errors:?}"
+        );
+        assert!(panes.is_empty(), "the post-routing admission stop spawned nothing");
+        let decisions = crate::commands::ctx::log::tail(&state, 20).expect("decisions");
+        assert!(
+            decisions
+                .iter()
+                .any(|line| line.contains("\"action\":\"harness-reroute\"")
+                    && line.contains("claude -> codex")),
+            "the reroute must be persisted too: {decisions:?}"
+        );
+    }
+
     /// Re-review (2026-08-27) finding 1: an admission granted by `admit_child`
     /// above must be rolled back when a LATER step in this same call fails
     /// before a pane is ever actually spawned -- otherwise a group's

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -92,6 +92,24 @@ pub struct ExecArgs {
     pub simple: bool,
 }
 
+/// One vendor-backed portion of a logical supervised execution. A cross-harness
+/// fallback produces more than one segment; a normal run produces exactly one.
+#[derive(Debug, Clone)]
+pub struct ExecutionSegment {
+    pub session: String,
+    pub agent: String,
+    pub model: Option<String>,
+    pub usage: TranscriptUsage,
+    pub wall_ms: u64,
+}
+
+/// Accounting returned to callers that need to attribute one logical
+/// delegation across cross-harness continuations.
+#[derive(Debug, Clone, Default)]
+pub struct ExecutionReport {
+    pub segments: Vec<ExecutionSegment>,
+}
+
 /// Flags that pin a launch to a conversation that already exists. A restart is
 /// a deliberate escape from the session that rotted, so inheriting any of them
 /// would march the fresh child straight back into it and burn the whole
@@ -322,27 +340,35 @@ pub fn run_with<W: Write>(
     repo: &Path,
     env: EnvLookup<'_>,
 ) -> CtxResult<i32> {
-    run_with_clock(
+    let (code, _) = run_with_report(args, w, repo, env)?;
+    Ok(code)
+}
+
+/// Same supervised execution as [run_with], plus the per-harness accounting
+/// segments that make a cross-harness continuation observable to its caller.
+pub fn run_with_report<W: Write>(
+    args: &ExecArgs,
+    w: &mut W,
+    repo: &Path,
+    env: EnvLookup<'_>,
+) -> CtxResult<(i32, ExecutionReport)> {
+    let mut report = ExecutionReport::default();
+    let code = run_with_clock_inner(
         args,
         w,
         repo,
         env,
         &super::state::now_secs,
         &|d: Duration| std::thread::sleep(d),
-    )
+        None,
+        &mut report,
+    )?;
+    Ok((code, report))
 }
 
-/// T11 (sleep injection): identical to the former `run_with` in every way
-/// except `now_fn`/`sleep_fn` are now parameters instead of a real-clock
-/// closure hardcoded two calls deep in the body. Before this, the pacing
-/// gate's fail-safe delay (`blind_delay_secs`, T8) was verifiable at the
-/// unit level (`pace.rs`'s own `FakeClock` tests) but not at this
-/// integration level -- exec's own tests had to zero the delay out via
-/// `base_env` just to stay fast, which meant nothing here proved the delay
-/// actually reaches a real `sleep_fn` call with the right duration. Tests
-/// now inject a recording closure the same way `pace.rs`'s `FakeClock` does,
-/// so a future refactor that silently drops the sleep call is a test
-/// failure, not a shipped no-op.
+/// T11 (sleep injection): identical to the former run_with in every way
+/// except now_fn/sleep_fn are now parameters instead of a real-clock
+/// closure hardcoded two calls deep in the body.
 pub(crate) fn run_with_clock<W: Write>(
     args: &ExecArgs,
     w: &mut W,
@@ -350,6 +376,30 @@ pub(crate) fn run_with_clock<W: Write>(
     env: EnvLookup<'_>,
     now_fn: &dyn Fn() -> u64,
     sleep_fn: &dyn Fn(Duration),
+) -> CtxResult<i32> {
+    let mut report = ExecutionReport::default();
+    run_with_clock_inner(
+        args,
+        w,
+        repo,
+        env,
+        now_fn,
+        sleep_fn,
+        None,
+        &mut report,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_with_clock_inner<W: Write>(
+    args: &ExecArgs,
+    w: &mut W,
+    repo: &Path,
+    env: EnvLookup<'_>,
+    now_fn: &dyn Fn() -> u64,
+    sleep_fn: &dyn Fn(Duration),
+    stable_short: Option<&str>,
+    report: &mut ExecutionReport,
 ) -> CtxResult<i32> {
     let cfg = CtxConfig::load_for_launch(repo, env)?;
     // Gated only by `cfg.chrome.events` (which already folds in `--quiet` on
@@ -360,6 +410,8 @@ pub(crate) fn run_with_clock<W: Write>(
         super::announce::Announcer::new(cfg.chrome.events, console::colors_enabled_stderr());
     let agent_name = args.agent.as_deref().or(cfg.agent.as_deref());
     let adapter = adapters::select(agent_name, &args.command, &cfg)?;
+    let execution_started = Instant::now();
+    let execution_model = adapters::last_model_flag(&args.command).map(str::to_string);
     // Issue #155 review finding C2: refused here, before anything is
     // spawned, rather than left to silently never fire -- see
     // `AgentAdapter::counts_tool_calls`'s own doc comment for why this
@@ -470,7 +522,9 @@ pub(crate) fn run_with_clock<W: Write>(
     // reuses this exact value rather than recomputing `short_id(session)`,
     // which rotates on every restart and stranded any mail addressed to the
     // session a sender had actually resolved.
-    let registry_short = super::sessions::short_id(session.as_str());
+    let registry_short = stable_short
+        .map(str::to_string)
+        .unwrap_or_else(|| super::sessions::short_id(session.as_str()));
     // An adapter with no system-prompt injection mechanism never reaches
     // `injection_args_for_session`'s output at all -- folding mail into
     // `composed` for one only would silently destroy it, so for such an
@@ -940,6 +994,7 @@ pub(crate) fn run_with_clock<W: Write>(
             repo,
             super::sessions::Verb::Exec,
         )
+        .with_stable_short(&registry_short)
         .with_safety_policy_sha256(safety_policy_sha256)
         // Issue #169: `exec::run_with` has no `PromptRole` parameter to get
         // wrong (see `agent.rs`'s own module doc comment: a delegated run is
@@ -1063,6 +1118,15 @@ pub(crate) fn run_with_clock<W: Write>(
                 "zirv ctx exec: token/tool-call budget exhausted, stopping (exit \
                  {EXIT_BUDGET_EXHAUSTED})"
             )?;
+            record_execution_segment(
+                report,
+                adapter.as_ref(),
+                &session,
+                &transcript,
+                &prior_usage,
+                execution_model.as_deref(),
+                execution_started,
+            );
             session_guard.release();
             return Ok(EXIT_BUDGET_EXHAUSTED);
         }
@@ -1119,6 +1183,15 @@ pub(crate) fn run_with_clock<W: Write>(
                         &cfg,
                     );
                 }
+                record_execution_segment(
+                    report,
+                    adapter.as_ref(),
+                    &session,
+                    &transcript,
+                    &prior_usage,
+                    execution_model.as_deref(),
+                    execution_started,
+                );
                 session_guard.release();
                 return Ok(code);
             }
@@ -1410,6 +1483,19 @@ pub(crate) fn run_with_clock<W: Write>(
                 );
                 let stored = handoff::store(&state, repo, session.as_str(), &note)?;
 
+                // The source-harness portion is complete at this boundary.
+                // Record it before harvesting the current transcript into the
+                // budget accumulator, otherwise the helper would count it twice.
+                record_execution_segment(
+                    report,
+                    adapter.as_ref(),
+                    &session,
+                    &transcript,
+                    &prior_usage,
+                    execution_model.as_deref(),
+                    execution_started,
+                );
+
                 // Preserve the delegation's original budget across the vendor
                 // boundary. This harvest includes the just-stopped child plus
                 // every prior restart already accumulated in these counters.
@@ -1512,7 +1598,16 @@ pub(crate) fn run_with_clock<W: Write>(
                 // the continuation is registered. Releasing first prevents two
                 // live registry entries from claiming one logical worker.
                 session_guard.release();
-                return run_with_clock(&nested_args, w, repo, &nested_env, now_fn, sleep_fn);
+                return run_with_clock_inner(
+                    &nested_args,
+                    w,
+                    repo,
+                    &nested_env,
+                    now_fn,
+                    sleep_fn,
+                    Some(&registry_short),
+                    report,
+                );
             }
 
             let _ = log::append(
@@ -1561,6 +1656,15 @@ pub(crate) fn run_with_clock<W: Write>(
                     w,
                     "zirv ctx exec: usage limit hit and the original prompt is unknown, so it cannot relaunch. Pass --prompt to enable parking."
                 )?;
+                record_execution_segment(
+                    report,
+                    adapter.as_ref(),
+                    &session,
+                    &transcript,
+                    &prior_usage,
+                    execution_model.as_deref(),
+                    execution_started,
+                );
                 session_guard.release();
                 return Ok(EXIT_ROT_EXHAUSTED);
             };
@@ -1677,6 +1781,24 @@ pub(crate) fn run_with_clock<W: Write>(
                     action: "stand-down",
                     detail: "no prompt available for restart",
                 },
+            );
+            record_execution_segment(
+                report,
+                adapter.as_ref(),
+                &session,
+                &transcript,
+                &prior_usage,
+                execution_model.as_deref(),
+                execution_started,
+            );
+            record_execution_segment(
+                report,
+                adapter.as_ref(),
+                &session,
+                &transcript,
+                &prior_usage,
+                execution_model.as_deref(),
+                execution_started,
             );
             session_guard.release();
             return Ok(exhausted_code);
@@ -1831,6 +1953,27 @@ pub(crate) fn run_with_clock<W: Write>(
 /// flushed its first line. Shared by [`evaluate_worker_budget`] and
 /// [`harvest_spend`] (issue #169.2), so the two can never drift on how one
 /// transcript's own spend is computed.
+fn record_execution_segment(
+    report: &mut ExecutionReport,
+    adapter: &dyn adapters::AgentAdapter,
+    session: &SessionId,
+    transcript: &Path,
+    prior_usage: &TranscriptUsage,
+    model: Option<&str>,
+    started: Instant,
+) {
+    let current = read_transcript_spend(adapter, transcript)
+        .map(|(usage, _)| usage)
+        .unwrap_or_default();
+    report.segments.push(ExecutionSegment {
+        session: session.as_str().to_string(),
+        agent: adapter.name().to_string(),
+        model: model.map(str::to_string),
+        usage: add_usage(prior_usage, &current),
+        wall_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+    });
+}
+
 fn read_transcript_spend(
     adapter: &dyn adapters::AgentAdapter,
     transcript: &Path,

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -785,7 +785,6 @@ fn run_with_clock_inner<W: Write>(
     // budget bounds the whole supervised run, not just its latest incarnation.
     let mut prior_usage = TranscriptUsage::default();
     let mut prior_tool_calls: u32 = 0;
-    let has_budget = worker_budget.tokens.is_some() || worker_budget.tool_calls.is_some();
 
     let socket_path = state.socket_for(session.as_str());
     let server = match signal::SignalServer::bind(&socket_path) {
@@ -1219,17 +1218,15 @@ fn run_with_clock_inner<W: Write>(
             );
             let stored = handoff::store(&state, repo, session.as_str(), &note)?;
 
-            // Issue #169.2: harvest the outgoing child's own spend before its
-            // transcript is superseded, so a nudge restart never resets the
-            // budget meter.
-            if has_budget {
-                harvest_spend(
-                    adapter.as_ref(),
-                    &transcript,
-                    &mut prior_usage,
-                    &mut prior_tool_calls,
-                );
-            }
+            // Harvest every outgoing child even for an unbounded run: the same
+            // accumulator now feeds both budget enforcement and delegation
+            // accounting, so skipping it would hide pre-handoff/restart spend.
+            harvest_spend(
+                adapter.as_ref(),
+                &transcript,
+                &mut prior_usage,
+                &mut prior_tool_calls,
+            );
             session = SessionId::new_v4();
             session_guard.refresh_session(session.as_str());
             transcript = derive_transcript(&session);
@@ -1528,17 +1525,15 @@ fn run_with_clock_inner<W: Write>(
                     execution_started,
                 );
 
-                // Preserve the delegation's original budget across the vendor
-                // boundary. This harvest includes the just-stopped child plus
-                // every prior restart already accumulated in these counters.
-                if has_budget {
-                    harvest_spend(
-                        adapter.as_ref(),
-                        &transcript,
-                        &mut prior_usage,
-                        &mut prior_tool_calls,
-                    );
-                }
+                // Preserve both accounting and any configured delegation budget
+                // across the vendor boundary. This includes the just-stopped
+                // child plus every prior restart already accumulated here.
+                harvest_spend(
+                    adapter.as_ref(),
+                    &transcript,
+                    &mut prior_usage,
+                    &mut prior_tool_calls,
+                );
                 let spent_tokens = prior_usage
                     .context_total()
                     .saturating_add(prior_usage.output_tokens);
@@ -1705,20 +1700,15 @@ fn run_with_clock_inner<W: Write>(
                 return Ok(EXIT_ROT_EXHAUSTED);
             };
 
-            // A park is not a restart: the restart budget (`max_restarts`)
-            // is for rot, not for waiting. The token/tool-call budget is a
-            // different ceiling, for the whole run regardless of why it
-            // relaunched -- a park mints a fresh transcript exactly like a
-            // restart does, so its outgoing child's spend is harvested here
-            // too (issue #169.2).
-            if has_budget {
-                harvest_spend(
-                    adapter.as_ref(),
-                    &transcript,
-                    &mut prior_usage,
-                    &mut prior_tool_calls,
-                );
-            }
+            // A park mints a fresh transcript exactly like a restart, so the
+            // outgoing child's spend must be harvested for both whole-run
+            // accounting and any configured token/tool-call ceiling.
+            harvest_spend(
+                adapter.as_ref(),
+                &transcript,
+                &mut prior_usage,
+                &mut prior_tool_calls,
+            );
             session = SessionId::new_v4();
             session_guard.refresh_session(session.as_str());
             transcript = derive_transcript(&session);
@@ -1910,17 +1900,14 @@ fn run_with_clock_inner<W: Write>(
             "zirv ctx exec: {reason} detected, restarting ({restarts}/{max_restarts}) with a {source} handoff"
         )?;
 
-        // Issue #169.2: harvest the outgoing child's own spend before its
-        // transcript is superseded, so a rot/timeout restart never resets
-        // the budget meter.
-        if has_budget {
-            harvest_spend(
-                adapter.as_ref(),
-                &transcript,
-                &mut prior_usage,
-                &mut prior_tool_calls,
-            );
-        }
+        // Harvest before superseding the transcript so both accounting and
+        // any configured whole-run budget include this rot/timeout child.
+        harvest_spend(
+            adapter.as_ref(),
+            &transcript,
+            &mut prior_usage,
+            &mut prior_tool_calls,
+        );
         session = SessionId::new_v4();
         session_guard.refresh_session(session.as_str());
         // The new session writes somewhere new, so the next iteration's watcher

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -1451,27 +1451,59 @@ fn run_with_clock_inner<W: Write>(
                 .map(|raw| super::config::split_csv_list(&raw))
                 .unwrap_or_default();
             let source_model = adapters::last_model_flag(&args.command);
+            let route_request = super::fallback::RouteRequest {
+                requested: adapter.name(),
+                source_model,
+                source_model_explicit: source_model.is_some(),
+                bounds: super::fallback::TaskBounds {
+                    tokens: worker_budget.tokens,
+                    tool_calls: worker_budget.tool_calls,
+                },
+                now: now_fn(),
+            };
             let route = (adapter_builds_launch && prompt.is_some())
                 .then(|| {
                     super::fallback::route_blocked_session(
                         &state,
                         &cfg,
-                        super::fallback::RouteRequest {
-                            requested: adapter.name(),
-                            source_model,
-                            source_model_explicit: source_model.is_some(),
-                            bounds: super::fallback::TaskBounds {
-                                tokens: worker_budget.tokens,
-                                tool_calls: worker_budget.tool_calls,
-                            },
-                            now: now_fn(),
-                        },
+                        route_request,
                         &visited,
                     )
                 })
                 .flatten();
+            let deferred_reset = (route.is_none() && adapter_builds_launch && prompt.is_some())
+                .then(|| {
+                    super::fallback::earliest_reset_choice(
+                        &state,
+                        &cfg,
+                        route_request,
+                        &visited,
+                    )
+                })
+                .flatten();
+            let alternate = route
+                .as_ref()
+                .map(|route| {
+                    (
+                        route.selected.clone(),
+                        route.model.clone(),
+                        route.detail(),
+                    )
+                })
+                .or_else(|| {
+                    deferred_reset.as_ref().and_then(|choice| {
+                        if !choice.is_cross_harness() {
+                            return None;
+                        }
+                        Some((
+                            choice.selected.clone(),
+                            choice.model.clone()?,
+                            choice.detail(),
+                        ))
+                    })
+                });
 
-            if let Some(route) = route {
+            if let Some((selected_agent, selected_model, selection_detail)) = alternate {
                 let jsonl = std::fs::read_to_string(&transcript).unwrap_or_default();
                 let ctx = adapter.structural_context(&jsonl, cfg.handoff.tail_items);
                 let (note, source) = handoff::distill_or_structural(
@@ -1541,7 +1573,7 @@ fn run_with_clock_inner<W: Write>(
 
                 let detail = format!(
                     "{}; {} handoff at {}",
-                    route.detail(),
+                    selection_detail,
                     source,
                     stored.display()
                 );
@@ -1567,9 +1599,9 @@ fn run_with_clock_inner<W: Write>(
                     "{prompt_text}\n\nThe previous harness exhausted its usage window. Continue from this handoff without redoing completed work:\n\n{}",
                     note.to_markdown()
                 );
-                let target = adapters::select(Some(&route.selected), &[], &cfg)?;
+                let target = adapters::select(Some(&selected_agent), &[], &cfg)?;
                 let nested_args = ExecArgs {
-                    agent: Some(route.selected.clone()),
+                    agent: Some(selected_agent.clone()),
                     session_id: None,
                     transcript: None,
                     prompt: Some(continuation),
@@ -1577,7 +1609,7 @@ fn run_with_clock_inner<W: Write>(
                     timeout_secs: args.timeout_secs,
                     budget_tokens: remaining_tokens,
                     max_tool_calls: remaining_tool_calls,
-                    command: target.model_args(&route.model),
+                    command: target.model_args(&selected_model),
                     simple: args.simple,
                 };
 
@@ -1610,6 +1642,13 @@ fn run_with_clock_inner<W: Write>(
                 );
             }
 
+            let wait_detail = deferred_reset
+                .as_ref()
+                .map(super::fallback::ResetChoice::detail)
+                .unwrap_or_else(|| {
+                    "agent reported a usage limit; parking until the current window resets"
+                        .to_string()
+                });
             let _ = log::append(
                 &state,
                 &log::Decision {
@@ -1619,13 +1658,10 @@ fn run_with_clock_inner<W: Write>(
                     verdict: "limit",
                     score: 100,
                     action: "limit-park",
-                    detail: "agent reported a usage limit; parking until the window resets",
+                    detail: &wait_detail,
                 },
             );
-            writeln!(
-                w,
-                "zirv ctx exec: the agent reported a usage limit, parking until the window resets"
-            )?;
+            writeln!(w, "zirv ctx exec: {wait_detail}")?;
 
             pace::wait_for_window(
                 w,

--- a/src/commands/ctx/fallback.rs
+++ b/src/commands/ctx/fallback.rs
@@ -447,6 +447,105 @@ mod tests {
         assert_eq!(bounds.required_headroom_pct(&cfg, "seven_day"), Some(2.5));
     }
 
+    fn test_cfg_with_ready_adapters() -> CtxConfig {
+        let mut cfg = CtxConfig::default();
+        cfg.agent_bin = Some(
+            std::env::current_exe()
+                .expect("current test executable")
+                .display()
+                .to_string(),
+        );
+        cfg.pace.estimator = false;
+        cfg
+    }
+
+    fn store_usage(
+        state: &StateDir,
+        provider: &str,
+        percent: f64,
+        reset_at: u64,
+        now: u64,
+    ) {
+        crate::commands::ctx::window::store_for(
+            state,
+            provider,
+            &crate::commands::ctx::window::UsageWindows {
+                five_hour: Some(crate::commands::ctx::window::Window {
+                    used_percentage: percent,
+                    resets_at: reset_at,
+                    observed_at: now,
+                }),
+                seven_day: None,
+            },
+        )
+        .expect("store provider usage");
+    }
+
+    #[test]
+    fn all_exhausted_selects_the_admissible_harness_with_the_earliest_reset() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let cfg = test_cfg_with_ready_adapters();
+        let now = 1_700_000_000;
+        store_usage(&state, "anthropic", 100.0, now + 3_600, now);
+        store_usage(&state, "openai", 100.0, now + 600, now);
+
+        let choice = earliest_reset_choice(
+            &state,
+            &cfg,
+            RouteRequest {
+                requested: "claude",
+                source_model: Some("sonnet"),
+                source_model_explicit: false,
+                bounds: TaskBounds {
+                    tokens: None,
+                    tool_calls: None,
+                },
+                now,
+            },
+            &[],
+        )
+        .expect("both seats are hard blocked");
+
+        assert_eq!(choice.selected, "codex");
+        assert_eq!(choice.model.as_deref(), Some("gpt-5.6-terra"));
+        assert_eq!(choice.reset_at, now + 600);
+    }
+
+    #[test]
+    fn predictive_routing_uses_the_task_budget_when_the_source_cannot_fit_it() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let mut cfg = test_cfg_with_ready_adapters();
+        cfg.pace.five_hour_budget_tokens = 100_000;
+        cfg.fallback.predictive_headroom_pct = 20.0;
+        let now = 1_700_000_000;
+        // 25% headroom is above the static 20% threshold, but a 30% task
+        // budget cannot fit. The target has ample room.
+        store_usage(&state, "anthropic", 75.0, now + 3_600, now);
+        store_usage(&state, "openai", 20.0, now + 3_600, now);
+
+        let route = route_new_delegation(
+            &state,
+            &cfg,
+            RouteRequest {
+                requested: "claude",
+                source_model: Some("sonnet"),
+                source_model_explicit: false,
+                bounds: TaskBounds {
+                    tokens: Some(30_000),
+                    tool_calls: None,
+                },
+                now,
+            },
+            false,
+        )
+        .expect("the bounded task does not fit the requested seat");
+
+        assert_eq!(route.reason, RouteReason::Predictive);
+        assert_eq!(route.selected, "codex");
+    }
+
     #[test]
     fn reset_choice_detail_names_the_earliest_seat_and_reset() {
         let choice = ResetChoice {

--- a/src/commands/ctx/fallback.rs
+++ b/src/commands/ctx/fallback.rs
@@ -70,11 +70,32 @@ pub struct TaskBounds {
 
 impl TaskBounds {
     pub fn is_small(self, cfg: &CtxConfig) -> bool {
+        // A tool-call cap alone does not bound total work: a three-tool-call
+        // brief can still spend an unbounded number of model tokens. Require
+        // the total-token ceiling, and reject any additionally supplied tool
+        // ceiling that is itself larger than the small-task policy.
         self.tokens
             .is_some_and(|tokens| tokens <= cfg.fallback.small_task_max_tokens)
-            || self
+            && self
                 .tool_calls
-                .is_some_and(|tools| tools <= cfg.fallback.small_task_max_tool_calls)
+                .is_none_or(|tools| tools <= cfg.fallback.small_task_max_tool_calls)
+    }
+
+    fn required_headroom_pct(self, cfg: &CtxConfig, window: &str) -> Option<f64> {
+        let tokens = self.tokens?;
+        let budget = match window {
+            "five_hour" => cfg.pace.five_hour_budget_tokens,
+            "seven_day" => cfg.pace.seven_day_budget_tokens,
+            _ => 0,
+        };
+        (budget > 0).then(|| (tokens as f64 / budget as f64) * 100.0)
+    }
+
+    fn required_unknown_headroom_pct(self, cfg: &CtxConfig) -> f64 {
+        ["five_hour", "seven_day"]
+            .into_iter()
+            .filter_map(|window| self.required_headroom_pct(cfg, window))
+            .fold(0.0, f64::max)
     }
 }
 
@@ -97,6 +118,7 @@ fn candidate_headroom(
     state: &StateDir,
     cfg: &CtxConfig,
     name: &str,
+    bounds: TaskBounds,
     now: u64,
 ) -> Option<CandidateHeadroom> {
     let provider = adapters::provider_for_agent_name(Some(name));
@@ -108,16 +130,21 @@ fn candidate_headroom(
         return None;
     }
     if let Some(reading) = pace::spawn_headroom(&collector, estimator.as_ref(), now, &cfg.pace) {
-        return (reading.headroom_pct >= cfg.fallback.min_candidate_headroom_pct).then_some(
-            CandidateHeadroom {
-                pct: reading.headroom_pct,
-                assumed: false,
-            },
-        );
+        let required = bounds
+            .required_headroom_pct(cfg, reading.window)
+            .unwrap_or(0.0);
+        let floor = cfg.fallback.min_candidate_headroom_pct.max(required);
+        return (reading.headroom_pct >= floor).then_some(CandidateHeadroom {
+            pct: reading.headroom_pct,
+            assumed: false,
+        });
     }
     let pct = cfg.fallback.unknown_headroom_pct;
-    (pct > 0.0 && pct >= cfg.fallback.min_candidate_headroom_pct)
-        .then_some(CandidateHeadroom { pct, assumed: true })
+    let floor = cfg
+        .fallback
+        .min_candidate_headroom_pct
+        .max(bounds.required_unknown_headroom_pct(cfg));
+    (pct > 0.0 && pct >= floor).then_some(CandidateHeadroom { pct, assumed: true })
 }
 
 fn requested_headroom(state: &StateDir, cfg: &CtxConfig, name: &str, now: u64) -> Option<f64> {
@@ -160,7 +187,9 @@ fn best_alternate(
         if request.bounds.tool_calls.is_some() && !candidate_adapter.counts_tool_calls() {
             continue;
         }
-        let Some(headroom) = candidate_headroom(state, cfg, name, request.now) else {
+        let Some(headroom) =
+            candidate_headroom(state, cfg, name, request.bounds, request.now)
+        else {
             continue;
         };
         let Some(model) = handover::equivalent_model(
@@ -204,12 +233,20 @@ pub fn route_new_delegation(
     let provider = adapters::provider_for_agent_name(Some(request.requested));
     let (collector, estimator) = pace::current_windows(state, &cfg.pace, request.now, provider);
     let gate = pace::spawn_gate(&collector, estimator.as_ref(), request.now, &cfg.pace);
-    let source_headroom =
-        pace::spawn_headroom(&collector, estimator.as_ref(), request.now, &cfg.pace)
-            .map(|reading| reading.headroom_pct);
+    let source_reading =
+        pace::spawn_headroom(&collector, estimator.as_ref(), request.now, &cfg.pace);
+    let source_headroom = source_reading.map(|reading| reading.headroom_pct);
+    let task_will_not_fit = source_reading.is_some_and(|reading| {
+        request
+            .bounds
+            .required_headroom_pct(cfg, reading.window)
+            .is_some_and(|required| reading.headroom_pct < required)
+    });
     let reason = match gate {
         SpawnGate::Refuse { .. } => RouteReason::Exhausted,
-        _ if source_headroom.is_some_and(|pct| pct <= cfg.fallback.predictive_headroom_pct) => {
+        _ if task_will_not_fit
+            || source_headroom.is_some_and(|pct| pct <= cfg.fallback.predictive_headroom_pct) =>
+        {
             RouteReason::Predictive
         }
         _ => return None,
@@ -256,7 +293,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn small_capacity_requires_an_explicit_bounded_dimension() {
+    fn small_capacity_requires_a_bounded_small_token_budget() {
         let mut cfg = CtxConfig::default();
         cfg.fallback.small_task_max_tokens = 10_000;
         cfg.fallback.small_task_max_tool_calls = 10;
@@ -269,25 +306,46 @@ mod tests {
         );
         assert!(
             TaskBounds {
-                tokens: None,
+                tokens: Some(1_000),
                 tool_calls: Some(3),
             }
             .is_small(&cfg)
         );
         assert!(
             !TaskBounds {
-                tokens: Some(20_000),
+                tokens: None,
+                tool_calls: Some(3),
+            }
+            .is_small(&cfg),
+            "a tool-call cap alone leaves model-token spend unbounded"
+        );
+        assert!(
+            !TaskBounds {
+                tokens: Some(1_000),
                 tool_calls: Some(30),
             }
             .is_small(&cfg)
         );
         assert!(
             !TaskBounds {
-                tokens: None,
-                tool_calls: None,
+                tokens: Some(20_000),
+                tool_calls: Some(3),
             }
             .is_small(&cfg)
         );
+    }
+
+    #[test]
+    fn token_budget_converts_to_required_window_headroom_when_capacity_is_known() {
+        let mut cfg = CtxConfig::default();
+        cfg.pace.five_hour_budget_tokens = 100_000;
+        cfg.pace.seven_day_budget_tokens = 1_000_000;
+        let bounds = TaskBounds {
+            tokens: Some(25_000),
+            tool_calls: None,
+        };
+        assert_eq!(bounds.required_headroom_pct(&cfg, "five_hour"), Some(25.0));
+        assert_eq!(bounds.required_headroom_pct(&cfg, "seven_day"), Some(2.5));
     }
 
     #[test]

--- a/src/commands/ctx/fallback.rs
+++ b/src/commands/ctx/fallback.rs
@@ -62,6 +62,30 @@ impl Route {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResetChoice {
+    pub requested: String,
+    pub selected: String,
+    /// None only when waiting on the originally requested harness, where no
+    /// cross-vendor model translation is needed.
+    pub model: Option<String>,
+    pub reset_at: u64,
+    pub window: &'static str,
+}
+
+impl ResetChoice {
+    pub fn is_cross_harness(&self) -> bool {
+        self.selected != self.requested
+    }
+
+    pub fn detail(&self) -> String {
+        format!(
+            "{} -> {} (all admissible seats exhausted; earliest {} reset at {})",
+            self.requested, self.selected, self.window, self.reset_at
+        )
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TaskBounds {
     pub tokens: Option<u64>,
@@ -264,6 +288,81 @@ pub fn route_new_delegation(
     })
 }
 
+/// When no admissible harness can run now, chooses the seat whose hard spawn
+/// gate clears first. The requested harness remains a candidate even when its
+/// model is unknown, because waiting on the same vendor requires no quality
+/// translation. Alternate harnesses use the same roster, readiness, capacity,
+/// tool-enforcement, and verified-tier checks as immediate fallback.
+pub fn earliest_reset_choice(
+    state: &StateDir,
+    cfg: &CtxConfig,
+    request: RouteRequest<'_>,
+    excluded: &[String],
+) -> Option<ResetChoice> {
+    if !cfg.fallback.enabled {
+        return None;
+    }
+
+    let requested_provider = adapters::provider_for_agent_name(Some(request.requested));
+    let (collector, estimator) =
+        pace::current_windows(state, &cfg.pace, request.now, requested_provider);
+    let requested_reset = pace::spawn_reset(&collector, estimator.as_ref(), request.now, &cfg.pace)?;
+
+    let mut best = ResetChoice {
+        requested: request.requested.to_string(),
+        selected: request.requested.to_string(),
+        model: request.source_model.map(str::to_string),
+        reset_at: requested_reset.reset_at,
+        window: requested_reset.window,
+    };
+    let mut best_order = usize::MAX;
+
+    for (order_index, name) in cfg.fallback.order.iter().enumerate() {
+        if name == request.requested
+            || excluded.iter().any(|seen| seen == name)
+            || !cfg.agents.is_enabled(name)
+            || !candidate_allowed_by_capacity(cfg, name, request.bounds)
+        {
+            continue;
+        }
+        let Ok(candidate_adapter) = adapters::select(Some(name), &[], cfg) else {
+            continue;
+        };
+        if request.bounds.tool_calls.is_some() && !candidate_adapter.counts_tool_calls() {
+            continue;
+        }
+        let Some(model) = handover::equivalent_model(
+            request.requested,
+            request.source_model,
+            request.source_model_explicit,
+            name,
+            cfg,
+        ) else {
+            continue;
+        };
+        let provider = candidate_adapter.provider();
+        let (collector, estimator) = pace::current_windows(state, &cfg.pace, request.now, provider);
+        let Some(reset) = pace::spawn_reset(&collector, estimator.as_ref(), request.now, &cfg.pace)
+        else {
+            continue;
+        };
+        if reset.reset_at < best.reset_at
+            || (reset.reset_at == best.reset_at && order_index < best_order)
+        {
+            best = ResetChoice {
+                requested: request.requested.to_string(),
+                selected: name.clone(),
+                model: Some(model),
+                reset_at: reset.reset_at,
+                window: reset.window,
+            };
+            best_order = order_index;
+        }
+    }
+
+    Some(best)
+}
+
 /// Selection after a vendor-confirmed block. Unlike predictive routing this
 /// does not need the source usage collector to agree: the child's own limit
 /// message is stronger evidence than a stale/missing passive reading.
@@ -346,6 +445,21 @@ mod tests {
         };
         assert_eq!(bounds.required_headroom_pct(&cfg, "five_hour"), Some(25.0));
         assert_eq!(bounds.required_headroom_pct(&cfg, "seven_day"), Some(2.5));
+    }
+
+    #[test]
+    fn reset_choice_detail_names_the_earliest_seat_and_reset() {
+        let choice = ResetChoice {
+            requested: "claude".into(),
+            selected: "codex".into(),
+            model: Some("gpt-5.6-terra".into()),
+            reset_at: 1_700_000_600,
+            window: "five_hour",
+        };
+        assert!(choice.is_cross_harness());
+        let detail = choice.detail();
+        assert!(detail.contains("claude -> codex"));
+        assert!(detail.contains("1700000600"));
     }
 
     #[test]

--- a/src/commands/ctx/handover.rs
+++ b/src/commands/ctx/handover.rs
@@ -116,33 +116,20 @@ pub fn tier_for_model(agent: &str, model: &str, cfg: &CtxConfig) -> Option<&'sta
     })
 }
 
-/// Resolves the equivalent generic tier on another harness. When the source
-/// model came from zirv's own worker default and is absent, `standard` is the
-/// conservative background-work baseline. An explicit source model that does
-/// not match a verified tier returns `None`, preserving the operator's quality
-/// choice instead of translating a vendor-specific literal by guesswork.
+/// Resolves the equivalent generic tier on another harness. Automatic
+/// translation requires a concrete source model that Zirv can place on the
+/// verified ladder. An absent model means the vendor's own configuration chose
+/// it, which may be cheap, standard, or deep; guessing "standard" there would
+/// violate issue #186's no-quality-downgrade contract.
 pub fn equivalent_model(
     source_agent: &str,
     source_model: Option<&str>,
-    source_model_explicit: bool,
+    _source_model_explicit: bool,
     target_agent: &str,
     cfg: &CtxConfig,
 ) -> Option<String> {
-    let tier = match source_model {
-        Some(model) => tier_for_model(source_agent, model, cfg),
-        None if !source_model_explicit => Some("standard"),
-        None => None,
-    };
-    let tier = match tier {
-        Some(tier) => tier,
-        // A concrete source model that is not on the verified ladder is not
-        // automatically "standard", regardless of whether it came from an
-        // explicit CLI flag or the operator's worker default. Guessing here
-        // would violate issue #186's no-quality-downgrade contract.
-        None if source_model.is_some() => return None,
-        None if source_model_explicit => return None,
-        None => "standard",
-    };
+    let model = source_model?;
+    let tier = tier_for_model(source_agent, model, cfg)?;
     resolve_model(target_agent, tier, cfg).ok()
 }
 
@@ -634,6 +621,12 @@ mod tests {
             equivalent_model("claude", Some("sonnet-custom"), true, "codex", &cfg),
             Some("terra-custom".to_string())
         );
+    }
+
+    #[test]
+    fn absent_source_model_never_guesses_standard_quality() {
+        let cfg = CtxConfig::default();
+        assert_eq!(equivalent_model("codex", None, false, "claude", &cfg), None);
     }
 
     #[test]

--- a/src/commands/ctx/pace.rs
+++ b/src/commands/ctx/pace.rs
@@ -340,6 +340,64 @@ pub fn spawn_headroom(
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SpawnReset {
+    pub reset_at: u64,
+    pub window: &'static str,
+    pub source: Source,
+}
+
+/// When a new-work gate is hard-refused, returns when that provider can next
+/// be considered usable. If more than one authoritative window is at the hard
+/// ceiling, all of them must clear, so this returns the latest reset among the
+/// blocking windows. The source layering is identical to [spawn_gate]:
+/// binding collector data wins as a layer; the estimator is considered only
+/// when no collector window is binding.
+pub fn spawn_reset(
+    collector: &UsageWindows,
+    estimator: Option<&UsageWindows>,
+    now: u64,
+    cfg: &PaceConfig,
+) -> Option<SpawnReset> {
+    if !cfg.enabled {
+        return None;
+    }
+
+    let collector_five = binding(&collector.five_hour, now, cfg);
+    let collector_seven = binding(&collector.seven_day, now, cfg);
+    let collector_has_binding = collector_five.is_some() || collector_seven.is_some();
+    let (source, five, seven) = if collector_has_binding {
+        (Source::Collector, collector_five, collector_seven)
+    } else if cfg.estimator {
+        (
+            Source::Estimator,
+            estimator.and_then(|windows| windows.five_hour.as_ref()),
+            estimator.and_then(|windows| windows.seven_day.as_ref()),
+        )
+    } else {
+        (Source::None, None, None)
+    };
+
+    [("five_hour", five), ("seven_day", seven)]
+        .into_iter()
+        .filter_map(|(window, reading)| {
+            let reading = reading?;
+            (reading.used_percentage >= cfg.spawn_hard_pct).then(|| {
+                let reset_at = if reading.resets_at > now {
+                    reading.resets_at
+                } else {
+                    now.saturating_add(cfg.fallback_delay_secs)
+                };
+                SpawnReset {
+                    reset_at,
+                    window,
+                    source,
+                }
+            })
+        })
+        .max_by_key(|reset| reset.reset_at)
+}
+
 pub fn spawn_gate(
     collector: &UsageWindows,
     estimator: Option<&UsageWindows>,
@@ -1224,6 +1282,51 @@ pub fn wait_for_window<W: Write>(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn spawn_reset_waits_for_every_hard_blocking_window() {
+        let now = 1_700_000_000;
+        let cfg = super::PaceConfig {
+            spawn_hard_pct: 95.0,
+            ..Default::default()
+        };
+        let collector = super::UsageWindows {
+            five_hour: Some(super::Window {
+                used_percentage: 99.0,
+                resets_at: now + 600,
+                observed_at: now,
+            }),
+            seven_day: Some(super::Window {
+                used_percentage: 96.0,
+                resets_at: now + 3_600,
+                observed_at: now,
+            }),
+        };
+        let reset = super::spawn_reset(&collector, None, now, &cfg).expect("hard refused");
+        assert_eq!(reset.reset_at, now + 3_600);
+        assert_eq!(reset.window, "seven_day");
+        assert_eq!(reset.source, super::Source::Collector);
+    }
+
+    #[test]
+    fn spawn_reset_uses_the_configured_fallback_delay_when_reset_is_unknown() {
+        let now = 1_700_000_000;
+        let cfg = super::PaceConfig {
+            spawn_hard_pct: 95.0,
+            fallback_delay_secs: 777,
+            ..Default::default()
+        };
+        let collector = super::UsageWindows {
+            five_hour: Some(super::Window {
+                used_percentage: 100.0,
+                resets_at: 0,
+                observed_at: now,
+            }),
+            seven_day: None,
+        };
+        let reset = super::spawn_reset(&collector, None, now, &cfg).expect("hard refused");
+        assert_eq!(reset.reset_at, now + 777);
+    }
+
     use super::*;
     use crate::commands::ctx::config::PaceConfig;
     use crate::commands::ctx::state::StateDir;

--- a/src/commands/ctx/run_loop.rs
+++ b/src/commands/ctx/run_loop.rs
@@ -8,7 +8,7 @@ use super::pace;
 use super::rot::Verdict;
 use super::state::{StateDir, now_secs};
 use super::supervise::{self, Outcome, Tick};
-use super::{CtxResult, adapters, log, score};
+use super::{CtxResult, adapters, handoff, log, score};
 
 /// Repeated cycle failures, escalated to the caller.
 pub const EXIT_FAILED: i32 = 75;
@@ -118,11 +118,13 @@ pub(crate) fn run_with_clock<W: Write>(
         return Err("--cycles must be at least 1".into());
     }
 
-    let prompt = resolve_prompt(args)?;
+    let mut task_prompt = resolve_prompt(args)?;
     let cfg = CtxConfig::load_for_launch(repo, env)?;
     let announcer =
         super::announce::Announcer::new(cfg.chrome.events, console::colors_enabled_stderr());
-    let adapter = adapters::select(args.agent.as_deref().or(cfg.agent.as_deref()), &[], &cfg)?;
+    let mut adapter = adapters::select(args.agent.as_deref().or(cfg.agent.as_deref()), &[], &cfg)?;
+    let mut extra = args.extra.clone();
+    let mut visited: Vec<String> = Vec::new();
     let state = StateDir::resolve(env)?;
 
     let interval = Duration::from_secs(args.interval_secs.unwrap_or(cfg.supervise.interval_secs));
@@ -260,7 +262,7 @@ pub(crate) fn run_with_clock<W: Write>(
         };
         let (user_extra, composed) = super::prompt::merge_command_line_prompt(
             adapter.as_ref(),
-            &args.extra,
+            &extra,
             composed,
             None,
             super::prompt::PromptRole::Worker,
@@ -268,7 +270,7 @@ pub(crate) fn run_with_clock<W: Write>(
         );
 
         match session_guard.as_mut() {
-            Some(guard) => guard.refresh_session(session.as_str()),
+            Some(guard) => guard.refresh_session_agent(session.as_str(), adapter.name()),
             None => {
                 registry_short = Some(session_short.clone());
                 // Issue #139: see `wrap.rs::run_with`'s identical comment.
@@ -348,8 +350,8 @@ pub(crate) fn run_with_clock<W: Write>(
 
         // When argv injection is unsafe, the complete compiled context moves
         // to the task-prompt channel ahead of mail.
-        let prompt = super::prompt::task_prompt_with_composed_fallback(
-            &prompt,
+        let cycle_prompt = super::prompt::task_prompt_with_composed_fallback(
+            &task_prompt,
             system_prompt_supported,
             composed.as_ref(),
         );
@@ -360,8 +362,8 @@ pub(crate) fn run_with_clock<W: Write>(
         // an adapter with no system-prompt mechanism: the task prompt text
         // itself. A capable adapter (claude) gets the unchanged `prompt`
         // back, since its mail already rode the `composed` fold above.
-        let prompt = super::prompt::task_prompt_with_mail_fallback(
-            &prompt,
+        let cycle_prompt = super::prompt::task_prompt_with_mail_fallback(
+            &cycle_prompt,
             (system_prompt_supported && composed.is_some()) || mail_in_composed,
             &mail_messages,
             cfg.mail.max_delivered_bytes,
@@ -382,11 +384,11 @@ pub(crate) fn run_with_clock<W: Write>(
         let (mut command, stdin_prompt) =
             if prompt_delivery_via_stdin(adapter.as_ref(), &session, &extra) {
                 match adapter.headless_cmd_stdin(&session, &extra) {
-                    Some(command) => (command, Some(prompt.clone())),
-                    None => (adapter.headless_cmd(&prompt, &session, &extra), None),
+                    Some(command) => (command, Some(cycle_prompt.clone())),
+                    None => (adapter.headless_cmd(&cycle_prompt, &session, &extra), None),
                 }
             } else {
-                (adapter.headless_cmd(&prompt, &session, &extra), None)
+                (adapter.headless_cmd(&cycle_prompt, &session, &extra), None)
             };
         command.current_dir(repo);
         // F3: `loop` binds no turn-signal socket of its own, so it has no
@@ -488,6 +490,112 @@ pub(crate) fn run_with_clock<W: Write>(
                 "loop",
                 &mut std::io::stderr(),
             );
+        }
+
+        if limit_hit {
+            let source_model = adapters::last_model_flag(&extra);
+            let route_request = super::fallback::RouteRequest {
+                requested: adapter.name(),
+                source_model,
+                source_model_explicit: source_model.is_some(),
+                bounds: super::fallback::TaskBounds {
+                    tokens: None,
+                    tool_calls: None,
+                },
+                now: now_fn(),
+            };
+            let route =
+                super::fallback::route_blocked_session(&state, &cfg, route_request, &visited);
+            let deferred_reset = route
+                .is_none()
+                .then(|| {
+                    super::fallback::earliest_reset_choice(
+                        &state,
+                        &cfg,
+                        route_request,
+                        &visited,
+                    )
+                })
+                .flatten();
+            let alternate = route
+                .as_ref()
+                .map(|route| {
+                    (
+                        route.selected.clone(),
+                        route.model.clone(),
+                        route.detail(),
+                    )
+                })
+                .or_else(|| {
+                    deferred_reset.as_ref().and_then(|choice| {
+                        if !choice.is_cross_harness() {
+                            return None;
+                        }
+                        Some((
+                            choice.selected.clone(),
+                            choice.model.clone()?,
+                            choice.detail(),
+                        ))
+                    })
+                });
+
+            if let Some((selected_agent, selected_model, selection_detail)) = alternate
+                && let Ok(target) = adapters::select(Some(&selected_agent), &[], &cfg)
+                && let Some(translated) =
+                    super::agent::translated_route_flags(&extra, target.as_ref(), &selected_model)
+            {
+                let jsonl = std::fs::read_to_string(&transcript).unwrap_or_default();
+                let ctx = adapter.structural_context(&jsonl, cfg.handoff.tail_items);
+                let distiller_model =
+                    handoff::resolve_distiller_model(cfg.handoff.model.as_deref(), adapter.as_ref());
+                let (note, source) = handoff::distill_or_structural(
+                    adapter.as_ref(),
+                    &distiller_model,
+                    &ctx,
+                    Duration::from_secs(cfg.handoff.timeout_secs),
+                    cfg.chrome.events,
+                );
+                let stored = handoff::store(&state, repo, session.as_str(), &note)?;
+                let detail = format!(
+                    "{}; {} handoff at {}",
+                    selection_detail,
+                    source,
+                    stored.display()
+                );
+                let _ = log::append(
+                    &state,
+                    &log::Decision {
+                        ts: now_secs(),
+                        session: session.as_str(),
+                        verb: "loop",
+                        verdict: "limit",
+                        score: 100,
+                        action: "harness-handover",
+                        detail: &detail,
+                    },
+                );
+                writeln!(
+                    w,
+                    "zirv ctx loop: usage limit hit; continuing on another harness ({detail})"
+                )?;
+
+                if !visited.iter().any(|name| name == adapter.name()) {
+                    visited.push(adapter.name().to_string());
+                }
+                task_prompt = format!(
+                    "{}\n\nThe previous harness exhausted its usage window. Continue from this handoff without redoing completed work:\n\n{}",
+                    task_prompt,
+                    note.to_markdown()
+                );
+                extra = translated;
+                adapter = target;
+                pace_flags = pace::PaceGateFlags::default();
+                if let Some(guard) = session_guard.as_mut() {
+                    guard.refresh_session_agent(session.as_str(), adapter.name());
+                }
+                failures = 0;
+                continue;
+            }
         }
 
         let (action, failed) = match outcome {

--- a/src/commands/ctx/sessions.rs
+++ b/src/commands/ctx/sessions.rs
@@ -1602,6 +1602,45 @@ mod tests {
     use super::super::testenv::dead_pid;
 
     #[test]
+    fn cross_harness_refresh_keeps_the_logical_address_and_registry_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = state_in(&tmp.path().join("state"));
+        let repo = tmp.path().join("repo");
+        let record = Record::new(
+            "aaaaaaaa-1111-4111-8111-111111111111",
+            "claude",
+            &repo,
+            Verb::Exec,
+        )
+        .with_stable_short("stable01");
+        let mut guard = SessionGuard::register(&state, record);
+        let original_path = guard.path.clone();
+
+        guard.refresh_session_agent(
+            "bbbbbbbb-2222-4222-8222-222222222222",
+            "codex",
+        );
+
+        assert_eq!(guard.record.short, "stable01");
+        assert_eq!(guard.record.agent, "codex");
+        assert_eq!(
+            guard.record.session,
+            "bbbbbbbb-2222-4222-8222-222222222222"
+        );
+        assert_eq!(
+            guard.path, original_path,
+            "changing the underlying vendor session must not mint a new address"
+        );
+
+        let stored: Record = serde_json::from_str(
+            &std::fs::read_to_string(&guard.path).expect("stored record"),
+        )
+        .expect("deserialize record");
+        assert_eq!(stored.short, "stable01");
+        assert_eq!(stored.agent, "codex");
+    }
+
+    #[test]
     fn a_record_without_owner_pid_deserializes_as_unowned() {
         // A record written by a build that predates `owner_pid` has no such
         // key in its JSON at all -- not `null`, simply absent -- which is

--- a/src/commands/ctx/sessions.rs
+++ b/src/commands/ctx/sessions.rs
@@ -561,6 +561,20 @@ impl SessionGuard {
         self.path = write_record(&self.state, &self.record);
     }
 
+    /// Same stable-address refresh as [refresh_session], while also changing
+    /// the harness that currently owns this logical supervisor. Used by
+    /// cross-harness loop continuation, where status must follow the new
+    /// vendor without minting a new delivery address.
+    pub fn refresh_session_agent(&mut self, new_session: &str, agent: &str) {
+        if self.released {
+            return;
+        }
+        self.record.session = new_session.to_string();
+        self.record.agent = agent.to_string();
+        self.record.started_at = super::state::now_secs();
+        self.path = write_record(&self.state, &self.record);
+    }
+
     /// Points this run's record at the pid of the agent child the supervisor
     /// actually spawned, rather than at the supervisor's own pid.
     ///

--- a/src/commands/ctx/sessions.rs
+++ b/src/commands/ctx/sessions.rs
@@ -460,6 +460,17 @@ impl Record {
         self.role = Some(role.to_string());
         self
     }
+
+    /// Issue #186 hardening: preserves a supervisor's already-established
+    /// delivery address while the underlying vendor session changes. This is
+    /// only used by Zirv's own cross-harness continuation path; callers must
+    /// supply the short id of the logical supervisor that is being continued.
+    pub fn with_stable_short(mut self, short: &str) -> Self {
+        if !short.is_empty() {
+            self.short = short.to_string();
+        }
+        self
+    }
 }
 
 fn record_path(state: &StateDir, short: &str) -> PathBuf {

--- a/src/commands/ctx/status.rs
+++ b/src/commands/ctx/status.rs
@@ -509,9 +509,14 @@ pub fn run_with<W: Write>(
                     } else {
                         "full"
                     };
+                    let readiness = if adapters::select(Some(name), &[], cfg).is_ok() {
+                        "ready"
+                    } else {
+                        "unavailable"
+                    };
                     writeln!(
                         w,
-                        "  fallback {name}: {} / {capacity} / {headroom}",
+                        "  fallback {name}: {} / {readiness} / {capacity} / {headroom}",
                         if cfg.agents.is_enabled(name) {
                             "enabled"
                         } else {


### PR DESCRIPTION
## Summary

Follow-up hardening for #186 after review of #189.

- fail closed on malformed `[fallback]` configuration
- preserve the logical session address across cross-harness handoffs
- account source and continuation harness spend separately
- refuse unknown-quality model translation
- make predictive routing task-size aware
- choose the earliest admissible reset when every seat is exhausted
- hand off blocked `ctx loop` sessions
- route dashboard-originated spawns through the shared fallback policy
- surface fallback harness readiness in status

## Validation

Targeted regression coverage is being added on this branch. Full repository CI is expected before this draft is marked ready.

Closes the review gaps found after #189; relates to #186.