### PR TITLE
release: 3.9.0 - close #268 #282 #283 #286 #298 (top-5 batch)

### DIFF
--- a/.zirv/ctx.toml
+++ b/.zirv/ctx.toml
@@ -182,6 +182,7 @@ model = "fable"
 # review_worker_budget_tokens = 0    # REPO-FORBIDDEN (ZIRV_CTX_WORKFLOW_REVIEW_WORKER_BUDGET_TOKENS): token ceiling appended to a workflow reviewer worker's launch as `--budget-tokens`, only when set. Default: unset (no flag appended).
 # review_worker_max_tool_calls = 0   # REPO-FORBIDDEN (ZIRV_CTX_WORKFLOW_REVIEW_WORKER_MAX_TOOL_CALLS): tool-call ceiling appended to a workflow reviewer worker's launch as `--max-tool-calls`, only when set. Default: unset (no flag appended).
 # auto_spawn_on_gate = false         # REPO-FORBIDDEN (ZIRV_CTX_WORKFLOW_AUTO_SPAWN_ON_GATE): auto-spawns a bounded review run/test changed/verify worker when a gate transition lands the workflow on that phase. Default: false.
+# allow_empty_verify = false         # REPO-FORBIDDEN (ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY): lets zirv verify/zirv test report Passed instead of Inconclusive when zero verification checks are configured or discoverable. Default: false.
 
 # [workflow.deploy]
 # tier = "development"               # REPO-FORBIDDEN (ZIRV_CTX_WORKFLOW_DEPLOY_TIER): development < staging < production. Operator env overrides all layers. Default: "development".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/README.md
+++ b/README.md
@@ -1291,6 +1291,7 @@ checkout:
 | `workflow.review_worker_budget_tokens` | `ZIRV_CTX_WORKFLOW_REVIEW_WORKER_BUDGET_TOKENS` |
 | `workflow.review_worker_max_tool_calls` | `ZIRV_CTX_WORKFLOW_REVIEW_WORKER_MAX_TOOL_CALLS` |
 | `workflow.auto_spawn_on_gate` | `ZIRV_CTX_WORKFLOW_AUTO_SPAWN_ON_GATE` |
+| `workflow.allow_empty_verify` | `ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY` |
 
 The `mail.*`/`chrome.events` entries close the same hole `prompt.max_repo_bytes`
 does: mail is folded into a launched worker's prompt as its own layer, so a

--- a/docs/obsidian/Concepts/Untrusted Configuration.md
+++ b/docs/obsidian/Concepts/Untrusted Configuration.md
@@ -98,6 +98,7 @@ Plus a third, read-only case: `zirv ctx optimize` reads the repo's own CLAUDE.md
 | `workflow.review_worker_budget_tokens` | `ZIRV_CTX_WORKFLOW_REVIEW_WORKER_BUDGET_TOKENS` |
 | `workflow.review_worker_max_tool_calls` | `ZIRV_CTX_WORKFLOW_REVIEW_WORKER_MAX_TOOL_CALLS` |
 | `workflow.auto_spawn_on_gate` | `ZIRV_CTX_WORKFLOW_AUTO_SPAWN_ON_GATE` |
+| `workflow.allow_empty_verify` | `ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY` |
 | `context.max_common_bytes` | `ZIRV_CTX_CONTEXT_MAX_COMMON_BYTES` |
 | `context.max_harness_bytes` | `ZIRV_CTX_CONTEXT_MAX_HARNESS_BYTES` |
 | `context.max_harness_roster_bytes` | `ZIRV_CTX_CONTEXT_MAX_HARNESS_ROSTER_BYTES` |

--- a/src/commands/ctx/adapters/claude.rs
+++ b/src/commands/ctx/adapters/claude.rs
@@ -917,6 +917,21 @@ impl AgentAdapter for ClaudeAdapter {
         cmd
     }
 
+    fn headless_resume_cmd(
+        &self,
+        prompt: Option<&str>,
+        session_id: &str,
+        extra: &[String],
+    ) -> Option<Command> {
+        let mut cmd = self.base();
+        cmd.arg("-p");
+        if let Some(prompt) = prompt {
+            cmd.arg(prompt);
+        }
+        cmd.arg("--resume").arg(session_id).args(extra);
+        Some(cmd)
+    }
+
     fn interactive_cmd(&self, initial_prompt: Option<&str>, extra: &[String]) -> Command {
         let mut cmd = self.base();
         if let Some(prompt) = initial_prompt {

--- a/src/commands/ctx/adapters/claude.rs
+++ b/src/commands/ctx/adapters/claude.rs
@@ -932,6 +932,10 @@ impl AgentAdapter for ClaudeAdapter {
         Some(cmd)
     }
 
+    fn supports_headless_compact(&self) -> bool {
+        true
+    }
+
     fn interactive_cmd(&self, initial_prompt: Option<&str>, extra: &[String]) -> Command {
         let mut cmd = self.base();
         if let Some(prompt) = initial_prompt {

--- a/src/commands/ctx/adapters/claude.rs
+++ b/src/commands/ctx/adapters/claude.rs
@@ -190,6 +190,14 @@ pub fn parse_events(jsonl: &str) -> Vec<NormalizedEvent> {
             continue;
         }
 
+        if row.get("isApiErrorMessage").and_then(Value::as_bool) == Some(true) {
+            let message = row.get("message").cloned().unwrap_or(Value::Null);
+            events.push(NormalizedEvent::ProviderError {
+                class: super::classify_provider_error(&text_of(&message)),
+            });
+            continue;
+        }
+
         match row.get("type").and_then(Value::as_str) {
             Some("user") => {
                 if row.get("isMeta").and_then(Value::as_bool) == Some(true) {
@@ -224,6 +232,9 @@ pub fn parse_events(jsonl: &str) -> Vec<NormalizedEvent> {
             }
             Some("assistant") => {
                 let message = row.get("message").cloned().unwrap_or(Value::Null);
+                if let Some(id) = message.get("model").and_then(Value::as_str) {
+                    events.push(NormalizedEvent::ModelId { id: id.to_string() });
+                }
                 let input_tokens = message.get("usage").map(context_tokens_of).unwrap_or(0);
                 events.push(NormalizedEvent::AssistantFinal {
                     text: text_of(&message),
@@ -1402,6 +1413,23 @@ impl AgentAdapter for ClaudeAdapter {
         }
     }
 
+    fn model_strength(&self, model: &str) -> Option<u8> {
+        let model = model.to_lowercase();
+        if model.contains("fable") || model.contains("mythos") {
+            return Some(4);
+        }
+        if model.contains("opus") {
+            return Some(3);
+        }
+        if model.contains("sonnet") {
+            return Some(2);
+        }
+        if model.contains("haiku") {
+            return Some(1);
+        }
+        None
+    }
+
     fn transcript_path(&self, session: &SessionRef) -> PathBuf {
         let projects = self.home_dir().join(".claude").join("projects");
         let computed = projects
@@ -1841,6 +1869,99 @@ mod tests {
     fn compact_boundary_becomes_a_compaction_event() {
         let jsonl = r#"{"type":"system","subtype":"compact_boundary","compactMetadata":{"trigger":"manual"}}"#;
         assert_eq!(parse_events(jsonl), vec![NormalizedEvent::Compaction]);
+    }
+
+    #[test]
+    fn api_error_classification_checks_exclusions_before_overflow_patterns() {
+        use crate::commands::ctx::event::ProviderErrorClass;
+
+        let cases = [
+            (
+                "API Error: prompt is too long: 213462 tokens > 200000 maximum",
+                ProviderErrorClass::Overflow,
+            ),
+            (
+                "API Error: 413 {\"error\":{\"type\":\"request_too_large\"}}",
+                ProviderErrorClass::Overflow,
+            ),
+            (
+                "Your input exceeds the context window of this model",
+                ProviderErrorClass::Overflow,
+            ),
+            (
+                "Requested token count exceeds the model's maximum context length of 131072 tokens",
+                ProviderErrorClass::Overflow,
+            ),
+            (
+                "Throttling error: Too many tokens, please wait before trying again",
+                ProviderErrorClass::RateLimit,
+            ),
+            (
+                "rate limit: prompt is too long",
+                ProviderErrorClass::RateLimit,
+            ),
+            (
+                "too many requests: request_too_large",
+                ProviderErrorClass::RateLimit,
+            ),
+            (
+                "Service unavailable: request_too_large",
+                ProviderErrorClass::Other,
+            ),
+            ("API Error: connection reset", ProviderErrorClass::Other),
+        ];
+
+        for (message, expected) in cases {
+            assert_eq!(
+                super::super::classify_provider_error(message),
+                expected,
+                "{message}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_error_and_model_events_are_parsed_from_the_recorded_fixture() {
+        use crate::commands::ctx::event::ProviderErrorClass;
+
+        let jsonl =
+            std::fs::read_to_string(fixture_path("claude-provider-errors-model-drift.jsonl"))
+                .expect("fixture");
+        let events = parse_events(&jsonl);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    NormalizedEvent::ProviderError {
+                        class: ProviderErrorClass::Overflow
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    NormalizedEvent::ProviderError {
+                        class: ProviderErrorClass::RateLimit
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| match event {
+                    NormalizedEvent::ModelId { id } => Some(id.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            vec!["claude-opus-5", "claude-sonnet-5"]
+        );
     }
 
     #[test]

--- a/src/commands/ctx/adapters/codex.rs
+++ b/src/commands/ctx/adapters/codex.rs
@@ -5,6 +5,8 @@ use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+use serde_json::Value;
+
 use super::super::CtxResult;
 use super::super::event::{
     Capabilities, NormalizedEvent, SessionId, SessionRef, StructuralContext, TranscriptUsage,
@@ -981,6 +983,23 @@ impl AgentAdapter for CodexAdapter {
         }
     }
 
+    fn model_strength(&self, model: &str) -> Option<u8> {
+        let model = model.to_lowercase();
+        if model.contains("gpt-5.6-sol") {
+            return Some(4);
+        }
+        if model.contains("gpt-5.6-terra") {
+            return Some(3);
+        }
+        if model.contains("gpt-5.6-luna") {
+            return Some(2);
+        }
+        if model.contains("gpt-5.4-mini") {
+            return Some(1);
+        }
+        None
+    }
+
     /// Codex's descriptors come from the repo's **recorded** facts
     /// (docs/superpowers/notes/2026-07-31-codex-cli-facts.md, and the
     /// `distiller_cmd` notes above), not from a live CLI: codex is not
@@ -1377,8 +1396,54 @@ impl AgentAdapter for CodexAdapter {
                 }
                 _ => {}
             }
+            let Ok(row) = serde_json::from_str::<Value>(line.trim()) else {
+                continue;
+            };
+            match row.get("type").and_then(Value::as_str) {
+                Some("turn_context") => {
+                    if let Some(id) = row
+                        .get("payload")
+                        .and_then(|payload| payload.get("model"))
+                        .and_then(Value::as_str)
+                    {
+                        events.push(NormalizedEvent::ModelId { id: id.to_string() });
+                    }
+                }
+                Some("event_msg")
+                    if row
+                        .get("payload")
+                        .and_then(|payload| payload.get("type"))
+                        .and_then(Value::as_str)
+                        == Some("task_complete") =>
+                {
+                    if let Some(message) = row
+                        .get("payload")
+                        .and_then(|payload| payload.get("error"))
+                        .and_then(|error| error.get("message"))
+                        .and_then(Value::as_str)
+                    {
+                        events.push(NormalizedEvent::ProviderError {
+                            class: super::classify_provider_error(message),
+                        });
+                    }
+                }
+                _ => {}
+            }
         }
         events
+    }
+
+    fn model_hint(&self, jsonl: &str) -> Option<String> {
+        jsonl.lines().rev().find_map(|line| {
+            let row = serde_json::from_str::<Value>(line.trim()).ok()?;
+            if row.get("type").and_then(Value::as_str) != Some("turn_context") {
+                return None;
+            }
+            row.get("payload")?
+                .get("model")?
+                .as_str()
+                .map(str::to_string)
+        })
     }
 
     /// Only `assistant_texts` is populated, from verified
@@ -1684,8 +1749,53 @@ mod tests {
                     text: String::new(),
                     input_tokens: 3400,
                 },
+                NormalizedEvent::ProviderError {
+                    class: crate::commands::ctx::event::ProviderErrorClass::Other,
+                },
             ],
             "got {events:?}"
+        );
+    }
+
+    #[test]
+    fn provider_error_and_model_events_are_parsed_from_the_recorded_fixture() {
+        use crate::commands::ctx::event::ProviderErrorClass;
+
+        let jsonl = fixture("codex-provider-errors-model-drift.jsonl");
+        let events = CodexAdapter::new(None).parse_events(&jsonl);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    NormalizedEvent::ProviderError {
+                        class: ProviderErrorClass::Overflow
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    NormalizedEvent::ProviderError {
+                        class: ProviderErrorClass::RateLimit
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| match event {
+                    NormalizedEvent::ModelId { id } => Some(id.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            vec!["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-terra"]
         );
     }
 

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -929,6 +929,13 @@ pub trait AgentAdapter: std::fmt::Debug {
         let _ = (prompt, session_id, extra);
         None
     }
+    /// Whether this adapter can compact and then resume the same headless
+    /// conversation. False unless an adapter has verified both halves of the
+    /// operation; headless supervisors use this before spending a compact
+    /// attempt or stopping the child for one.
+    fn supports_headless_compact(&self) -> bool {
+        false
+    }
     fn interactive_cmd(&self, initial_prompt: Option<&str>, extra: &[String]) -> Command;
     /// Builds the judgment/distiller model child's command. `model` is empty
     /// when neither the operator's own config (`handoff.model`/`optimize.

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -3701,6 +3701,7 @@ mod tests {
     /// seat / outranks-other-routing rule.
     #[test]
     fn harness_prompt_lines_review_line_shows_computed_defaults_when_unset() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let lines = harness_prompt_lines(&permissive_cfg(), "");
         let review_line = lines.last().expect("at least the review line");
         assert!(
@@ -3725,6 +3726,7 @@ mod tests {
     /// and is marked `(configured)` rather than `(default: ...)`.
     #[test]
     fn harness_prompt_lines_review_line_uses_the_operators_configured_model() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let cfg = CtxConfig {
             review: crate::commands::ctx::config::ReviewConfig {
                 claude: Some("custom-review-model".to_string()),
@@ -3748,6 +3750,7 @@ mod tests {
     /// absence-not-silence rule its own per-harness line above follows.
     #[test]
     fn harness_prompt_lines_review_line_omits_a_disabled_harnesses_entry() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let cfg = cfg_disabling("codex");
         let lines = harness_prompt_lines(&cfg, "");
         let review_line = lines.last().expect("at least the review line");
@@ -3835,6 +3838,7 @@ mod tests {
     /// true for every entry, so it stays.
     #[test]
     fn review_roster_line_normal_case_keeps_the_strict_clause() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let lines = harness_prompt_lines(&permissive_cfg(), "");
         let review_line = lines.last().expect("at least the review line");
         assert!(
@@ -3854,6 +3858,7 @@ mod tests {
     /// to stay honest.
     #[test]
     fn review_roster_line_floor_seat_case_is_not_contradictory() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let cfg = CtxConfig {
             chat: crate::commands::ctx::config::ChatConfig {
                 model: Some("haiku".to_string()),
@@ -3884,6 +3889,7 @@ mod tests {
     /// soften to something that stays true.
     #[test]
     fn review_roster_line_configured_equals_seat_case_is_not_contradictory() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let cfg = CtxConfig {
             chat: crate::commands::ctx::config::ChatConfig {
                 model: Some("opus".to_string()),
@@ -3911,6 +3917,7 @@ mod tests {
     /// default to "haiku" (one tier below sonnet).
     #[test]
     fn harness_prompt_lines_review_line_threads_the_seat_for_claude() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let cfg = CtxConfig {
             chat: crate::commands::ctx::config::ChatConfig {
                 model: Some("sonnet".to_string()),

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -2548,6 +2548,14 @@ fn harness_roster_lines(
     let bin = cfg.agent_bin.as_deref();
     let mut lines: Vec<String> = Vec::new();
     let mut omitted_texts: Vec<String> = Vec::new();
+    // Issue #298 review follow-up: every name that earns its own per-adapter
+    // line above (ready-and-live, ready-and-unknown/fail-open, or ready()
+    // itself failed) -- never a disabled or confirmed-`Absent` one. Threaded
+    // into `review_roster_line` below so it never directs a review to a
+    // harness the roster above it just omitted, without a second probe: the
+    // liveness verdict already computed (and cached) in this same loop is
+    // reused, not recomputed, so the injected prefix stays byte-stable.
+    let mut roster_names: Vec<&str> = Vec::new();
     for (name, ctor) in ADAPTERS {
         let name: &str = name;
         let is_self = name == current_adapter;
@@ -2615,15 +2623,17 @@ fn harness_roster_lines(
                         "- {name}: enabled, ready{capacity_note} -- initiate with `zirv agent {name} \"<prompt>\"`{degraded}"
                     )
                 });
+                roster_names.push(name);
             }
             Err(err) => {
                 let reason = err.to_string();
                 let short = reason.lines().next().unwrap_or(&reason);
                 lines.push(format!("- {name}: installed? not ready ({short})"));
+                roster_names.push(name);
             }
         }
     }
-    if let Some(review_line) = review_roster_line(cfg) {
+    if let Some(review_line) = review_roster_line(cfg, &roster_names) {
         lines.push(review_line);
     }
     let omitted = omitted_texts.len();
@@ -2741,20 +2751,31 @@ pub fn policy_launch_args(
     out
 }
 
-/// The trailing "- code review: ..." line `harness_prompt_lines` appends
-/// after its per-harness lines: names every *enabled* harness's resolved
+/// The trailing "- code review: ..." line `harness_roster_lines` appends
+/// after its per-harness lines: names every *enabled, roster-listed*
+/// harness's resolved
 /// review model (an operator override or the ladder default, each marked as
 /// such) and states the rule that outranks any other model-routing guidance
 /// a session's own base prompt carries (see `ORCHESTRATOR_PROMPT`'s
 /// model-routing bullet in claude.rs, which now points back at this line).
-/// Returns `None` when no harness is enabled at all -- absence, not a line
-/// naming zero harnesses.
+/// Returns `None` when no harness is both enabled and roster-listed --
+/// absence, not a line naming zero harnesses.
 ///
 /// A disabled harness's entry is simply absent, the same "absence, not
-/// silence" rule its own per-harness line above follows -- readiness is
-/// deliberately not checked here (unlike the per-harness lines): the rule
-/// this line states applies to a harness the moment it is enabled, whether
-/// or not its binary happens to be on disk on this machine right now.
+/// silence" rule its own per-harness line above follows. Issue #298 review
+/// follow-up: so is a confirmed-`Absent` one -- `roster_names` is the set of
+/// adapter names that earned their own per-adapter line in this same pass
+/// (`harness_roster_lines`'s own liveness verdict, already computed and
+/// possibly cache-served, never re-probed here), and an entry is included
+/// only when it is both enabled *and* in that set. Before issue #298 this
+/// line checked only enablement -- "the rule applies to a harness the moment
+/// it is enabled, whether or not its binary happens to be on disk" -- but
+/// that reasoning stopped holding once the roster above it started omitting
+/// a confirmed-absent adapter's own line: naming a harness here that the
+/// roster never mentioned would send a review to something that cannot run.
+/// A harness that is merely not-ready (`adapter.ready()` failed) still gets
+/// its own "installed? not ready" line above, so it is still in
+/// `roster_names` and still named here -- unchanged from before.
 ///
 /// The rendered sentence must never be false for any entry. Two cases would
 /// otherwise make it false: a harness whose ladder default is already at
@@ -2776,13 +2797,13 @@ pub fn policy_launch_args(
 /// "never on an orchestrator seat's own model" to the weaker but always-true
 /// "never on a model above the named one" (the named model is by
 /// construction never ranked above the seat, so this holds in every case).
-fn review_roster_line(cfg: &CtxConfig) -> Option<String> {
+fn review_roster_line(cfg: &CtxConfig, roster_names: &[&str]) -> Option<String> {
     let bin = cfg.agent_bin.as_deref();
     let seat = cfg.chat.model.as_deref();
     let mut any_equals_seat = false;
     let entries: Vec<String> = ADAPTERS
         .iter()
-        .filter(|(name, _)| cfg.agents.is_enabled(name))
+        .filter(|(name, _)| cfg.agents.is_enabled(name) && roster_names.contains(name))
         .map(|(name, ctor)| {
             let adapter = if agent_bin_names_a_different_adapter(bin, name).is_some() {
                 ctor(None)
@@ -3669,6 +3690,75 @@ mod tests {
         );
     }
 
+    /// Review follow-up on issue #298: an adapter the roster above just
+    /// omitted for being confirmed `Absent` must not still be named in the
+    /// trailing review line either -- that would send a review to a harness
+    /// that cannot run, the one inconsistency the roster's own omission
+    /// rule exists to prevent. Claude stays live via a real stub on a `PATH`
+    /// that carries no `codex` binary and no known install root for it
+    /// either (an isolated `HOME`), so codex is confirmed absent, not
+    /// merely undetected.
+    #[test]
+    fn harness_prompt_lines_review_line_omits_a_confirmed_absent_adapter() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("claude"), "").expect("write stub");
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(dir.path().to_str().expect("utf8 tempdir path")),
+        )]);
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+
+        let lines = harness_prompt_lines(&permissive_cfg(), "");
+        let review_line = lines
+            .iter()
+            .find(|l| l.starts_with("- code review:"))
+            .expect("claude is live, so the review line must still exist");
+        assert!(review_line.contains("claude ->"), "got {review_line}");
+        assert!(
+            !review_line.contains("codex ->"),
+            "codex is confirmed absent, so it must not be named in the review line: \
+             {review_line}"
+        );
+    }
+
+    /// Positive case: with both adapters genuinely live, the liveness filter
+    /// above changes nothing -- the review line is exactly the text it
+    /// rendered before this fix existed (same substrings `harness_prompt_
+    /// lines_review_line_shows_computed_defaults_when_unset` already pins,
+    /// here with an explicit `PATH` stub so the claim holds independent of
+    /// whatever the machine running this suite happens to have installed).
+    #[test]
+    fn harness_prompt_lines_review_line_is_unchanged_when_both_adapters_are_live() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (name, _) in ADAPTERS {
+            std::fs::write(dir.path().join(name), "").expect("write stub");
+        }
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(dir.path().to_str().expect("utf8 tempdir path")),
+        )]);
+
+        let lines = harness_prompt_lines(&permissive_cfg(), "");
+        let review_line = lines.last().expect("at least the review line");
+        assert!(
+            review_line.contains("claude -> \"opus\" (default: one tier below the seat)"),
+            "got {review_line}"
+        );
+        assert!(
+            review_line.contains("codex -> \"gpt-5.6-terra\" (default: one tier below the seat)"),
+            "got {review_line}"
+        );
+        assert!(
+            review_line.contains("never on an orchestrator seat's own model"),
+            "got {review_line}"
+        );
+        assert!(
+            review_line.ends_with("This outranks any other model-routing guidance."),
+            "got {review_line}"
+        );
+    }
+
     /// Normal case (no entry's resolved model equals the orchestrator seat):
     /// the strict "never on an orchestrator seat's own model" clause is
     /// true for every entry, so it stays.
@@ -3860,10 +3950,11 @@ mod tests {
     /// Bug A (harness/model parity), reframed for issue #298: two harnesses
     /// in the identical state -- here, both absent, behind the same missing
     /// `agent_bin` override -- must be treated identically. Pre-#298 that
-    /// meant "the same annotated template"; now it means "both omitted",
-    /// which this pins down behaviourally: neither adapter gets a line, and
-    /// only the review line (which does not check presence -- see `review_
-    /// roster_line`'s own doc comment) survives.
+    /// meant "the same annotated template"; now it means "both omitted".
+    /// Review follow-up: with neither adapter earning its own roster line,
+    /// the trailing review line must vanish too -- it would otherwise be the
+    /// one line left directing a review to a harness the roster just said
+    /// nothing about.
     #[test]
     fn harness_prompt_lines_omits_both_adapters_equally_in_the_same_state() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -3883,8 +3974,9 @@ mod tests {
             "codex must be equally absent: {lines:?}"
         );
         assert!(
-            lines.iter().any(|l| l.starts_with("- code review:")),
-            "the review line does not check presence, so it must still survive: {lines:?}"
+            lines.is_empty(),
+            "with both adapters confirmed absent, the review line must not survive as the one \
+             line still naming them: {lines:?}"
         );
     }
 

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -1934,6 +1934,293 @@ pub fn program_is_present(program: &str) -> bool {
     }
 }
 
+/// Issue #298 ("capability-gated injection"): a cheap, filesystem/config-only
+/// verdict on whether a capability can actually be exercised right now -- no
+/// process spawn, no network call, no more than a few `stat`s. Only `Live`
+/// earns a line in the injected harness roster: `Absent` costs the session
+/// zero prompt bytes rather than annotating a capability it cannot use, and
+/// `Unknown` still renders the line, because a probe that could not decide
+/// must never cost a session a capability it might actually have -- the same
+/// fail-open discipline [`program_is_present`]'s own doc comment already
+/// holds `resolve_program`/`ready()` to.
+///
+/// Never assert absence in injected text: an omitted line is honest, but a
+/// rendered "not installed" claim can be wrong (see [`program_is_present`]'s
+/// own doc comment -- codex's real install root on this repo's own dev
+/// machine is one a plain `PATH` walk never reaches). `Absent`'s `String` is
+/// a diagnostic reason for an operator-facing surface (`compile --measure`'s
+/// own note column) only; nothing in this module ever prints it into a
+/// session's own prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Liveness {
+    Live,
+    Absent(String),
+    Unknown(String),
+}
+
+impl Liveness {
+    /// `Live` and `Unknown` both earn a line (fail-open); only a confirmed
+    /// `Absent` is omitted. See this type's own doc comment.
+    fn emits_line(&self) -> bool {
+        !matches!(self, Liveness::Absent(_))
+    }
+}
+
+/// `~/rest` -> the operator's real home directory joined with `rest`, using
+/// [`crate::utils::home_dir`] (`HOME`/`USERPROFILE`) -- deliberately the
+/// *operator's* environment, never anything a repo checkout can name (see
+/// [`known_install_roots`]'s own doc comment). Any other shape (no leading
+/// `~/`, or a home dir that cannot be resolved) is returned unchanged.
+fn expand_home(path: &str) -> PathBuf {
+    match path.strip_prefix("~/") {
+        Some(rest) => crate::utils::home_dir()
+            .map(|home| home.join(rest))
+            .unwrap_or_else(|_| PathBuf::from(path)),
+        None => PathBuf::from(path),
+    }
+}
+
+/// Extra install roots the issue #298 liveness probe consults for
+/// `adapter_name` after `PATH` and any `agent_bin` override come up empty --
+/// codex-cli on this repo's own dev machine lives at a real, working install
+/// outside `PATH` (see CLAUDE.md's "This Windows dev machine" section),
+/// which [`program_is_present`]'s plain `PATH` walk alone reports as absent.
+///
+/// A fixed Rust table, never a config read: repo-owned surfaces may only
+/// *narrow* what a probe can conclude (see `context.rs`'s own trust model),
+/// and an operator who wants a *different* install location already has
+/// `agent_bin` (itself `REPO_FORBIDDEN`) for that -- widening the search is
+/// the one thing a repo checkout must never be able to do on its own, so
+/// this function takes no `CtxConfig`/repo path at all, which is what keeps
+/// the acceptance criterion "a repo-layer config change cannot flip an
+/// adapter from `Absent` to `Live`" true by construction.
+fn known_install_roots(adapter_name: &str) -> &'static [&'static str] {
+    match adapter_name {
+        "codex" => &["~/AppData/Local/Programs/OpenAI/Codex/bin"],
+        _ => &[],
+    }
+}
+
+/// Every directory the widened liveness probe checks for `adapter_name`'s
+/// `program`: `PATH`, then [`known_install_roots`]. Empty when `program`
+/// already names a directory (an absolute/relative path, or an `agent_bin`
+/// override) -- matching [`program_is_present`]'s own convention that such a
+/// program is checked only at that one exact path.
+fn liveness_search_dirs(adapter_name: &str, program: &str) -> Vec<PathBuf> {
+    if program.is_empty() || program.contains('/') || program.contains('\\') {
+        return Vec::new();
+    }
+    let mut dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).collect())
+        .unwrap_or_default();
+    dirs.extend(
+        known_install_roots(adapter_name)
+            .iter()
+            .map(|root| expand_home(root)),
+    );
+    dirs
+}
+
+/// [`program_is_present`], widened with [`known_install_roots`]: reuses
+/// `program_is_present`'s own PATHEXT-aware Windows resolution and plain
+/// Unix file check unchanged -- handing it a full candidate path exercises
+/// exactly the same code path an absolute `agent_bin` override already does
+/// -- so widening only ever adds candidate *directories*; it never changes
+/// how a program name or an explicit override is resolved.
+fn program_is_present_widened(adapter_name: &str, program: &str) -> bool {
+    if program_is_present(program) {
+        return true;
+    }
+    liveness_search_dirs(adapter_name, program)
+        .iter()
+        .any(|dir| program_is_present(dir.join(program).to_string_lossy().as_ref()))
+}
+
+/// Whether any directory [`liveness_search_dirs`] walked for `program` could
+/// not be checked for a reason other than a clean "not found" -- permission
+/// denied, a `PATH` entry that turns out to be a plain file rather than a
+/// directory, or similar. Only ever consulted after
+/// [`program_is_present_widened`] has already come up empty: a probe this
+/// inconclusive must never be reported as a confirmed absence. Approximate
+/// by design (it stats the bare program name, not every `PATHEXT`
+/// candidate) -- this is a fail-open safety net, not the presence check
+/// itself.
+fn inconclusive_reason(adapter_name: &str, program: &str) -> Option<String> {
+    liveness_search_dirs(adapter_name, program)
+        .into_iter()
+        .find_map(|dir| {
+            let candidate = dir.join(program);
+            match std::fs::metadata(&candidate) {
+                Ok(_) => None,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                Err(e) => Some(format!("could not check '{}': {e}", candidate.display())),
+            }
+        })
+}
+
+/// The full issue #298 probe: `Live` when [`program_is_present_widened`]
+/// finds `program`, `Unknown` when the search could not reach a confident
+/// verdict (fail-open -- see [`Liveness`]'s own doc comment), `Absent`
+/// otherwise.
+fn liveness_probe(adapter_name: &str, program: &str) -> Liveness {
+    if program.is_empty() {
+        return Liveness::Absent("no program name".to_string());
+    }
+    if program_is_present_widened(adapter_name, program) {
+        return Liveness::Live;
+    }
+    match inconclusive_reason(adapter_name, program) {
+        Some(reason) => Liveness::Unknown(reason),
+        None => Liveness::Absent(format!("no '{program}' found")),
+    }
+}
+
+/// One cached liveness verdict, keyed by [`ProbeCache::key`] (adapter name,
+/// program, resolved `agent_bin` override). `checked_at` is a plain
+/// `now_secs()`-style timestamp the caller supplies -- this module reads no
+/// clock itself, the same discipline `compile.rs`/`memory::render_for_prompt`
+/// already hold to.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CachedProbe {
+    checked_at: u64,
+    live: bool,
+    reason: String,
+}
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct ProbeCacheFile {
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    entries: std::collections::BTreeMap<String, CachedProbe>,
+}
+
+const PROBE_CACHE_VERSION: u32 = 1;
+
+/// How long a cached `Live`/`Absent` verdict is trusted before [`ProbeCache`]
+/// re-probes. Issue #298 pairs this cache with issue 20 in the same batch (a
+/// byte-stable injected prefix across a session's turns, which upstream
+/// prompt caching depends on): a strictly per-`SessionId` cache would give
+/// zero reuse to the one launch path that most needs it (`run_loop` mints a
+/// fresh `SessionId` every cycle -- see `StateDir::adoption`'s own doc
+/// comment), so this cache is scoped per repository instead (see
+/// `StateDir::probes`) and self-corrects on this TTL rather than never at
+/// all.
+const PROBE_CACHE_TTL_SECS: u64 = 3600;
+
+/// A per-repository cache of [`Liveness`] probe verdicts, backed by one JSON
+/// file under the state dir (`StateDir::probes`). Missing or unparseable
+/// (including a version mismatch) reads back empty, never an error: a cache
+/// miss just means the next probe is a real one, exactly as if the cache did
+/// not exist. A failed *write* is silently ignored for the same reason
+/// `score.rs::save_checkpoint` already is -- a cache that cannot be written
+/// costs the next call a real probe, which is exactly what would happen
+/// without a cache at all.
+pub struct ProbeCache {
+    path: Option<PathBuf>,
+    now: u64,
+    file: ProbeCacheFile,
+    dirty: bool,
+}
+
+impl ProbeCache {
+    /// Reads `<state>/probes/<repo_slug>.json`. `now` is stored for TTL
+    /// comparisons and for stamping any entry this instance goes on to
+    /// (re)probe.
+    pub fn load(state: &super::state::StateDir, repo_slug: &str, now: u64) -> Self {
+        let path = state.probes().join(format!("{repo_slug}.json"));
+        let file = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|text| serde_json::from_str::<ProbeCacheFile>(&text).ok())
+            .filter(|file| file.version == PROBE_CACHE_VERSION)
+            .unwrap_or_default();
+        Self {
+            path: Some(path),
+            now,
+            file,
+            dirty: false,
+        }
+    }
+
+    fn key(name: &str, program: &str, bin: Option<&str>) -> String {
+        format!("{name}\u{1}{program}\u{1}{}", bin.unwrap_or(""))
+    }
+
+    /// The cached verdict for `key` when both present and inside
+    /// `PROBE_CACHE_TTL_SECS`; otherwise runs `probe`, records the result
+    /// (unless it is `Unknown` -- an inconclusive probe is never frozen into
+    /// the cache, so the very next call gets a fresh look rather than a
+    /// stale guess), and returns it.
+    fn get_or_probe(&mut self, key: &str, probe: impl FnOnce() -> Liveness) -> Liveness {
+        if let Some(cached) = self.file.entries.get(key)
+            && self.now.saturating_sub(cached.checked_at) <= PROBE_CACHE_TTL_SECS
+        {
+            return if cached.live {
+                Liveness::Live
+            } else {
+                Liveness::Absent(cached.reason.clone())
+            };
+        }
+        let verdict = probe();
+        match &verdict {
+            Liveness::Live => {
+                self.file.entries.insert(
+                    key.to_string(),
+                    CachedProbe {
+                        checked_at: self.now,
+                        live: true,
+                        reason: String::new(),
+                    },
+                );
+                self.dirty = true;
+            }
+            Liveness::Absent(reason) => {
+                self.file.entries.insert(
+                    key.to_string(),
+                    CachedProbe {
+                        checked_at: self.now,
+                        live: false,
+                        reason: reason.clone(),
+                    },
+                );
+                self.dirty = true;
+            }
+            Liveness::Unknown(_) => {}
+        }
+        verdict
+    }
+
+    /// Best-effort, the same shape `score.rs::save_checkpoint` already uses:
+    /// write to a process-unique temp file, then rename into place, so a
+    /// process killed mid-write leaves the previous cache file intact rather
+    /// than a truncated one. A no-op when nothing changed (`load` alone
+    /// never dirties the cache) or when this instance has no backing path
+    /// (`ProbeCache::disabled`).
+    pub fn save(&self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(path) = &self.path else {
+            return;
+        };
+        let file = ProbeCacheFile {
+            version: PROBE_CACHE_VERSION,
+            entries: self.file.entries.clone(),
+        };
+        let Ok(json) = serde_json::to_string(&file) else {
+            return;
+        };
+        let Some(dir) = path.parent() else {
+            return;
+        };
+        let _ = super::state::create_private_dir_all(dir);
+        let staged = dir.join(format!("{}.tmp", std::process::id()));
+        if super::state::write_private(&staged, &json).is_ok() {
+            let _ = std::fs::rename(&staged, path);
+        }
+    }
+}
+
 /// An adapter constructor: the same shape `ClaudeAdapter::new` and
 /// `CodexAdapter::new` already share, named so `ADAPTERS` reads as a table
 /// rather than a wall of type punctuation.
@@ -2186,17 +2473,24 @@ pub fn available_adapter_names(cfg: &CtxConfig) -> Vec<&'static str> {
 ///
 /// Walks `ADAPTERS` in registry order, same as `readiness_note`, but reports
 /// per-adapter gate state too (`readiness_note` only ever speaks about
-/// installed-but-not-ready or degraded adapters, never a disabled one): a
-/// disabled adapter gets its own line naming where the disable came from
-/// (`AgentState::location`) rather than silently vanishing from the roster,
-/// so an operator reading the prompt can tell "not offered because disabled
-/// in .zirv/.settings.toml" from "not offered because not installed".
+/// installed-but-not-ready or degraded adapters, never a disabled one).
+///
+/// Issue #298 ("capability-gated injection"): a disabled adapter, or one
+/// whose [`liveness_probe`] comes back confirmed [`Liveness::Absent`], gets
+/// no line at all -- omission, never an annotated "disabled"/"not
+/// installed" claim spending prompt bytes on a capability that cannot run
+/// (and, for "not installed" specifically, a claim [`program_is_present`]'s
+/// own doc comment already admits can be wrong). `Liveness::Unknown` still
+/// renders the normal "ready" line (fail-open: a probe that cannot decide
+/// must never cost the session a capability it might actually have). The
+/// trailing "- code review: ..." line is unaffected -- see `review_roster_
+/// line`'s own doc comment for why it deliberately does not check presence.
 ///
 /// `ready()` alone is fail-open for a binary that simply is not there (see
-/// [`program_is_present`]'s own doc comment), so a `ready()`-Ok adapter is
-/// checked again against the real filesystem before its line may claim
-/// "ready" and hand out the `zirv agent` invitation -- otherwise it reads as
-/// "not installed" instead, exactly like a genuinely unready one.
+/// [`program_is_present`]'s own doc comment), so a `ready()`-Ok adapter's
+/// [`Liveness`] is checked again against the real filesystem (widened with
+/// [`known_install_roots`]) before its line may claim "ready" and hand out
+/// the `zirv agent` invitation.
 ///
 /// `cfg.agent_bin` is one global override (see `agent_bin_names_a_different_
 /// adapter`'s own doc comment), so it is never handed to an adapter whose own
@@ -2205,79 +2499,140 @@ pub fn available_adapter_names(cfg: &CtxConfig) -> Vec<&'static str> {
 /// binary's presence verdict onto codex's line (and vice versa) whenever an
 /// operator's `agent_bin` named one specific agent -- either wrongly
 /// advertising `zirv agent codex` on the strength of claude's binary, or, for
-/// a not-yet-real wrapper path, wrongly marking every *other* adapter "not
-/// installed" too. `agent_bin_names_a_different_adapter` returning `Some`
-/// means `bin`'s basename names a *different* registered adapter than the one
+/// a not-yet-real wrapper path, wrongly omitting every *other* adapter's
+/// line too. `agent_bin_names_a_different_adapter` returning `Some` means
+/// `bin`'s basename names a *different* registered adapter than the one
 /// about to be built, so that adapter is built with `None` instead and its
 /// presence is judged from its own default program name, exactly as if no
 /// override were configured at all.
+///
+/// Test-only: every production caller has a `StateDir` in hand and goes
+/// through [`harness_prompt_lines_cached`] instead (`compile::compile_with_
+/// harness_roster`'s only real call site), so this uncached, `Vec<String>`-
+/// returning shape now exists purely as the simpler entry point the bulk of
+/// this module's own tests were written against before the cache existed.
+#[cfg(test)]
 pub fn harness_prompt_lines(cfg: &CtxConfig, current_adapter: &str) -> Vec<String> {
-    let bin = cfg.agent_bin.as_deref();
-    let mut lines: Vec<String> = ADAPTERS
-        .iter()
-        .map(|(name, ctor)| {
-            let name: &str = name;
-            let is_self = name == current_adapter;
-            let (enabled, location) = cfg
-                .agents
-                .states()
-                .find(|(n, _)| *n == name)
-                .map(|(_, s)| (s.enabled, s.location()))
-                .unwrap_or((true, "default".to_string()));
-            if !enabled {
-                return format!("- {name}: disabled ({location})");
-            }
+    harness_roster_lines(cfg, current_adapter, None).lines
+}
 
-            let adapter = if agent_bin_names_a_different_adapter(bin, name).is_some() {
-                ctor(None)
-            } else {
-                ctor(bin)
-            };
-            match adapter.ready() {
-                Ok(()) => {
-                    let program = adapter.program();
-                    if !program_is_present(program) {
-                        return format!("- {name}: not installed (no '{program}' found)");
+/// As [`harness_prompt_lines`], but reusing (and updating) `cache`'s probe
+/// verdicts instead of probing fresh on every call -- `compile::compile_
+/// with_harness_roster`'s own entry point. See [`ProbeCache`]'s own doc
+/// comment for the scope/TTL it substitutes for a literal per-session cache.
+pub fn harness_prompt_lines_cached(
+    cfg: &CtxConfig,
+    current_adapter: &str,
+    cache: &mut ProbeCache,
+) -> HarnessRosterReport {
+    harness_roster_lines(cfg, current_adapter, Some(cache))
+}
+
+/// The per-adapter roster lines both entry points above share, plus issue
+/// #298's own measurement data: how many adapter lines were omitted for a
+/// confirmed-`Absent` `Liveness` (or a disabled adapter), and how many bytes
+/// those lines would have cost had they still been rendered the pre-#298 way
+/// (`"- name: disabled (...)"` / `"- name: not installed (...)"`) -- the
+/// success metric `zirv ctx compile --measure` reports.
+pub struct HarnessRosterReport {
+    pub lines: Vec<String>,
+    pub omitted: usize,
+    pub omitted_bytes: usize,
+}
+
+fn harness_roster_lines(
+    cfg: &CtxConfig,
+    current_adapter: &str,
+    mut cache: Option<&mut ProbeCache>,
+) -> HarnessRosterReport {
+    let bin = cfg.agent_bin.as_deref();
+    let mut lines: Vec<String> = Vec::new();
+    let mut omitted_texts: Vec<String> = Vec::new();
+    for (name, ctor) in ADAPTERS {
+        let name: &str = name;
+        let is_self = name == current_adapter;
+        let (enabled, location) = cfg
+            .agents
+            .states()
+            .find(|(n, _)| *n == name)
+            .map(|(_, s)| (s.enabled, s.location()))
+            .unwrap_or((true, "default".to_string()));
+        if !enabled {
+            // Issue #298: absence, not annotation -- `location` is recorded
+            // only for `compile --measure`'s own note column, never for a
+            // session's own prompt.
+            omitted_texts.push(format!("- {name}: disabled ({location})"));
+            continue;
+        }
+
+        let names_other = agent_bin_names_a_different_adapter(bin, name).is_some();
+        let adapter = if names_other { ctor(None) } else { ctor(bin) };
+        match adapter.ready() {
+            Ok(()) => {
+                let program = adapter.program();
+                let resolved_bin = if names_other { None } else { bin };
+                let verdict = match cache.as_deref_mut() {
+                    Some(cache) => {
+                        let key = ProbeCache::key(name, program, resolved_bin);
+                        cache.get_or_probe(&key, || liveness_probe(name, program))
                     }
-                    let missing = missing_capability_labels(adapter.capabilities());
-                    let degraded = if missing.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" (degraded: no {})", join_with_or(&missing))
-                    };
-                    // Repo `.settings.toml` (or the operator, or the
-                    // environment) may mark a harness capacity-limited; the
-                    // roster line carries that forward so an orchestrator
-                    // routes only small, bounded briefs its way -- both for
-                    // reviews and for `zirv agent` delegations (see
-                    // `HARNESS_PROMPT`'s final paragraph).
-                    let capacity_note = if cfg.agents.is_capacity_small(name) {
-                        " -- small tasks only"
-                    } else {
-                        ""
-                    };
-                    if is_self {
-                        format!(
-                            "- {name}: enabled, ready{capacity_note} (this session's harness){degraded}"
-                        )
-                    } else {
-                        format!(
-                            "- {name}: enabled, ready{capacity_note} -- initiate with `zirv agent {name} \"<prompt>\"`{degraded}"
-                        )
-                    }
+                    None => liveness_probe(name, program),
+                };
+                if let Liveness::Unknown(reason) = &verdict {
+                    eprintln!(
+                        "zirv ctx: liveness probe for '{name}' inconclusive ({reason}); \
+                         treating it as live rather than costing the session a capability \
+                         it might actually have"
+                    );
                 }
-                Err(err) => {
-                    let reason = err.to_string();
-                    let short = reason.lines().next().unwrap_or(&reason);
-                    format!("- {name}: installed? not ready ({short})")
+                if !verdict.emits_line() {
+                    omitted_texts.push(format!("- {name}: not installed (no '{program}' found)"));
+                    continue;
                 }
+                let missing = missing_capability_labels(adapter.capabilities());
+                let degraded = if missing.is_empty() {
+                    String::new()
+                } else {
+                    format!(" (degraded: no {})", join_with_or(&missing))
+                };
+                // Repo `.settings.toml` (or the operator, or the
+                // environment) may mark a harness capacity-limited; the
+                // roster line carries that forward so an orchestrator
+                // routes only small, bounded briefs its way -- both for
+                // reviews and for `zirv agent` delegations (see
+                // `HARNESS_PROMPT`'s final paragraph).
+                let capacity_note = if cfg.agents.is_capacity_small(name) {
+                    " -- small tasks only"
+                } else {
+                    ""
+                };
+                lines.push(if is_self {
+                    format!(
+                        "- {name}: enabled, ready{capacity_note} (this session's harness){degraded}"
+                    )
+                } else {
+                    format!(
+                        "- {name}: enabled, ready{capacity_note} -- initiate with `zirv agent {name} \"<prompt>\"`{degraded}"
+                    )
+                });
             }
-        })
-        .collect();
+            Err(err) => {
+                let reason = err.to_string();
+                let short = reason.lines().next().unwrap_or(&reason);
+                lines.push(format!("- {name}: installed? not ready ({short})"));
+            }
+        }
+    }
     if let Some(review_line) = review_roster_line(cfg) {
         lines.push(review_line);
     }
-    lines
+    let omitted = omitted_texts.len();
+    let omitted_bytes = omitted_texts.iter().map(|line| line.len() + 1).sum();
+    HarnessRosterReport {
+        lines,
+        omitted,
+        omitted_bytes,
+    }
 }
 
 /// The resolved review-model choice for one enabled harness: either the
@@ -3211,8 +3566,24 @@ mod tests {
         );
     }
 
+    /// Issue #298: a `Live` adapter (its own default program name genuinely
+    /// present, here via a restricted `PATH` carrying a stub for each --
+    /// `permissive_cfg`/`CtxConfig::default` alone says nothing about the
+    /// real machine's `PATH`, so this test must not depend on it) earns a
+    /// line; an `Absent` one would not, so pinning "one line per adapter" to
+    /// mean anything under this issue's omission rule requires every
+    /// adapter to be genuinely live first.
     #[test]
     fn harness_prompt_lines_returns_one_line_per_registered_adapter() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (name, _) in ADAPTERS {
+            std::fs::write(dir.path().join(name), "").expect("write stub");
+        }
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(dir.path().to_str().expect("utf8 tempdir path")),
+        )]);
+
         let lines = harness_prompt_lines(&permissive_cfg(), "");
         // One line per adapter, plus one trailing "- code review: ..." line
         // naming every enabled harness's resolved review model.
@@ -3395,8 +3766,15 @@ mod tests {
 
     /// No enabled harness at all: `review_roster_line` must not emit a
     /// line naming zero harnesses -- absence, not an empty-handed line.
+    /// Issue #298 widens the claim to the whole roster: with both adapters
+    /// disabled (so their own per-adapter lines are omitted too, the same
+    /// "absence, not annotation" rule as an absent binary), `harness_prompt_
+    /// lines` returns a genuinely empty vec -- the precondition `prompt::
+    /// compose`'s own `!harness_lines.is_empty()` gate relies on to skip the
+    /// whole "zirv harness roster (session)" header rather than render one
+    /// with nothing under it.
     #[test]
-    fn harness_prompt_lines_omits_the_review_line_when_no_harness_is_enabled() {
+    fn harness_prompt_lines_returns_nothing_when_no_harness_is_enabled() {
         let repo = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(repo.path().join(".zirv")).expect("mkdir");
         std::fs::write(
@@ -3414,17 +3792,19 @@ mod tests {
         };
         let lines = harness_prompt_lines(&cfg, "");
         assert!(
-            !lines.iter().any(|l| l.starts_with("- code review:")),
-            "no harness enabled: there must be no review line at all: {lines:?}"
+            lines.is_empty(),
+            "no harness enabled: the whole roster must be empty, not just the review line: \
+             {lines:?}"
         );
     }
 
     /// The one call site (`prompt::compose` for an Orchestrator session) must
-    /// never learn about a disabled adapter as if it were offered for
-    /// delegation: a disabled line names where the disable came from and
-    /// never the `zirv agent <name>` invitation.
+    /// never learn about a disabled adapter at all, whether as an annotated
+    /// "disabled" line or as the `zirv agent <name>` invitation -- issue
+    /// #298: absence, not annotation, the same rule an absent binary gets
+    /// below.
     #[test]
-    fn harness_prompt_lines_names_the_disabled_adapter_and_its_location() {
+    fn harness_prompt_lines_omits_the_disabled_adapter_entirely() {
         let repo = tempfile::tempdir().expect("tempdir");
         let home = tempfile::tempdir().expect("tempdir");
         let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
@@ -3439,29 +3819,26 @@ mod tests {
         };
 
         let lines = harness_prompt_lines(&cfg, "");
-        let codex_line = lines
-            .iter()
-            .find(|l| l.starts_with("- codex:"))
-            .expect("codex line present");
-        assert!(codex_line.contains("disabled"), "got {codex_line}");
         assert!(
-            codex_line.contains("ZIRV_AGENT_CODEX_ENABLED"),
-            "names the environment source: {codex_line}"
+            !lines.iter().any(|l| l.starts_with("- codex:")),
+            "a disabled adapter must contribute no line at all: {lines:?}"
         );
         assert!(
-            !codex_line.contains("zirv agent codex"),
-            "a disabled adapter is never offered for delegation: {codex_line}"
+            !lines.iter().any(|l| l.contains("zirv agent codex")),
+            "a disabled adapter is never offered for delegation: {lines:?}"
         );
     }
 
-    /// Finding 1: `ready()` alone is fail-open for a program that simply is
-    /// not on disk anywhere -- `resolve_program` deliberately returns `Ok`
-    /// for it (see its own doc comment), and several other call sites lean on
-    /// that. `harness_prompt_lines` must not repeat the same fail-open claim
-    /// in a roster line an orchestrator can act on immediately: a name that
-    /// resolves to nothing must read as not installed, not ready.
+    /// Finding 1 (pre-#298): `ready()` alone is fail-open for a program that
+    /// simply is not on disk anywhere -- `resolve_program` deliberately
+    /// returns `Ok` for it (see its own doc comment), and several other call
+    /// sites lean on that. Issue #298 changes what a resolved-but-absent
+    /// program earns from "not installed" annotation to no line at all: a
+    /// name that resolves to nothing must cost the session zero bytes, not
+    /// spend them on a claim `program_is_present`'s own doc comment already
+    /// admits can be wrong.
     #[test]
-    fn harness_prompt_lines_reports_not_installed_when_the_resolved_program_is_absent() {
+    fn harness_prompt_lines_omits_the_line_when_the_resolved_program_is_absent() {
         let dir = tempfile::tempdir().expect("tempdir");
         let missing = dir.path().join("nonexistent-agent-binary");
         let cfg = CtxConfig {
@@ -3470,26 +3847,25 @@ mod tests {
         };
 
         let lines = harness_prompt_lines(&cfg, "");
-        let claude_line = lines
-            .iter()
-            .find(|l| l.starts_with("- claude:"))
-            .expect("claude line present");
-        assert!(claude_line.contains("not installed"), "got {claude_line}");
         assert!(
-            !claude_line.contains("zirv agent"),
-            "a binary that is not there must never be offered for delegation: {claude_line}"
+            !lines.iter().any(|l| l.starts_with("- claude:")),
+            "an absent binary must contribute no line at all: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("zirv agent")),
+            "a binary that is not there must never be offered for delegation: {lines:?}"
         );
     }
 
-    /// Bug A (harness/model parity): two harnesses in the identical state --
-    /// here, both absent, behind the same missing `agent_bin` override --
-    /// must render the identical templated line, differing only by their own
-    /// name. No adapter may get softer or harsher wording than another for
-    /// the same underlying fact; `harness_prompt_lines` renders every entry
-    /// through one shared format, never an adapter-specific one, and this
-    /// pins that down behaviourally rather than only by code inspection.
+    /// Bug A (harness/model parity), reframed for issue #298: two harnesses
+    /// in the identical state -- here, both absent, behind the same missing
+    /// `agent_bin` override -- must be treated identically. Pre-#298 that
+    /// meant "the same annotated template"; now it means "both omitted",
+    /// which this pins down behaviourally: neither adapter gets a line, and
+    /// only the review line (which does not check presence -- see `review_
+    /// roster_line`'s own doc comment) survives.
     #[test]
-    fn harness_prompt_lines_render_the_same_template_for_two_adapters_in_the_same_state() {
+    fn harness_prompt_lines_omits_both_adapters_equally_in_the_same_state() {
         let dir = tempfile::tempdir().expect("tempdir");
         let missing = dir.path().join("nonexistent-agent-binary");
         let cfg = CtxConfig {
@@ -3498,21 +3874,17 @@ mod tests {
         };
 
         let lines = harness_prompt_lines(&cfg, "");
-        let claude_line = lines
-            .iter()
-            .find(|l| l.starts_with("- claude:"))
-            .expect("claude line present");
-        let codex_line = lines
-            .iter()
-            .find(|l| l.starts_with("- codex:"))
-            .expect("codex line present");
-
-        let normalize = |line: &str, name: &str| line.replacen(name, "{name}", 1);
-        assert_eq!(
-            normalize(claude_line, "claude"),
-            normalize(codex_line, "codex"),
-            "both adapters are equally absent and must render the identical template, \
-             differing only by name:\nclaude: {claude_line}\ncodex: {codex_line}"
+        assert!(
+            !lines.iter().any(|l| l.starts_with("- claude:")),
+            "claude must be equally absent: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.starts_with("- codex:")),
+            "codex must be equally absent: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.starts_with("- code review:")),
+            "the review line does not check presence, so it must still survive: {lines:?}"
         );
     }
 
@@ -3595,17 +3967,304 @@ mod tests {
             "claude's own named override is present: {claude_line}"
         );
 
-        let codex_line = lines
-            .iter()
-            .find(|l| l.starts_with("- codex:"))
-            .expect("codex line present");
         assert!(
-            !codex_line.contains("zirv agent codex"),
-            "agent_bin naming claude must never make codex's line claim delegable: {codex_line}"
+            !lines.iter().any(|l| l.starts_with("- codex:")),
+            "codex is judged on its own (absent) binary, not claude's override, so issue #298 \
+             omits its line entirely rather than claiming 'not installed': {lines:?}"
         );
         assert!(
-            codex_line.contains("not installed"),
-            "codex is judged on its own (absent) binary, not claude's override: {codex_line}"
+            !lines.iter().any(|l| l.contains("zirv agent codex")),
+            "agent_bin naming claude must never make codex's line claim delegable: {lines:?}"
+        );
+    }
+
+    // -- issue #298 ("capability-gated injection"): the Liveness predicate,
+    // the widened install-root probe, and the per-repository ProbeCache --
+
+    #[test]
+    fn liveness_emits_line_for_live_and_unknown_but_not_absent() {
+        assert!(Liveness::Live.emits_line());
+        assert!(Liveness::Unknown("inconclusive".to_string()).emits_line());
+        assert!(!Liveness::Absent("no such binary".to_string()).emits_line());
+    }
+
+    /// The widened probe finds codex's real Windows install root even
+    /// though it is nowhere on `PATH` -- CLAUDE.md's own "This Windows dev
+    /// machine" note: `program_is_present` alone reports absent, but
+    /// `program_is_present_widened`/`liveness_probe` widen the search and
+    /// report `Live`.
+    #[test]
+    fn liveness_probe_finds_codex_via_its_known_install_root_when_absent_from_path() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let root = home.path().join("AppData/Local/Programs/OpenAI/Codex/bin");
+        std::fs::create_dir_all(&root).expect("mkdir");
+        std::fs::write(root.join("codex"), "").expect("write stub");
+        let empty_path_dir = tempfile::tempdir().expect("tempdir");
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(empty_path_dir.path().to_str().expect("utf8 path")),
+        )]);
+
+        assert!(
+            !program_is_present("codex"),
+            "the plain PATH-only check must not see it"
+        );
+        assert_eq!(liveness_probe("codex", "codex"), Liveness::Live);
+        assert!(
+            known_install_roots("claude").is_empty(),
+            "claude has no known install root of its own, so this stub must not leak into it"
+        );
+    }
+
+    /// A `PATH` entry that turns out to be a plain file, not a directory,
+    /// makes the probe genuinely unable to tell -- `Unknown`, never a
+    /// confirmed `Absent`.
+    #[test]
+    fn liveness_probe_is_unknown_when_a_path_entry_is_not_a_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let not_a_directory = dir.path().join("not-a-directory-file");
+        std::fs::write(&not_a_directory, "").expect("write");
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(not_a_directory.to_str().expect("utf8 path")),
+        )]);
+
+        let verdict = liveness_probe("claude", "claude");
+        assert!(
+            matches!(verdict, Liveness::Unknown(_)),
+            "an inconclusive PATH entry must never be reported as a confirmed absence: \
+             {verdict:?}"
+        );
+    }
+
+    /// Acceptance criterion: a repo-layer config change cannot flip an
+    /// adapter from `Absent` to `Live`. True by construction --
+    /// `known_install_roots`/`liveness_probe` take no `CtxConfig`/repo path
+    /// at all -- pinned down behaviourally: codex's line is identical
+    /// whether the repo carries no `.zirv/.settings.toml` or a real,
+    /// non-empty one, as long as its known install root holds a stub.
+    #[test]
+    fn known_install_root_liveness_does_not_depend_on_any_repo_config() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let root = home.path().join("AppData/Local/Programs/OpenAI/Codex/bin");
+        std::fs::create_dir_all(&root).expect("mkdir");
+        std::fs::write(root.join("codex"), "").expect("write stub");
+        let empty_path_dir = tempfile::tempdir().expect("tempdir");
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(empty_path_dir.path().to_str().expect("utf8 path")),
+        )]);
+
+        let plain_repo = tempfile::tempdir().expect("tempdir");
+        let configured_repo = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(configured_repo.path().join(".zirv")).expect("mkdir");
+        std::fs::write(
+            configured_repo.path().join(".zirv/.settings.toml"),
+            "[agents.claude]\ncapacity = \"small\"\n",
+        )
+        .expect("write");
+        let empty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+        for repo in [plain_repo.path(), configured_repo.path()] {
+            let cfg = CtxConfig {
+                agents: crate::settings::AgentGate::load(repo, &|k| empty.get(k).cloned())
+                    .expect("load"),
+                ..CtxConfig::default()
+            };
+            let lines = harness_prompt_lines(&cfg, "");
+            assert!(
+                lines
+                    .iter()
+                    .any(|l| l.starts_with("- codex:") && l.contains("zirv agent codex")),
+                "codex must be live via its known install root regardless of repo config \
+                 ({}): {lines:?}",
+                repo.display()
+            );
+        }
+    }
+
+    #[test]
+    fn probe_cache_get_or_probe_reuses_a_cached_verdict_without_reprobing() {
+        let mut cache = ProbeCache {
+            path: None,
+            now: 1_000,
+            file: ProbeCacheFile::default(),
+            dirty: false,
+        };
+        let calls = std::cell::Cell::new(0);
+        let first = cache.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Live
+        });
+        assert_eq!(first, Liveness::Live);
+        assert_eq!(calls.get(), 1);
+
+        let second = cache.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Absent("should not run".to_string())
+        });
+        assert_eq!(
+            second,
+            Liveness::Live,
+            "the cached verdict must be reused, not a fresh probe"
+        );
+        assert_eq!(
+            calls.get(),
+            1,
+            "a second call within the TTL must not re-probe"
+        );
+    }
+
+    #[test]
+    fn probe_cache_reprobes_after_the_ttl_elapses() {
+        let mut cache = ProbeCache {
+            path: None,
+            now: 1_000,
+            file: ProbeCacheFile::default(),
+            dirty: false,
+        };
+        let _ = cache.get_or_probe("k", || Liveness::Live);
+
+        cache.now += PROBE_CACHE_TTL_SECS + 1;
+        let calls = std::cell::Cell::new(0);
+        let verdict = cache.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Absent("gone".to_string())
+        });
+        assert_eq!(calls.get(), 1, "past the TTL, get_or_probe must re-probe");
+        assert_eq!(verdict, Liveness::Absent("gone".to_string()));
+    }
+
+    /// An inconclusive probe must never be frozen into the cache: the very
+    /// next call gets a fresh look rather than a stale guess.
+    #[test]
+    fn probe_cache_never_freezes_an_unknown_verdict() {
+        let mut cache = ProbeCache {
+            path: None,
+            now: 1_000,
+            file: ProbeCacheFile::default(),
+            dirty: false,
+        };
+        let first = cache.get_or_probe("k", || Liveness::Unknown("inconclusive".to_string()));
+        assert_eq!(first, Liveness::Unknown("inconclusive".to_string()));
+        assert!(
+            !cache.dirty,
+            "an Unknown verdict must never be written to the cache"
+        );
+
+        let calls = std::cell::Cell::new(0);
+        let second = cache.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Live
+        });
+        assert_eq!(
+            calls.get(),
+            1,
+            "an Unknown verdict must not be cached, so the next call re-probes"
+        );
+        assert_eq!(second, Liveness::Live);
+    }
+
+    #[test]
+    fn probe_cache_save_and_load_round_trips_a_live_verdict() {
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let state =
+            crate::commands::ctx::state::StateDir::from_root(state_dir.path().to_path_buf());
+
+        let mut cache = ProbeCache::load(&state, "some-repo", 1_000);
+        let first = cache.get_or_probe("k", || Liveness::Live);
+        assert_eq!(first, Liveness::Live);
+        cache.save();
+
+        let mut reloaded = ProbeCache::load(&state, "some-repo", 1_000);
+        let calls = std::cell::Cell::new(0);
+        let second = reloaded.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Absent("should not run".to_string())
+        });
+        assert_eq!(
+            second,
+            Liveness::Live,
+            "a saved verdict must be read back on the next load"
+        );
+        assert_eq!(calls.get(), 0, "a warm cache must not re-probe");
+    }
+
+    #[test]
+    fn probe_cache_load_with_no_file_yet_probes_fresh() {
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let state =
+            crate::commands::ctx::state::StateDir::from_root(state_dir.path().to_path_buf());
+
+        let mut cache = ProbeCache::load(&state, "never-seen-repo", 1_000);
+        let calls = std::cell::Cell::new(0);
+        let verdict = cache.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Live
+        });
+        assert_eq!(calls.get(), 1);
+        assert_eq!(verdict, Liveness::Live);
+    }
+
+    /// A cache file that is not valid JSON (or not this version) must read
+    /// back empty, never error: a cache miss is exactly as if the cache did
+    /// not exist.
+    #[test]
+    fn probe_cache_load_ignores_an_unparseable_file() {
+        let state_dir = tempfile::tempdir().expect("tempdir");
+        let state =
+            crate::commands::ctx::state::StateDir::from_root(state_dir.path().to_path_buf());
+        std::fs::create_dir_all(state.probes()).expect("mkdir");
+        std::fs::write(state.probes().join("repo.json"), "not json").expect("write");
+
+        let mut cache = ProbeCache::load(&state, "repo", 1_000);
+        let calls = std::cell::Cell::new(0);
+        let verdict = cache.get_or_probe("k", || {
+            calls.set(calls.get() + 1);
+            Liveness::Live
+        });
+        assert_eq!(
+            calls.get(),
+            1,
+            "an unparseable cache file must not error out, just re-probe"
+        );
+        assert_eq!(verdict, Liveness::Live);
+    }
+
+    /// The success metric the issue's own probe cache exists for: a second
+    /// `harness_prompt_lines_cached` call against the same cache must
+    /// deliver byte-identical lines even after the underlying filesystem
+    /// truth changes mid-session -- the injected prompt prefix stays stable
+    /// across a session's turns.
+    #[test]
+    fn harness_prompt_lines_cached_survives_a_mid_session_filesystem_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (name, _) in ADAPTERS {
+            std::fs::write(dir.path().join(name), "").expect("write stub");
+        }
+        let _path_guard = crate::commands::ctx::testenv::VarGuard::set(&[(
+            "PATH",
+            Some(dir.path().to_str().expect("utf8 tempdir path")),
+        )]);
+        let cfg = permissive_cfg();
+        let mut cache = ProbeCache {
+            path: None,
+            now: 1_000,
+            file: ProbeCacheFile::default(),
+            dirty: false,
+        };
+
+        let first = harness_prompt_lines_cached(&cfg, "", &mut cache).lines;
+        for (name, _) in ADAPTERS {
+            std::fs::remove_file(dir.path().join(name)).expect("remove stub");
+        }
+        let second = harness_prompt_lines_cached(&cfg, "", &mut cache).lines;
+        assert_eq!(
+            first, second,
+            "a cached verdict must survive a mid-session change on disk, not flap the roster: \
+             first={first:?} second={second:?}"
         );
     }
 

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -916,6 +916,19 @@ pub trait AgentAdapter: std::fmt::Debug {
     fn detect(&self, command: &[String]) -> bool;
 
     fn headless_cmd(&self, prompt: &str, session: &SessionId, extra: &[String]) -> Command;
+    /// Builds a headless prompt against an existing conversation. `prompt`
+    /// is `None` when the caller will deliver it on stdin. The default is an
+    /// honest refusal: adapters must not guess a resume flag or claim stdin
+    /// support they have not verified.
+    fn headless_resume_cmd(
+        &self,
+        prompt: Option<&str>,
+        session_id: &str,
+        extra: &[String],
+    ) -> Option<Command> {
+        let _ = (prompt, session_id, extra);
+        None
+    }
     fn interactive_cmd(&self, initial_prompt: Option<&str>, extra: &[String]) -> Command;
     /// Builds the judgment/distiller model child's command. `model` is empty
     /// when neither the operator's own config (`handoff.model`/`optimize.

--- a/src/commands/ctx/adapters/mod.rs
+++ b/src/commands/ctx/adapters/mod.rs
@@ -7,8 +7,52 @@ pub mod codex;
 use super::CtxResult;
 use super::config::CtxConfig;
 use super::event::{
-    Capabilities, NormalizedEvent, SessionId, SessionRef, StructuralContext, TranscriptUsage,
+    Capabilities, NormalizedEvent, ProviderErrorClass, SessionId, SessionRef, StructuralContext,
+    TranscriptUsage,
 };
+
+/// Empirical overflow wording for the two provider families zirv supervises.
+/// These are the Anthropic and OpenAI entries from pi's live-provider table;
+/// broader provider entries stay out until zirv can observe those providers.
+const PROVIDER_OVERFLOW_PATTERNS: &[&str] = &[
+    "prompt is too long",
+    "request_too_large",
+    "exceeds the context window",
+    "maximum context length",
+];
+
+/// Checked before overflow wording. In particular, Bedrock throttling can say
+/// "too many tokens", while a rate-limit response can quote the rejected
+/// request, so a later overflow-shaped fragment must never win.
+const PROVIDER_RATE_LIMIT_PREFIXES: &[&str] = &["throttling error:"];
+const PROVIDER_RATE_LIMIT_PATTERNS: &[&str] = &["rate limit", "too many requests"];
+const PROVIDER_OTHER_PREFIXES: &[&str] = &["service unavailable:"];
+
+pub(crate) fn classify_provider_error(message: &str) -> ProviderErrorClass {
+    let lowered = message.trim_start().to_lowercase();
+    if PROVIDER_RATE_LIMIT_PREFIXES
+        .iter()
+        .any(|prefix| lowered.starts_with(prefix))
+        || PROVIDER_RATE_LIMIT_PATTERNS
+            .iter()
+            .any(|pattern| lowered.contains(pattern))
+    {
+        return ProviderErrorClass::RateLimit;
+    }
+    if PROVIDER_OTHER_PREFIXES
+        .iter()
+        .any(|prefix| lowered.starts_with(prefix))
+    {
+        return ProviderErrorClass::Other;
+    }
+    if PROVIDER_OVERFLOW_PATTERNS
+        .iter()
+        .any(|pattern| lowered.contains(pattern))
+    {
+        return ProviderErrorClass::Overflow;
+    }
+    ProviderErrorClass::Other
+}
 
 /// How an adapter arranges for turn-boundary events to reach a supervisor's
 /// socket. `env` is injected into the launched agent so the hook that runs
@@ -1047,6 +1091,13 @@ pub trait AgentAdapter: std::fmt::Debug {
     fn review_model_below(&self, seat: Option<&str>) -> &'static str {
         let _ = seat;
         ""
+    }
+
+    /// Adapter-owned ordering for model-change pacing hints. Larger means a
+    /// stronger rung; `None` keeps unknown ids informational only.
+    fn model_strength(&self, model: &str) -> Option<u8> {
+        let _ = model;
+        None
     }
 
     /// This adapter's own hard-coded model for a delegated headless worker

--- a/src/commands/ctx/agent.rs
+++ b/src/commands/ctx/agent.rs
@@ -326,7 +326,7 @@ pub fn budget_state(
     usage: &TranscriptUsage,
     tool_calls: u32,
 ) -> BudgetState {
-    let spent = usage.context_total().saturating_add(usage.output_tokens);
+    let spent = token_spend(usage);
     let mut worst = BudgetState::Ok;
     let mut consider = |used: u64, limit: u64| {
         if limit == 0 {
@@ -351,6 +351,10 @@ pub fn budget_state(
         consider(u64::from(tool_calls), u64::from(limit));
     }
     worst
+}
+
+fn token_spend(usage: &TranscriptUsage) -> u64 {
+    usage.context_total().saturating_add(usage.output_tokens)
 }
 
 /// A group's own token budget is a ceiling its children may only TIGHTEN. An
@@ -541,15 +545,16 @@ pub(crate) fn spawn_blocked(gate: &pace::SpawnGate, force: bool) -> bool {
 }
 
 /// Resolves this delegation's [`WorkerBudget`] from `--budget-tokens`/
-/// `--max-tool-calls` and, when `--group` names one, that group's own token
-/// ceiling -- which `--budget-tokens` may only tighten (`resolve_budget_
-/// tokens`). An unknown or closed group is a hard error: silently ignoring
-/// it would let a mistyped `--group` run unbounded work a batch's own budget
-/// was meant to cap. `--max-tool-calls` has no group-level counterpart
-/// (`group::WorkGroup` carries no such field) and so is never clamped.
+/// `--max-tool-calls` and, when `--group` names one, that group's token
+/// budget's remaining ceiling -- which `--budget-tokens` may only tighten
+/// (`resolve_budget_tokens`). An unknown or closed group is a hard error:
+/// silently ignoring it would let a mistyped `--group` run unbounded work a
+/// batch's own budget was meant to cap. `--max-tool-calls` has no group-level
+/// counterpart (`group::WorkGroup` carries no such field) and so is never
+/// clamped.
 ///
-/// Issue #155 review finding D2: this is also the headless admission choke
-/// point for `child_limit` -- `group::admit_child` is called here, once,
+/// This is also the headless admission choke point for the group's child,
+/// token, and deadline limits -- `group::admit_child` is called here, once,
 /// only on the path that actually runs the delegation headlessly. The
 /// dashboard-pane fork of the same request (`agent::try_join_dashboard`,
 /// tried BEFORE this function is ever reached -- see `run_with`) never
@@ -566,8 +571,15 @@ fn resolve_worker_budget(env: EnvLookup<'_>, args: &AgentArgs) -> CtxResult<Work
             if group.closed_at.is_some() {
                 return Err(format!("zirv ctx agent: work group '{id}' is closed").into());
             }
-            super::group::admit_child(&state, id).map_err(|e| format!("zirv ctx agent: {e}"))?;
-            group.token_budget
+            if let Err(e) = super::group::admit_child(&state, id, super::state::now_secs()) {
+                if super::group::is_admission_exhausted(e.as_ref()) {
+                    return Err(e);
+                }
+                return Err(format!("zirv ctx agent: {e}").into());
+            }
+            group
+                .token_budget
+                .map(|budget| budget.saturating_sub(group.spent_tokens))
         }
         None => None,
     };
@@ -882,7 +894,12 @@ fn answer_for_ack<W: Write>(ack: spawnreq::SpawnAck, w: &mut W) -> Option<CtxRes
         eprintln!("zirv ctx agent: {reason}; running headless");
         return None;
     }
-    Some(writeln!(w, "{reason}").map(|_| 1).map_err(|e| e.into()))
+    let code = if ack.budget_exhausted {
+        exec::EXIT_BUDGET_EXHAUSTED
+    } else {
+        1
+    };
+    Some(writeln!(w, "{reason}").map(|_| code).map_err(|e| e.into()))
 }
 
 /// O3: a request that was claimed but not acked within [`DASH_ACK_TIMEOUT`]
@@ -1642,6 +1659,11 @@ pub fn run_with<W: Write>(
             // Finding 4: nothing ran, so a group minted moments ago for this
             // delegation must not outlive it.
             discard_minted_group();
+            if super::group::is_admission_exhausted(e.as_ref()) {
+                let code = exec::EXIT_BUDGET_EXHAUSTED;
+                writeln!(w, "{}: {e}", delegation_outcome(code))?;
+                return Ok(code);
+            }
             return Err(e);
         }
     };
@@ -1702,10 +1724,9 @@ pub fn run_with<W: Write>(
         }
     };
     // Issue #170: this delegation's scope is done -- successfully or not --
-    // the moment its supervised run exits (completion contract and spend are
-    // both left for a reviewer to check against `zirv ctx group status`,
-    // never machine-verified -- see `WorkGroup::completion_contract`'s own
-    // doc comment). Closes the group only when THIS session is the one that
+    // the moment its supervised run exits. The free-text completion contract
+    // remains reviewer-checked; token spend is rolled up below. Closes the
+    // group only when THIS session is the one that
     // actually claimed it above, never a group some other, concurrent
     // claimant owns -- an operator's own shared `--group` across several
     // unrelated invocations must not be closed out from under whichever of
@@ -1769,6 +1790,9 @@ pub fn run_with<W: Write>(
             code,
             outcome,
         );
+        if let Some(id) = args.group.as_deref() {
+            let _ = super::group::add_spent_tokens(&state_dir, id, token_spend(&total));
+        }
         let route: Vec<String> = execution_report
             .segments
             .iter()
@@ -2175,6 +2199,7 @@ mod tests {
             scope: "test batch".to_string(),
             child_limit,
             token_budget: None,
+            spent_tokens: 0,
             deadline_secs: None,
             completion_contract: String::new(),
             created_at: 0,
@@ -2182,6 +2207,72 @@ mod tests {
             admitted_children: admitted,
             sub_orchestrator_session: None,
         }
+    }
+
+    fn create_work_group_with_spend(
+        state: &crate::commands::ctx::state::StateDir,
+        id: &str,
+        budget: u64,
+        spent: u64,
+    ) {
+        let mut group = sample_work_group(id, 3, 0);
+        group.token_budget = Some(budget);
+        group.spent_tokens = spent;
+        crate::commands::ctx::group::create(state, &group).expect("create group");
+    }
+
+    #[test]
+    fn resolve_worker_budget_uses_only_the_groups_remaining_tokens() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = crate::commands::ctx::state::StateDir::from_root(tmp.path().to_path_buf());
+        create_work_group_with_spend(&state, "wg-remaining", 400_000, 250_000);
+        create_work_group_with_spend(&state, "wg-tightened", 400_000, 250_000);
+        let env: HashMap<String, String> = [(
+            crate::commands::ctx::state::STATE_ENV.to_string(),
+            tmp.path().display().to_string(),
+        )]
+        .into();
+
+        let mut remaining = args_for("claude", "go");
+        remaining.group = Some("wg-remaining".to_string());
+        assert_eq!(
+            resolve_worker_budget(&|k| env.get(k).cloned(), &remaining)
+                .expect("resolve remaining budget")
+                .tokens,
+            Some(150_000)
+        );
+
+        let mut tightened = args_for("claude", "go");
+        tightened.group = Some("wg-tightened".to_string());
+        tightened.budget_tokens = Some(100_000);
+        assert_eq!(
+            resolve_worker_budget(&|k| env.get(k).cloned(), &tightened)
+                .expect("resolve tightened budget")
+                .tokens,
+            Some(100_000),
+            "an explicit child budget may still tighten the remaining group budget"
+        );
+    }
+
+    #[test]
+    fn exhausted_group_admission_returns_the_budget_exit_and_outcome() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let state_path = tmp.path().join("state");
+        let state = crate::commands::ctx::state::StateDir::from_root(state_path.clone());
+        create_work_group_with_spend(&state, "wg-spent", 400_000, 400_000);
+        let mut env = base_env(&state_path);
+        env.insert("ZIRV_CTX_PACE".to_string(), "false".to_string());
+        let mut args = args_for("claude", "go");
+        args.group = Some("wg-spent".to_string());
+        let mut out = Vec::new();
+
+        let code = run_with(&args, &mut out, tmp.path(), &|k| env.get(k).cloned())
+            .expect("budget exhaustion is a structured exit");
+
+        assert_eq!(code, exec::EXIT_BUDGET_EXHAUSTED);
+        assert_eq!(delegation_outcome(code), "budget-exhausted");
     }
 
     /// Issue #155 review finding D2: `resolve_worker_budget` is the headless
@@ -3839,6 +3930,47 @@ mod tests {
         assert!(rows.iter().any(|row| row.contains("gpt-5.6-terra")));
     }
 
+    #[test]
+    fn a_finished_child_rolls_its_spend_into_the_group_exactly_once() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let state_path = tmp.path().join("state");
+        let state = crate::commands::ctx::state::StateDir::from_root(state_path.clone());
+        create_work_group_with_spend(&state, "wg-roll-up", 1_000_000, 10);
+        let mut env = base_env(&state_path);
+        env.insert("ZIRV_CTX_PACE".to_string(), "false".to_string());
+        let mut args = args_for("claude", "do the work");
+        args.group = Some("wg-roll-up".to_string());
+        unsafe {
+            std::env::set_var("FAKE_AGENT_MODE", "healthy");
+        }
+
+        let code = run_with(&args, &mut Vec::new(), tmp.path(), &|k| env.get(k).cloned());
+
+        unsafe {
+            std::env::remove_var("FAKE_AGENT_MODE");
+        }
+        assert_eq!(code.expect("runs"), 0);
+        let rows = crate::commands::ctx::log::read_delegations(&state, 10);
+        let child_spend = rows.iter().fold(0_u64, |total, row| {
+            total
+                .saturating_add(row.input_tokens)
+                .saturating_add(row.cache_creation_input_tokens)
+                .saturating_add(row.cache_read_input_tokens)
+                .saturating_add(row.output_tokens)
+        });
+        assert!(child_spend > 0, "fixture must report real usage");
+        assert_eq!(
+            crate::commands::ctx::group::load(&state, "wg-roll-up")
+                .expect("load")
+                .expect("present")
+                .spent_tokens,
+            10 + child_spend,
+            "the completion path must add the child's spend once"
+        );
+    }
+
     /// Issue #155, Phase 2: the end-to-end write, against a real
     /// `AgentAdapter` (`ClaudeAdapter`) and a real fake-agent transcript --
     /// not just `log.rs`'s own isolated `append_delegation`/`tail_
@@ -4517,6 +4649,31 @@ mod tests {
         assert_eq!(code, 1);
         let output = String::from_utf8_lossy(&out);
         assert!(output.contains("disabled"), "got {output}");
+    }
+
+    #[test]
+    fn dashboard_budget_refusal_returns_the_budget_exhausted_exit() {
+        let mut out = Vec::new();
+        let result = answer_for_ack(
+            spawnreq::SpawnAck {
+                ok: false,
+                short: None,
+                reason: Some("budget-exhausted: work group budget is spent".to_string()),
+                retryable: false,
+                budget_exhausted: true,
+                capability_warnings: Vec::new(),
+            },
+            &mut out,
+        )
+        .expect("a policy refusal is final")
+        .expect("writes the result");
+
+        assert_eq!(result, exec::EXIT_BUDGET_EXHAUSTED);
+        assert!(
+            String::from_utf8(out)
+                .expect("utf8")
+                .contains("budget-exhausted")
+        );
     }
 
     /// Security review round 2 (Finding 4): `--scope` mints a group, and a

--- a/src/commands/ctx/agent.rs
+++ b/src/commands/ctx/agent.rs
@@ -106,7 +106,7 @@ pub struct AgentArgs {
     pub workdir: Option<PathBuf>,
     /// Issue #228: forces the headless supervised path even from inside a
     /// dashboard pane, skipping `try_join_dashboard` entirely. Preserves the
-    /// pre-#228 capability of running with restart/timeout/budget ceilings
+    /// pre-#228 capability of running with restart/timeout/tool-call ceilings
     /// or arbitrary trailing flags from inside a dashboard -- but only on
     /// explicit request now, since any of those would otherwise hard-error
     /// rather than silently demote (see `try_join_dashboard`'s own doc
@@ -353,7 +353,7 @@ pub fn budget_state(
     worst
 }
 
-fn token_spend(usage: &TranscriptUsage) -> u64 {
+pub(crate) fn token_spend(usage: &TranscriptUsage) -> u64 {
     usage.context_total().saturating_add(usage.output_tokens)
 }
 
@@ -565,18 +565,11 @@ fn resolve_worker_budget(env: EnvLookup<'_>, args: &AgentArgs) -> CtxResult<Work
     let group_token_budget = match &args.group {
         Some(id) => {
             let state = super::state::StateDir::resolve(env)?;
-            let group = super::group::load(&state, id)?.ok_or_else(|| {
-                format!("zirv ctx agent: no work group '{id}' -- create one with `zirv ctx group create`")
-            })?;
-            if group.closed_at.is_some() {
-                return Err(format!("zirv ctx agent: work group '{id}' is closed").into());
-            }
-            if let Err(e) = super::group::admit_child(&state, id, super::state::now_secs()) {
-                if super::group::is_admission_exhausted(e.as_ref()) {
-                    return Err(e);
-                }
-                return Err(format!("zirv ctx agent: {e}").into());
-            }
+            let group = match super::group::admit_child(&state, id, super::state::now_secs()) {
+                Ok(group) => group,
+                Err(e) if super::group::is_admission_exhausted(e.as_ref()) => return Err(e),
+                Err(e) => return Err(format!("zirv ctx agent: {e}").into()),
+            };
             group
                 .token_budget
                 .map(|budget| budget.saturating_sub(group.spent_tokens))
@@ -587,6 +580,21 @@ fn resolve_worker_budget(env: EnvLookup<'_>, args: &AgentArgs) -> CtxResult<Work
         tokens: resolve_budget_tokens(group_token_budget, args.budget_tokens),
         tool_calls: args.max_tool_calls,
     })
+}
+
+/// Preview of the ceiling an honest dashboard request carries. The
+/// dashboard still performs serialized admission and clamps this value
+/// against the then-current group record, so a forged or stale request can
+/// never widen the group's remaining budget.
+fn dashboard_budget_tokens(env: EnvLookup<'_>, args: &AgentArgs) -> Option<u64> {
+    let group_tokens = args.group.as_deref().and_then(|id| {
+        let state = super::state::StateDir::resolve(env).ok()?;
+        let group = super::group::load(&state, id).ok()??;
+        group
+            .token_budget
+            .map(|budget| budget.saturating_sub(group.spent_tokens))
+    });
+    resolve_budget_tokens(group_tokens, args.budget_tokens)
 }
 
 /// Everything wrong with `flags` that can be seen without running anything.
@@ -970,7 +978,7 @@ const EXIT_DASH_UNCONFIRMED: i32 = 1;
 /// task may run (O2).
 ///
 /// Issue #228: options a pane structurally cannot honour (`--max-restarts`/
-/// `--timeout-secs`/`--budget-tokens`/`--max-tool-calls`/`--flags` other
+/// `--timeout-secs`/`--max-tool-calls`/`--flags` other
 /// than a lone `--model` pin) USED TO print a notice and silently demote to
 /// headless (F9) -- an operator who was inside a dashboard specifically to
 /// get a pane could lose that without ever noticing. Now `Some(Err(_))`,
@@ -1009,15 +1017,9 @@ fn try_join_dashboard<W: Write>(
     // declines: honouring some of what the operator typed and dropping the
     // rest would be worse than not using the dashboard at all.
     let pinned_model = super::adapters::model_only_flags(&args.flags);
-    // Issue #155, Phase 5(d): `--budget-tokens`/`--max-tool-calls` join the
-    // same decline list as `--max-restarts`/`--timeout-secs`, for the same
-    // reason -- a pane is not a supervised headless run and `SpawnRequest`
-    // carries neither ceiling, so silently dropping one would be worse than
-    // not using the dashboard at all. `--role`/`--group` deliberately do
-    // NOT join this list: both ride in the request itself (`spawnreq::
-    // SpawnRequest::role`/`work_group_id`, below) and the dashboard's own
-    // `fulfill_spawn_request` re-validates both at the authority side, the
-    // same as every other field a pane can honour.
+    // `--max-tool-calls` remains unsupported because dashboard panes have no
+    // verified tool-call counter. Token ceilings do travel on the request
+    // and are enforced from the pane's transcript.
     // Issue #228: this used to print a notice and silently fall back to
     // headless (F9) -- an operator who explicitly asked for a pane-capable
     // run (by being inside a dashboard at all) got a demotion they might
@@ -1034,9 +1036,6 @@ fn try_join_dashboard<W: Write>(
     }
     if args.timeout_secs.is_some() {
         offending.push("--timeout-secs".to_string());
-    }
-    if args.budget_tokens.is_some() {
-        offending.push("--budget-tokens".to_string());
     }
     if args.max_tool_calls.is_some() {
         offending.push("--max-tool-calls".to_string());
@@ -1095,6 +1094,7 @@ fn try_join_dashboard<W: Write>(
         // from the same `ZIRV_CTX_SESSION` env var today.
         parent_session: super::mail::session_identity(env),
         work_group_id: args.group.clone(),
+        budget_tokens: dashboard_budget_tokens(env, args),
         // Issue #155, Phase 6(c): this process's own spawn gate (`run_with`,
         // above) already evaluated `--force` against the reading it had
         // before this request was ever written. Carrying it forward lets
@@ -1534,7 +1534,7 @@ pub fn run_with<W: Write>(
     // Issue #228: `--headless` skips the dashboard-join attempt entirely,
     // even from inside a live dashboard -- the one way to keep every option
     // `try_join_dashboard` would otherwise hard-error on (restart budget,
-    // wall-clock timeout, budget ceilings, arbitrary trailing flags) while
+    // wall-clock timeout, tool-call ceilings, arbitrary trailing flags) while
     // still asking for a pane-capable session to host the supervised run.
     if deferred_reset.is_none()
         && !args.headless
@@ -4577,11 +4577,8 @@ mod tests {
         );
     }
 
-    /// Issue #155, Phase 5(c): unlike `--budget-tokens`/`--max-tool-calls`
-    /// (which decline the dashboard join, see `options_a_pane_cannot_honour_
-    /// decline_the_dashboard_join`), `--role`/`--group` DO travel -- they
-    /// ride on the `SpawnRequest` itself, for `fulfill_spawn_request`'s own
-    /// depth cap and budget resolution to read on the fulfilment side.
+    /// Issue #155, Phase 5(c): `--role`/`--group` travel on the request for
+    /// the fulfilment side's depth cap and budget resolution.
     #[test]
     fn role_and_group_join_the_dashboard_and_travel_in_the_request() {
         let tmp = crate::commands::ctx::testenv::repo();
@@ -4616,6 +4613,50 @@ mod tests {
         assert!(
             req.parent_session.is_some(),
             "this process's own session id must be the lineage link: {request_body}"
+        );
+    }
+
+    #[test]
+    fn dashboard_group_request_carries_only_the_remaining_token_budget() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let (requests_dir, env) = live_dashboard_dir(tmp.path());
+        let state = crate::commands::ctx::state::StateDir::from_root(tmp.path().join("state"));
+        let group = crate::commands::ctx::group::WorkGroup {
+            work_group_id: "wg-remaining".to_string(),
+            parent_session_id: String::new(),
+            scope: "bounded dashboard work".to_string(),
+            child_limit: 3,
+            token_budget: Some(400_000),
+            spent_tokens: 125_000,
+            deadline_secs: None,
+            completion_contract: String::new(),
+            created_at: crate::commands::ctx::state::now_secs(),
+            closed_at: None,
+            admitted_children: 0,
+            sub_orchestrator_session: None,
+        };
+        crate::commands::ctx::group::create(&state, &group).expect("create group");
+
+        let responder = std::thread::spawn({
+            let dir = requests_dir.clone();
+            move || respond_to_next_request(dir, r#"{"ok":true,"short":"abcd1234","reason":null}"#)
+        });
+
+        let mut args = joinable_args("claude", "bounded work");
+        args.group = Some("wg-remaining".to_string());
+        let code = run_with(&args, &mut Vec::new(), tmp.path(), &|k| env.get(k).cloned())
+            .expect("dashboard join runs");
+        let request_body = responder.join().expect("responder thread");
+
+        assert_eq!(code, 0);
+        let req: spawnreq::SpawnRequest =
+            serde_json::from_str(&request_body).expect("the request parses");
+        assert_eq!(
+            req.budget_tokens,
+            Some(275_000),
+            "the pane request must carry the group's remaining ceiling"
         );
     }
 
@@ -4786,7 +4827,7 @@ mod tests {
         );
     }
 
-    /// Issue #228: `--max-restarts`, `--timeout-secs`, either budget ceiling
+    /// Issue #228: `--max-restarts`, `--timeout-secs`, `--max-tool-calls`
     /// and trailing `-- flags` beyond a lone `--model` pin are all honoured
     /// by `exec::run_with` and carried by nothing in a `SpawnRequest`. This
     /// USED TO print a notice and silently fall back to headless (F9) --
@@ -4827,12 +4868,6 @@ mod tests {
                     ]
                 },
                 "--verbose",
-            ),
-            // Issue #155, Phase 5(d): a pane cannot honour either budget
-            // ceiling, same reasoning as `max_restarts`/`timeout_secs` above.
-            (
-                |a: &mut AgentArgs| a.budget_tokens = Some(100_000),
-                "--budget-tokens",
             ),
             (
                 |a: &mut AgentArgs| a.max_tool_calls = Some(50),

--- a/src/commands/ctx/compile.rs
+++ b/src/commands/ctx/compile.rs
@@ -1451,6 +1451,7 @@ mod tests {
     /// canonical layer.
     #[test]
     fn an_over_budget_harness_roster_is_truncated_and_recorded() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let repo = tempfile::tempdir().expect("tempdir");
         let cfg = CtxConfig {
             context: crate::commands::ctx::config::ContextConfig {
@@ -1491,6 +1492,7 @@ mod tests {
     /// prompt's roster section is unaffected.
     #[test]
     fn a_harness_roster_under_budget_is_not_marked_truncated() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let repo = tempfile::tempdir().expect("tempdir");
         let cfg = CtxConfig::default(); // context.max_harness_roster_bytes = 4096
         let adapter = ClaudeAdapter::new(None);

--- a/src/commands/ctx/compile.rs
+++ b/src/commands/ctx/compile.rs
@@ -736,11 +736,22 @@ pub fn compile_with_harness_roster(
     let core_memory = prompt::memory_injection_summary(&memory_entries, cfg.memory.core_max_bytes);
     let retrieved_memory_summary =
         prompt::memory_injection_summary(&retrieved_memory, cfg.memory.retrieval_max_bytes);
-    let harness_lines = if include_harness_roster {
-        super::adapters::harness_prompt_lines(cfg, adapter.name())
+    // Issue #298: probe verdicts are cached per repository (`ProbeCache`'s
+    // own doc comment explains why not per session), so a second compile
+    // for this repo within the cache's TTL performs no new filesystem
+    // probe.
+    let mut probe_cache = super::adapters::ProbeCache::load(state, &slug, now);
+    let harness_report = if include_harness_roster {
+        super::adapters::harness_prompt_lines_cached(cfg, adapter.name(), &mut probe_cache)
     } else {
-        Vec::new()
+        super::adapters::HarnessRosterReport {
+            lines: Vec::new(),
+            omitted: 0,
+            omitted_bytes: 0,
+        }
     };
+    probe_cache.save();
+    let harness_lines = harness_report.lines;
 
     let composed = prompt::compose(
         home,
@@ -761,8 +772,10 @@ pub fn compile_with_harness_roster(
         && cfg.prompt.harnesses
         && !harness_lines.is_empty()
     {
-        let (_, injection) =
+        let (_, mut injection) =
             prompt::harness_roster_injection(&harness_lines, cfg.context.max_harness_roster_bytes);
+        injection.omitted = harness_report.omitted;
+        injection.omitted_bytes = harness_report.omitted_bytes;
         Some(injection)
     } else {
         None
@@ -877,12 +890,27 @@ fn render_measure_table(compiled: &CompiledContext, cfg: &CtxConfig, role: Promp
     }
 
     if let Some(roster) = &compiled.harness_roster {
-        let note = if roster.truncated {
-            format!("truncated to {}", cfg.context.max_harness_roster_bytes)
-        } else {
-            String::new()
-        };
-        rows.push(measure_row("harness roster", roster.delivered_bytes, &note));
+        let mut notes: Vec<String> = Vec::new();
+        if roster.truncated {
+            notes.push(format!(
+                "truncated to {}",
+                cfg.context.max_harness_roster_bytes
+            ));
+        }
+        // Issue #298's own success metric: how many adapter/review-line
+        // candidates were omitted for not being live, and the bytes that
+        // saved versus the pre-#298 behavior of emitting every one of them.
+        if roster.omitted > 0 {
+            notes.push(format!(
+                "{} omitted (not live), -{} bytes vs. emitting all lines",
+                roster.omitted, roster.omitted_bytes
+            ));
+        }
+        rows.push(measure_row(
+            "harness roster",
+            roster.delivered_bytes,
+            &notes.join("; "),
+        ));
     }
 
     for entry in &compiled.provenance {

--- a/src/commands/ctx/config.rs
+++ b/src/commands/ctx/config.rs
@@ -619,6 +619,13 @@ pub struct WorkflowConfig {
     /// phase. Off by default. `REPO_FORBIDDEN`: a repo checkout must not be
     /// able to make zirv spend on its own behalf.
     pub auto_spawn_on_gate: bool,
+    /// Issue #268: lets `zirv verify`/`zirv test` report `Passed` instead of
+    /// `Inconclusive` when zero verification checks are configured or
+    /// discoverable, rather than the degraded-gate ban's default of
+    /// treating "nothing to check" as proving nothing. Off by default.
+    /// `REPO_FORBIDDEN`: an untrusted checkout must not be able to declare
+    /// its own missing/empty `verify.toml` a pass.
+    pub allow_empty_verify: bool,
 }
 
 impl Default for WorkflowConfig {
@@ -637,6 +644,7 @@ impl Default for WorkflowConfig {
             review_worker_budget_tokens: None,
             review_worker_max_tool_calls: None,
             auto_spawn_on_gate: false,
+            allow_empty_verify: false,
         }
     }
 }
@@ -1518,6 +1526,11 @@ const ENV_MAP: &[(&str, &[&str], EnvKind)] = &[
         &["workflow", "auto_spawn_on_gate"],
         EnvKind::Bool,
     ),
+    (
+        "ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY",
+        &["workflow", "allow_empty_verify"],
+        EnvKind::Bool,
+    ),
     ("ZIRV_CTX_MEMORY", &["memory", "enabled"], EnvKind::Bool),
     (
         "ZIRV_CTX_MEMORY_HARVEST",
@@ -2024,6 +2037,12 @@ const REPO_FORBIDDEN: &[(&[&str], &str)] = &[
     (
         &["workflow", "auto_spawn_on_gate"],
         "ZIRV_CTX_WORKFLOW_AUTO_SPAWN_ON_GATE",
+    ),
+    // Issue #268: a repo checkout must not be able to declare its own
+    // missing/empty `verify.toml` a pass by setting this itself.
+    (
+        &["workflow", "allow_empty_verify"],
+        "ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY",
     ),
     // A repo checkout must not be able to switch either memory scope's own
     // gate on or off for itself, grow its cap, or turn on automatic
@@ -5134,6 +5153,53 @@ mod tests {
         );
     }
 
+    /// Issue #268: `workflow.allow_empty_verify` is operator-only, same
+    /// asymmetry as `auto_spawn_on_gate` above -- a repo checkout must not
+    /// be able to declare its own missing/empty `verify.toml` a pass.
+    #[test]
+    fn repo_layer_cannot_set_workflow_allow_empty_verify() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(repo.path().join(".zirv")).expect("mkdir");
+        std::fs::write(
+            repo.path().join(".zirv/ctx.toml"),
+            "[workflow]\nallow_empty_verify = true\n",
+        )
+        .expect("write");
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let empty = env_map(&[]);
+        let err = CtxConfig::load(repo.path(), &|k| empty.get(k).cloned())
+            .expect_err("a repo may not declare its own empty verify.toml a pass")
+            .to_string();
+        assert!(err.contains("workflow.allow_empty_verify"), "got {err}");
+        assert!(
+            err.contains("ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY"),
+            "names the operator escape hatch: {err}"
+        );
+    }
+
+    /// The operator's home layer and `ZIRV_CTX_*` env override still work,
+    /// same as `auto_spawn_on_gate`.
+    #[test]
+    fn the_operator_may_set_workflow_allow_empty_verify_from_home_config_and_env() {
+        let home = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(home.path().join(".zirv")).expect("mkdir");
+        std::fs::write(
+            home.path().join(".zirv/ctx.toml"),
+            "[workflow]\nallow_empty_verify = true\n",
+        )
+        .expect("write");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let repo = tempfile::tempdir().expect("tempdir");
+        let empty = env_map(&[]);
+        let cfg = CtxConfig::load(repo.path(), &|k| empty.get(k).cloned()).expect("load");
+        assert!(cfg.workflow.allow_empty_verify);
+
+        let env = env_map(&[("ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY", "false")]);
+        let cfg = CtxConfig::load(repo.path(), &|k| env.get(k).cloned()).expect("load");
+        assert!(!cfg.workflow.allow_empty_verify);
+    }
+
     /// The operator's home layer and `ZIRV_CTX_*` env override still work,
     /// same as `check_env_passthrough`.
     #[test]
@@ -5895,6 +5961,7 @@ mod tests {
         ("workflow", "review_worker_budget_tokens"),
         ("workflow", "review_worker_max_tool_calls"),
         ("workflow", "auto_spawn_on_gate"),
+        ("workflow", "allow_empty_verify"),
         ("policy", "repo_fs_write"),
         ("policy", "outside_repo_fs_write"),
         ("policy", "shell_exec"),

--- a/src/commands/ctx/context_status.rs
+++ b/src/commands/ctx/context_status.rs
@@ -1351,6 +1351,7 @@ mod tests {
     /// environment, the same way an operator would actually set it.
     #[test]
     fn an_over_budget_harness_roster_is_flagged_truncated_in_the_report() {
+        let _live = crate::commands::ctx::testenv::stub_live_adapters_on_path();
         let fixture = Fixture::new();
         let mut env = fixture.env.clone();
         env.insert(

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -47,7 +47,7 @@ use super::window;
 use super::{handoff, handover, mail, memory, prompt, score, sessions};
 use crate::commands::workflow;
 
-pub(crate) use pane::{Pane, PaneSpec, PaneState, ScrollOutcome};
+pub(crate) use pane::{Pane, PaneBudgetNotice, PaneSpec, PaneState, ScrollOutcome};
 
 /// The one dashboard prefix key, `Ctrl+A`. Not configurable in v1 (recorded
 /// as a deliberate spec deviation in the plan's self-review: YAGNI).
@@ -1216,6 +1216,73 @@ fn reap_fixup(removed: usize, focused: usize, selected: usize) -> (usize, usize)
     (focused, selected)
 }
 
+fn pane_transcript_usage(
+    pane: &Pane,
+    cfg: &CtxConfig,
+    repo: &Path,
+) -> Option<super::event::TranscriptUsage> {
+    let adapter = adapters::select(Some(pane.agent()), &[], cfg).ok()?;
+    let transcript = adapter.transcript_path(&SessionRef {
+        id: SessionId::parse(pane.session_id()),
+        cwd: repo.to_path_buf(),
+    });
+    let body = std::fs::read_to_string(transcript).ok()?;
+    adapter.transcript_usage(&body)
+}
+
+fn enforce_pane_token_budgets(
+    panes: &mut [Pane],
+    cfg: &CtxConfig,
+    repo: &Path,
+    errors: &mut Vec<String>,
+) {
+    for pane in panes {
+        if pane.budget_tokens().is_none() {
+            continue;
+        }
+        let Some(usage) = pane_transcript_usage(pane, cfg, repo) else {
+            continue;
+        };
+        let quit_sequence = adapters::select(Some(pane.agent()), &[], cfg)
+            .map(|adapter| adapter.quit_sequence().to_string())
+            .unwrap_or_default();
+        match pane.enforce_token_budget(&usage, &quit_sequence) {
+            Ok(Some(PaneBudgetNotice::SoftWarn { used, limit })) => push_error(
+                errors,
+                format!(
+                    "pane '{}' ({}) has spent {used}/{limit} tokens; wrap up and checkpoint soon",
+                    pane.title(),
+                    pane.short()
+                ),
+            ),
+            Ok(Some(PaneBudgetNotice::HardStop { used, limit })) => push_error(
+                errors,
+                format!(
+                    "pane '{}' ({}) token budget exhausted ({used}/{limit}); stopped with exit {}",
+                    pane.title(),
+                    pane.short(),
+                    super::exec::EXIT_BUDGET_EXHAUSTED
+                ),
+            ),
+            Ok(None) => {}
+            Err(e) => push_error(
+                errors,
+                format!("pane '{}' budget enforcement failed: {e}", pane.short()),
+            ),
+        }
+    }
+}
+
+fn account_reaped_pane_spend(pane: &Pane, cfg: &CtxConfig, state: &StateDir, repo: &Path) {
+    let Some(group_id) = pane.work_group_id() else {
+        return;
+    };
+    let Some(usage) = pane_transcript_usage(pane, cfg, repo) else {
+        return;
+    };
+    let _ = super::group::add_spent_tokens(state, group_id, super::agent::token_spend(&usage));
+}
+
 /// Pure: `selected` after `new_pane_count - old_pane_count` panes were
 /// appended to `panes`. `selected` indexes the combined sidebar (panes first,
 /// then view-only registry rows), so appending a pane pushes every view-only
@@ -1277,6 +1344,7 @@ fn reap_ended_panes(
     queues: &mut Vec<VecDeque<String>>,
     cfg: &CtxConfig,
     state: &StateDir,
+    repo: &Path,
     focused: &mut usize,
     selected: &mut usize,
     errors: &mut Vec<String>,
@@ -1297,6 +1365,7 @@ fn reap_ended_panes(
             push_error(errors, format!("reap {}: {e}", panes[index].short()));
         }
         let pane = panes.remove(index);
+        account_reaped_pane_spend(&pane, cfg, state, repo);
         close_claimed_group(&pane, state);
         if index < queues.len() {
             queues.remove(index);
@@ -1431,6 +1500,7 @@ fn on_quit(
             // Finding 6: and the group it belongs to, so the restore can put
             // it back inside the same one.
             work_group_id: pane.work_group_id().map(str::to_string),
+            budget_tokens: pane.budget_tokens(),
             // Issue #160 finding 1, review round (2026-08-28): the launch
             // mode this pane was ACTUALLY spawned with (`Pane::launch_mode`),
             // so a restore can relaunch it on the same terms rather than
@@ -3570,16 +3640,22 @@ fn fulfill_spawn_request(
     // fallback would call the identical `admit_child` in `agent.rs` and get
     // refused there too, so falling back gains nothing and the requester
     // deserves the honest, non-retryable answer.
-    if let Some(group_id) = &req.work_group_id
-        && let Err(e) = super::group::admit_child(state, group_id, now)
-    {
-        if super::group::is_admission_exhausted(e.as_ref()) {
-            return Err(SpawnRefusal::budget_exhausted(format!(
-                "budget-exhausted: {e}"
-            )));
+    let group_budget_tokens = if let Some(group_id) = &req.work_group_id {
+        match super::group::admit_child(state, group_id, now) {
+            Ok(group) => group
+                .token_budget
+                .map(|budget| budget.saturating_sub(group.spent_tokens)),
+            Err(e) if super::group::is_admission_exhausted(e.as_ref()) => {
+                return Err(SpawnRefusal::budget_exhausted(format!(
+                    "budget-exhausted: {e}"
+                )));
+            }
+            Err(e) => return Err(SpawnRefusal::policy(e.to_string())),
         }
-        return Err(SpawnRefusal::policy(e.to_string()));
-    }
+    } else {
+        None
+    };
+    let budget_tokens = super::agent::resolve_budget_tokens(group_budget_tokens, req.budget_tokens);
     // Re-review (2026-08-27) finding 1: from here on, `req.work_group_id`
     // (if any) has genuinely been admitted -- every remaining fallible step
     // between here and the pane actually spawning must roll that admission
@@ -3832,6 +3908,7 @@ fn fulfill_spawn_request(
     pane.set_report_to(report_to_for(req, cfg));
     pane.set_intake_dir(pane_channel);
     pane.set_work_group_id(req.work_group_id.clone());
+    pane.set_budget_tokens(budget_tokens);
     // Issue #249: the same server-verified value just pushed into this
     // pane's own `turn_env` above, stored here too so this dashboard's own
     // in-process mail sweep (`sweep_one_pane`, which never spawns a new OS
@@ -4825,6 +4902,7 @@ fn spawn_restored_pane(
             }
             pane.set_intake_dir(pane_channel);
             pane.set_work_group_id(candidate.work_group_id.clone());
+            pane.set_budget_tokens(candidate.budget_tokens);
             // Issue #249/#250 review (Fix 4): restores this pane's own
             // dashboard-side parent lineage (mirrors `restored_pane_turn_
             // env`'s identical re-export into the restored child's own real
@@ -6077,6 +6155,7 @@ pub fn run_dashboard(
             }
             pane.on_turn_signal();
         }
+        enforce_pane_token_budgets(&mut panes, cfg, repo, &mut errors);
         // R2: an exited pane leaves here -- registry record released, socket
         // unpublished, nudge queue dropped -- rather than sitting in the
         // vector as a corpse for the rest of the session.
@@ -6085,6 +6164,7 @@ pub fn run_dashboard(
             &mut nudge_queues,
             cfg,
             state,
+            repo,
             &mut focused,
             &mut selected,
             &mut errors,
@@ -6334,6 +6414,7 @@ pub fn run_dashboard(
                                                     role: None,
                                                     parent_session: None,
                                                     work_group_id: None,
+                                                    budget_tokens: None,
                                                     // The Spawn overlay has no
                                                     // `--force` of its own (see
                                                     // `fulfill_spawn_request`'s
@@ -9600,6 +9681,7 @@ mod tests {
                 &mut queues,
                 &cfg,
                 &state,
+                &repo,
                 &mut focused,
                 &mut selected,
                 &mut errors,
@@ -9696,6 +9778,7 @@ mod tests {
                 &mut queues,
                 &cfg,
                 &state,
+                &repo,
                 &mut focused,
                 &mut selected,
                 &mut errors,
@@ -10424,6 +10507,7 @@ mod tests {
             role: None,
             parent_session: None,
             work_group_id: None,
+            budget_tokens: None,
             force: false,
             workdir: None,
         }
@@ -11855,6 +11939,69 @@ mod tests {
             .expect("load")
             .expect("present");
         assert_eq!(group.admitted_children, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fulfill_spawn_request_applies_the_remaining_group_budget_to_the_pane() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let repo = tmp.path().to_path_buf();
+        let group = crate::commands::ctx::group::WorkGroup {
+            work_group_id: "wg-pane-budget".to_string(),
+            parent_session_id: String::new(),
+            scope: "bounded pane".to_string(),
+            child_limit: 3,
+            token_budget: Some(400_000),
+            spent_tokens: 125_000,
+            deadline_secs: None,
+            completion_contract: String::new(),
+            created_at: crate::commands::ctx::state::now_secs(),
+            closed_at: None,
+            admitted_children: 0,
+            sub_orchestrator_session: None,
+        };
+        crate::commands::ctx::group::create(&state, &group).expect("create group");
+
+        let mut req = spawn_request("bounded work", &repo);
+        req.work_group_id = Some("wg-pane-budget".to_string());
+        req.budget_tokens = Some(300_000);
+        let cfg = CtxConfig {
+            agent_bin: Some("true".to_string()),
+            pace: crate::commands::ctx::config::PaceConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            ..CtxConfig::default()
+        };
+        let mut panes = Vec::new();
+        let mut queues = Vec::new();
+        let mut errors = Vec::new();
+
+        fulfill_spawn_request(
+            &req,
+            false,
+            None,
+            &mut panes,
+            &mut queues,
+            &cfg,
+            &state,
+            &repo,
+            (80, 24),
+            &tmp.path().join("requests"),
+            &mut errors,
+        )
+        .expect("spawn pane");
+
+        assert_eq!(panes.len(), 1, "pane spawned: {errors:?}");
+        assert_eq!(
+            panes[0].budget_tokens(),
+            Some(275_000),
+            "the group remainder tightens the request's own ceiling"
+        );
+        let _ = panes[0].finish_shutdown();
     }
 
     #[test]
@@ -14930,6 +15077,7 @@ mod tests {
                 &mut queues,
                 &cfg,
                 &state,
+                &repo,
                 &mut focused,
                 &mut selected,
                 &mut errors,
@@ -14978,6 +15126,172 @@ mod tests {
                 .any(|(record, _)| record.short == short),
             "so `zirv ctx sessions` no longer lists it at all"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reaping_a_grouped_pane_rolls_its_transcript_spend_into_the_group() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let repo = tmp.path().to_path_buf();
+        let worker_cwd = tmp.path().join("worker-cwd");
+        std::fs::create_dir_all(&worker_cwd).expect("create worker cwd");
+        let group = crate::commands::ctx::group::WorkGroup {
+            work_group_id: "wg-reap-spend".to_string(),
+            parent_session_id: String::new(),
+            scope: "account a pane".to_string(),
+            child_limit: 3,
+            token_budget: Some(1_000),
+            spent_tokens: 10,
+            deadline_secs: None,
+            completion_contract: String::new(),
+            created_at: crate::commands::ctx::state::now_secs(),
+            closed_at: None,
+            admitted_children: 1,
+            sub_orchestrator_session: None,
+        };
+        crate::commands::ctx::group::create(&state, &group).expect("create group");
+
+        let session_id = "45454545-2222-4333-8444-555555555555";
+        let spec = PaneSpec {
+            agent_name: "claude".to_string(),
+            argv: trivial_argv(),
+            role: prompt::PromptRole::Worker,
+            verb: sessions::Verb::Dash,
+            session_id: session_id.to_string(),
+            title: "wrk claude".to_string(),
+        };
+        let mut pane = Pane::spawn(
+            spec,
+            &state,
+            &worker_cwd,
+            &repo,
+            (80, 24),
+            &[],
+            true,
+            pane::DEFAULT_IDLE_QUIET,
+        )
+        .expect("spawn");
+        pane.set_work_group_id(Some("wg-reap-spend".to_string()));
+
+        let cfg = CtxConfig::default();
+        let adapter = adapters::select(Some("claude"), &[], &cfg).expect("adapter");
+        let transcript = adapter.transcript_path(&SessionRef {
+            id: SessionId::parse(session_id),
+            cwd: worker_cwd,
+        });
+        std::fs::create_dir_all(transcript.parent().expect("transcript parent"))
+            .expect("create transcript dir");
+        std::fs::write(
+            &transcript,
+            r#"{"type":"assistant","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":20,"cache_read_input_tokens":30,"output_tokens":5}}}"#,
+        )
+        .expect("write transcript");
+
+        let mut panes = vec![pane];
+        let mut queues = vec![VecDeque::new()];
+        let mut errors = Vec::new();
+        let mut focused = 0;
+        let mut selected = 0;
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline && !panes.is_empty() {
+            for pane in &mut panes {
+                pane.drain();
+            }
+            reap_ended_panes(
+                &mut panes,
+                &mut queues,
+                &cfg,
+                &state,
+                &repo,
+                &mut focused,
+                &mut selected,
+                &mut errors,
+                &mut Vec::new(),
+                &mut HashSet::new(),
+                &mut None,
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        assert!(panes.is_empty(), "pane was reaped: {errors:?}");
+        assert_eq!(
+            crate::commands::ctx::group::load(&state, "wg-reap-spend")
+                .expect("load")
+                .expect("group")
+                .spent_tokens,
+            75,
+            "10 existing + 10 input + 20 cache-create + 30 cache-read + 5 output"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dashboard_stops_a_pane_that_exhausts_its_token_budget() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let repo = tmp.path().to_path_buf();
+        let session_id = "56565656-2222-4333-8444-555555555555";
+        let spec = PaneSpec {
+            agent_name: "claude".to_string(),
+            argv: vec!["sleep".to_string(), "30".to_string()],
+            role: prompt::PromptRole::Worker,
+            verb: sessions::Verb::Dash,
+            session_id: session_id.to_string(),
+            title: "wrk claude".to_string(),
+        };
+        let mut pane = Pane::spawn(
+            spec,
+            &state,
+            &repo,
+            &repo,
+            (80, 24),
+            &[],
+            true,
+            pane::DEFAULT_IDLE_QUIET,
+        )
+        .expect("spawn");
+        pane.set_budget_tokens(Some(50));
+
+        let cfg = CtxConfig::default();
+        let adapter = adapters::select(Some("claude"), &[], &cfg).expect("adapter");
+        let transcript = adapter.transcript_path(&SessionRef {
+            id: SessionId::parse(session_id),
+            cwd: repo.clone(),
+        });
+        std::fs::create_dir_all(transcript.parent().expect("transcript parent"))
+            .expect("create transcript dir");
+        std::fs::write(
+            &transcript,
+            r#"{"type":"assistant","message":{"usage":{"input_tokens":30,"cache_creation_input_tokens":10,"cache_read_input_tokens":5,"output_tokens":10}}}"#,
+        )
+        .expect("write transcript");
+
+        let mut panes = vec![pane];
+        let mut errors = Vec::new();
+        enforce_pane_token_budgets(&mut panes, &cfg, &repo, &mut errors);
+        assert!(
+            !matches!(panes[0].state(), PaneState::Ended(_)),
+            "the first hard-stop observation gives the same one-tick grace as exec"
+        );
+        enforce_pane_token_budgets(&mut panes, &cfg, &repo, &mut errors);
+
+        assert!(
+            matches!(
+                panes[0].state(),
+                PaneState::Ended(super::super::exec::EXIT_BUDGET_EXHAUSTED)
+            ),
+            "the pane must stop with the shared budget-exhausted exit"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("budget exhausted")),
+            "the dashboard should explain the stop: {errors:?}"
+        );
+        let _ = panes[0].finish_shutdown();
     }
 
     /// R4: the terminal-setup failure arms cannot be driven without a real
@@ -15883,6 +16197,7 @@ mod tests {
                 &mut queues,
                 &cfg,
                 &state,
+                &repo,
                 &mut focused,
                 &mut selected,
                 &mut errors,

--- a/src/commands/ctx/dash/mod.rs
+++ b/src/commands/ctx/dash/mod.rs
@@ -2769,6 +2769,7 @@ const FILE_DROP_TRUSTED_INTERACTIVE: bool = false;
 pub(crate) struct SpawnRefusal {
     pub reason: String,
     pub retryable: bool,
+    pub budget_exhausted: bool,
 }
 
 impl SpawnRefusal {
@@ -2779,6 +2780,7 @@ impl SpawnRefusal {
         SpawnRefusal {
             reason: reason.into(),
             retryable: false,
+            budget_exhausted: false,
         }
     }
 
@@ -2789,6 +2791,15 @@ impl SpawnRefusal {
         SpawnRefusal {
             reason: reason.into(),
             retryable: true,
+            budget_exhausted: false,
+        }
+    }
+
+    fn budget_exhausted(reason: impl Into<String>) -> Self {
+        SpawnRefusal {
+            reason: reason.into(),
+            retryable: false,
+            budget_exhausted: true,
         }
     }
 }
@@ -3550,8 +3561,8 @@ fn fulfill_spawn_request(
         );
     }
 
-    // Issue #155 review finding D2: the pane-side admission choke point for
-    // `child_limit`. `agent::run_with`'s own headless choke point
+    // The pane-side admission choke point for the group's child, token, and
+    // deadline limits. `agent::run_with`'s own headless choke point
     // (`resolve_worker_budget`) never runs for a request that reaches here
     // -- `try_join_dashboard` is the fork point between the two forks of one
     // delegation -- so this is the ONLY place a pane spawn is counted
@@ -3560,8 +3571,13 @@ fn fulfill_spawn_request(
     // refused there too, so falling back gains nothing and the requester
     // deserves the honest, non-retryable answer.
     if let Some(group_id) = &req.work_group_id
-        && let Err(e) = super::group::admit_child(state, group_id)
+        && let Err(e) = super::group::admit_child(state, group_id, now)
     {
+        if super::group::is_admission_exhausted(e.as_ref()) {
+            return Err(SpawnRefusal::budget_exhausted(format!(
+                "budget-exhausted: {e}"
+            )));
+        }
         return Err(SpawnRefusal::policy(e.to_string()));
     }
     // Re-review (2026-08-27) finding 1: from here on, `req.work_group_id`
@@ -3981,6 +3997,7 @@ fn drain_one_channel(
                 short: Some(short),
                 reason: None,
                 retryable: false,
+                budget_exhausted: false,
                 capability_warnings,
             },
             Err(refusal) => {
@@ -3997,6 +4014,7 @@ fn drain_one_channel(
                     short: None,
                     reason: Some(refusal.reason),
                     retryable: refusal.retryable,
+                    budget_exhausted: refusal.budget_exhausted,
                     capability_warnings: Vec::new(),
                 }
             }
@@ -11743,6 +11761,7 @@ mod tests {
             scope: "test batch".to_string(),
             child_limit: 1,
             token_budget: None,
+            spent_tokens: 0,
             deadline_secs: None,
             completion_contract: String::new(),
             created_at: 0,
@@ -11789,6 +11808,109 @@ mod tests {
     }
 
     #[test]
+    fn fulfill_spawn_request_refuses_a_work_group_with_a_spent_token_budget() {
+        let repo = std::env::current_dir().expect("cwd");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let group = crate::commands::ctx::group::WorkGroup {
+            work_group_id: "wg-spent".to_string(),
+            parent_session_id: String::new(),
+            scope: "test batch".to_string(),
+            child_limit: 0,
+            token_budget: Some(400_000),
+            spent_tokens: 400_000,
+            deadline_secs: None,
+            completion_contract: String::new(),
+            created_at: 0,
+            closed_at: None,
+            admitted_children: 0,
+            sub_orchestrator_session: None,
+        };
+        crate::commands::ctx::group::create(&state, &group).expect("persist group");
+
+        let mut req = spawn_request("do the work", &repo);
+        req.work_group_id = Some("wg-spent".to_string());
+        let cfg = CtxConfig::default();
+        let mut panes = Vec::new();
+        let mut queues = Vec::new();
+        let mut errors = Vec::new();
+        let refusal = fulfill_spawn_request(
+            &req,
+            false,
+            None,
+            &mut panes,
+            &mut queues,
+            &cfg,
+            &state,
+            &repo,
+            (80, 24),
+            &tmp.path().join("requests"),
+            &mut errors,
+        )
+        .expect_err("the group budget is spent");
+
+        assert!(refusal.reason.contains("token budget"), "{refusal:?}");
+        assert!(refusal.budget_exhausted);
+        let group = crate::commands::ctx::group::load(&state, "wg-spent")
+            .expect("load")
+            .expect("present");
+        assert_eq!(group.admitted_children, 0);
+    }
+
+    #[test]
+    fn fulfill_spawn_request_refuses_an_overdue_work_group() {
+        let repo = std::env::current_dir().expect("cwd");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().join("state"));
+        let group = crate::commands::ctx::group::WorkGroup {
+            work_group_id: "wg-overdue".to_string(),
+            parent_session_id: String::new(),
+            scope: "test batch".to_string(),
+            child_limit: 0,
+            token_budget: None,
+            spent_tokens: 0,
+            deadline_secs: Some(1),
+            completion_contract: String::new(),
+            created_at: 1,
+            closed_at: None,
+            admitted_children: 0,
+            sub_orchestrator_session: None,
+        };
+        crate::commands::ctx::group::create(&state, &group).expect("create group");
+
+        let mut req = spawn_request("do the work", &repo);
+        req.work_group_id = Some("wg-overdue".to_string());
+        let cfg = CtxConfig::default();
+        let mut panes = Vec::new();
+        let mut queues = Vec::new();
+        let mut errors = Vec::new();
+        let refusal = fulfill_spawn_request(
+            &req,
+            false,
+            None,
+            &mut panes,
+            &mut queues,
+            &cfg,
+            &state,
+            &repo,
+            (80, 24),
+            &tmp.path().join("requests"),
+            &mut errors,
+        )
+        .expect_err("the group deadline elapsed");
+
+        assert!(refusal.reason.contains("deadline"), "{refusal:?}");
+        assert!(refusal.budget_exhausted);
+        assert_eq!(
+            crate::commands::ctx::group::load(&state, "wg-overdue")
+                .expect("load")
+                .expect("present")
+                .admitted_children,
+            0
+        );
+    }
+
+    #[test]
     fn dashboard_spawn_reroutes_an_exhausted_requested_harness_before_admission() {
         let repo = std::env::current_dir().expect("cwd");
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -11828,6 +11950,7 @@ mod tests {
             scope: "test batch".to_string(),
             child_limit: 0,
             token_budget: None,
+            spent_tokens: 0,
             deadline_secs: None,
             completion_contract: String::new(),
             created_at: 0,
@@ -12038,6 +12161,7 @@ mod tests {
             scope: "test batch".to_string(),
             child_limit: 3,
             token_budget: None,
+            spent_tokens: 0,
             deadline_secs: None,
             completion_contract: String::new(),
             created_at: 0,
@@ -13191,6 +13315,7 @@ mod tests {
             scope: "test batch".to_string(),
             child_limit: 3,
             token_budget: None,
+            spent_tokens: 0,
             deadline_secs: None,
             completion_contract: String::new(),
             created_at: 0,

--- a/src/commands/ctx/dash/pane.rs
+++ b/src/commands/ctx/dash/pane.rs
@@ -51,6 +51,12 @@ pub enum PaneState {
     Ended(i32),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneBudgetNotice {
+    SoftWarn { used: u64, limit: u64 },
+    HardStop { used: u64, limit: u64 },
+}
+
 /// What `Pane::spawn` needs to launch and register a pane. `argv` is the
 /// full program-plus-arguments invocation -- built by the caller from an
 /// adapter's `interactive_cmd`/`build_launch`, prompt composition and
@@ -801,6 +807,12 @@ pub struct Pane {
     /// Also what `dash::mod::on_quit` persists into the restore roster, so a
     /// restored pane comes back inside the same group.
     work_group_id: Option<String>,
+    /// Per-child token ceiling carried by the spawn request. Evaluated from
+    /// this pane's transcript with the same `agent::budget_state` and
+    /// one-tick hard-stop grace as the headless exec supervisor.
+    budget_tokens: Option<u64>,
+    budget_soft_warned: bool,
+    budget_grace_given: bool,
     /// Issue #249: this pane's own server-verified supervising session
     /// (`dash::mod::fulfill_spawn_request`'s `verified_parent` -- the
     /// requester identity the per-pane intake-channel gate already proved,
@@ -1040,6 +1052,9 @@ impl Pane {
             report_to: None,
             intake_dir: None,
             work_group_id: None,
+            budget_tokens: None,
+            budget_soft_warned: false,
+            budget_grace_given: false,
             parent_session: None,
             report_reminder_sent: false,
             pending_submit: None,
@@ -1498,6 +1513,59 @@ impl Pane {
     /// The work group this pane belongs to, if any.
     pub fn work_group_id(&self) -> Option<&str> {
         self.work_group_id.as_deref()
+    }
+
+    pub fn set_budget_tokens(&mut self, budget: Option<u64>) {
+        self.budget_tokens = budget;
+        self.budget_soft_warned = false;
+        self.budget_grace_given = false;
+    }
+
+    pub fn budget_tokens(&self) -> Option<u64> {
+        self.budget_tokens
+    }
+
+    /// Applies the pane's transcript usage to the same budget state machine
+    /// as a headless worker. A naturally failed child keeps its own exit;
+    /// a clean child whose final transcript is over budget becomes exit 77.
+    pub fn enforce_token_budget(
+        &mut self,
+        usage: &super::super::event::TranscriptUsage,
+        quit_sequence: &str,
+    ) -> CtxResult<Option<PaneBudgetNotice>> {
+        let Some(limit) = self.budget_tokens else {
+            return Ok(None);
+        };
+        let budget = super::super::agent::WorkerBudget {
+            tokens: Some(limit),
+            tool_calls: None,
+        };
+        match super::super::agent::budget_state(&budget, usage, 0) {
+            super::super::agent::BudgetState::Ok => Ok(None),
+            super::super::agent::BudgetState::SoftWarn { used, limit } => {
+                if self.budget_soft_warned {
+                    return Ok(None);
+                }
+                self.budget_soft_warned = true;
+                Ok(Some(PaneBudgetNotice::SoftWarn { used, limit }))
+            }
+            super::super::agent::BudgetState::HardStop { used, limit } => {
+                if self.exit_code.is_some_and(|code| code != 0) {
+                    return Ok(None);
+                }
+                if self.exit_code == Some(0) {
+                    self.exit_code = Some(super::super::exec::EXIT_BUDGET_EXHAUSTED);
+                    return Ok(Some(PaneBudgetNotice::HardStop { used, limit }));
+                }
+                if !self.budget_grace_given {
+                    self.budget_grace_given = true;
+                    return Ok(None);
+                }
+                self.shutdown(quit_sequence)?;
+                self.exit_code = Some(super::super::exec::EXIT_BUDGET_EXHAUSTED);
+                Ok(Some(PaneBudgetNotice::HardStop { used, limit }))
+            }
+        }
     }
 
     /// Issue #249: records this pane's own server-verified supervising

--- a/src/commands/ctx/dash/roster.rs
+++ b/src/commands/ctx/dash/roster.rs
@@ -70,6 +70,11 @@ pub struct RosterPane {
     /// same reasoning as `report_to`.
     #[serde(default)]
     pub work_group_id: Option<String>,
+    /// Per-child token ceiling for this pane. A restore resumes the same
+    /// logical worker, so dropping its ceiling would let a dashboard restart
+    /// turn bounded work into unbounded work. Older rosters remain unbounded.
+    #[serde(default)]
+    pub budget_tokens: Option<u64>,
     /// Issue #160 finding 1, review round (2026-08-28): whether this pane
     /// carried the durable interactive-launch pin (`adapters::LAUNCH_MODE_
     /// ENV`/`LaunchMode::Interactive`) at quit time -- `dash::mod::on_quit`
@@ -249,6 +254,7 @@ mod tests {
                     report_to: None,
                     report_reminder_sent: false,
                     work_group_id: None,
+                    budget_tokens: None,
                     interactive: true,
                     parent_session: None,
                 },
@@ -261,6 +267,7 @@ mod tests {
                     report_to: Some("aaaa1111".to_string()),
                     report_reminder_sent: true,
                     work_group_id: Some("wg-1".to_string()),
+                    budget_tokens: Some(200_000),
                     interactive: false,
                     parent_session: Some("orch0001".to_string()),
                 },
@@ -308,6 +315,10 @@ mod tests {
     /// covers `parent_session` -- a build that predates it wrote no such key
     /// either, and `#[serde(default)]` must read that absence as `None`
     /// (peer trust, the fail-safe side), not a fabricated parent.
+    ///
+    /// Issue #286: `budget_tokens` follows the same compatibility rule. An
+    /// old entry restores with no per-pane ceiling rather than failing the
+    /// entire roster parse.
     #[test]
     fn an_old_style_roster_entry_with_no_report_back_fields_loads_with_none_and_false() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -333,6 +344,7 @@ mod tests {
         assert_eq!(got.panes.len(), 1);
         assert_eq!(got.panes[0].report_to, None);
         assert!(!got.panes[0].report_reminder_sent);
+        assert_eq!(got.panes[0].budget_tokens, None);
         assert!(
             !got.panes[0].interactive,
             "an old-format entry with no `interactive` key must default to fail-closed \

--- a/src/commands/ctx/dash/spawnreq.rs
+++ b/src/commands/ctx/dash/spawnreq.rs
@@ -103,6 +103,13 @@ pub struct SpawnRequest {
     /// one-off delegation, which is every delegation before 2.35.0.
     #[serde(default)]
     pub work_group_id: Option<String>,
+    /// Token ceiling this pane must enforce. For a grouped request written
+    /// by `zirv agent`, this is already clamped to the group's remaining
+    /// budget; the dashboard clamps it again after serialized admission
+    /// because request files are untrusted and the group may have changed.
+    /// Older request files predate pane budgets and remain unbounded.
+    #[serde(default)]
+    pub budget_tokens: Option<u64>,
     /// Issue #155, Phase 6(c): whether the requester already accepted the
     /// spend at quota pressure (`agent.rs`'s own `--force`). `fulfill_spawn_
     /// request` applies the SAME `pace::spawn_gate` the requester's own
@@ -464,6 +471,7 @@ mod tests {
             role: None,
             parent_session: None,
             work_group_id: None,
+            budget_tokens: None,
             force: false,
             workdir: None,
         }
@@ -480,6 +488,7 @@ mod tests {
         assert_eq!(req.role, None);
         assert_eq!(req.parent_session, None);
         assert_eq!(req.work_group_id, None);
+        assert_eq!(req.budget_tokens, None);
         assert_eq!(
             req.workdir, None,
             "an unstated workdir must fall back to the accepted `cwd` (pre-#228 behaviour)"

--- a/src/commands/ctx/dash/spawnreq.rs
+++ b/src/commands/ctx/dash/spawnreq.rs
@@ -163,6 +163,11 @@ pub struct SpawnAck {
     pub reason: Option<String>,
     #[serde(default)]
     pub retryable: bool,
+    /// Whether a non-retryable admission refusal maps to zirv's existing
+    /// budget-exhausted process exit. Older acknowledgements default to the
+    /// existing generic failure.
+    #[serde(default)]
+    pub budget_exhausted: bool,
     /// Issue #230 item 3: the degraded/unsupported capabilities the spawned
     /// pane's own launch carries (`policy::PolicyReport::degraded_
     /// capabilities`), so a requester waiting on this exact ack
@@ -599,6 +604,7 @@ mod tests {
             short: Some("bbbb2222".to_string()),
             reason: None,
             retryable: false,
+            budget_exhausted: false,
             capability_warnings: Vec::new(),
         };
         write_ack(&dir, &stem, &ack).expect("write_ack");
@@ -619,6 +625,7 @@ mod tests {
             short: Some("bbbb2222".to_string()),
             reason: None,
             retryable: false,
+            budget_exhausted: false,
             capability_warnings: vec![CapabilityWarning {
                 capability: "shell execution".to_string(),
                 mechanism: "no verified per-run mechanism".to_string(),
@@ -632,6 +639,26 @@ mod tests {
         let old = r#"{"ok":true,"short":"cccc3333","reason":null}"#;
         let parsed: SpawnAck = serde_json::from_str(old).expect("older acks still parse");
         assert!(parsed.capability_warnings.is_empty());
+        assert!(!parsed.budget_exhausted);
+    }
+
+    #[test]
+    fn an_acks_structured_exit_round_trips() {
+        let (_tmp, dir) = dir();
+        let ack = SpawnAck {
+            ok: false,
+            short: None,
+            reason: Some("budget-exhausted".to_string()),
+            retryable: false,
+            budget_exhausted: true,
+            capability_warnings: Vec::new(),
+        };
+
+        write_ack(&dir, "req-budget", &ack).expect("write_ack");
+        assert_eq!(
+            wait_for_ack(&dir, "req-budget", Duration::from_secs(1)),
+            Some(ack)
+        );
     }
 
     #[test]
@@ -754,6 +781,7 @@ mod tests {
                 short: Some("bbbb2222".to_string()),
                 reason: None,
                 retryable: false,
+                budget_exhausted: false,
                 capability_warnings: Vec::new(),
             },
         )

--- a/src/commands/ctx/event.rs
+++ b/src/commands/ctx/event.rs
@@ -79,12 +79,29 @@ impl TranscriptUsage {
 /// messages. The marker signal groups by turn and takes the last non-empty
 /// text; the token gate takes the most recent event's `input_tokens`
 /// regardless of text, so mid-turn token growth is visible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderErrorClass {
+    Overflow,
+    RateLimit,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ModelChange {
+    pub from: String,
+    pub to: String,
+    pub turns_ago: usize,
+    pub limit_pressure: bool,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum NormalizedEvent {
     TurnStart,
     AssistantFinal { text: String, input_tokens: u64 },
     ToolCall { name: String, input_hash: u64 },
     ToolResult { is_error: bool },
+    ProviderError { class: ProviderErrorClass },
+    ModelId { id: String },
     Compaction,
 }
 

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -2500,6 +2500,10 @@ fn supervise_run(
                 screening_announced,
             );
         }
+        if scorer.provider_limit_hit() {
+            *limit_hit = true;
+            return Tick::Stop("limit");
+        }
         match poll_result {
             Ok((Some(score), _)) if score.verdict == Verdict::Restart => {
                 *rotted = true;
@@ -2509,6 +2513,15 @@ fn supervise_run(
         }
     };
     let outcome = supervise::supervise_child(child, deadline, poll, &mut tick)?;
+
+    // A fast API-error exit can land its provider event after the final live
+    // tick, just like the tapped-output race closed by the caller's final
+    // drain. Give the transcript one last incremental read before deciding
+    // whether this was an ordinary exit.
+    if !*limit_hit {
+        let _ = scorer.poll(adapter, score_cfg);
+        *limit_hit = scorer.provider_limit_hit();
+    }
 
     // C1 (issue #155 review finding): `supervise_child` checks `try_wait`
     // for a completed child *before* ever calling the tick above, so a

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -330,12 +330,148 @@ pub fn nudges_after(used: u32, progressed: bool) -> u32 {
     if progressed { 0 } else { used }
 }
 
-/// Compaction of a headless run is pointless (there is no TUI to type into), so
-/// only a restart verdict acts, and only for the session this supervisor owns:
-/// the socket is named after eight hex characters of a session id, so a stale
-/// hook can reach it and must not be able to kill a healthy child.
-pub fn should_stop_for_signal(signal: &TurnSignal, session: &str) -> bool {
-    signal.session_id == session && signal.verdict == Verdict::Restart
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalAction {
+    Ignore,
+    Compact,
+    Stop,
+}
+
+pub(crate) fn action_for_verdict(verdict: Verdict) -> SignalAction {
+    match verdict {
+        Verdict::Compact => SignalAction::Compact,
+        Verdict::Restart => SignalAction::Stop,
+        Verdict::Healthy | Verdict::Advise => SignalAction::Ignore,
+    }
+}
+
+/// Maps a turn signal to an action only when it belongs to this supervisor's
+/// current session. The socket name is short enough that a stale hook can
+/// reach it, so ownership remains the first and non-negotiable gate.
+pub fn action_for_signal(signal: &TurnSignal, session: &str) -> SignalAction {
+    if signal.session_id != session {
+        return SignalAction::Ignore;
+    }
+    action_for_verdict(signal.verdict)
+}
+
+/// One bounded in-place attempt per cooldown window, and never another until
+/// the resumed conversation has reported progress after the previous attempt.
+#[derive(Debug, Default)]
+pub(crate) struct CompactBudget {
+    attempted_at: Option<Instant>,
+    progressed_after_attempt: bool,
+}
+
+impl CompactBudget {
+    pub(crate) fn ready(&self, now: Instant, window: Duration) -> bool {
+        let Some(attempted_at) = self.attempted_at else {
+            return true;
+        };
+        self.progressed_after_attempt && now.saturating_duration_since(attempted_at) >= window
+    }
+
+    pub(crate) fn arm(&mut self, now: Instant) {
+        self.attempted_at = Some(now);
+        self.progressed_after_attempt = false;
+    }
+
+    pub(crate) fn observe_progress(&mut self) {
+        if self.attempted_at.is_some() {
+            self.progressed_after_attempt = true;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CompactPlan<'a> {
+    prompt: String,
+    transcript: &'a Path,
+}
+
+fn compact_plan<'a>(
+    adapter: &dyn adapters::AgentAdapter,
+    transcript: Option<&'a Path>,
+) -> Result<CompactPlan<'a>, String> {
+    let command = adapter.compact_command().ok_or_else(|| {
+        format!(
+            "adapter '{}' does not support in-place compaction",
+            adapter.name()
+        )
+    })?;
+    let transcript = transcript
+        .filter(|path| path.is_file())
+        .ok_or_else(|| "no transcript reported, compaction unverifiable".to_string())?;
+    Ok(CompactPlan {
+        prompt: supervise::compact_prompt(command),
+        transcript,
+    })
+}
+
+pub(crate) fn headless_resume_launch(
+    adapter: &dyn adapters::AgentAdapter,
+    prompt: &str,
+    session: &SessionId,
+    extra: &[String],
+    prompt_via_stdin: bool,
+) -> Option<(Command, Option<String>)> {
+    let probe = adapter.headless_resume_cmd(Some(prompt), session.as_str(), extra)?;
+    let argv_total_len = headless_argv_len(&probe);
+    if headless_prompt_via_stdin(prompt_via_stdin, argv_total_len)
+        && let Some(command) = adapter.headless_resume_cmd(None, session.as_str(), extra)
+    {
+        return Some((command, Some(prompt.to_string())));
+    }
+    Some((probe, None))
+}
+
+pub(crate) fn compact_in_place<F>(
+    adapter: &dyn adapters::AgentAdapter,
+    transcript: Option<&Path>,
+    timeout: Duration,
+    poll: Duration,
+    build: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&str) -> Option<(Command, Option<String>)>,
+{
+    let plan = compact_plan(adapter, transcript)?;
+    let mut watcher = supervise::Watcher::new(plan.transcript.to_path_buf());
+    watcher
+        .read_appended()
+        .map_err(|error| format!("compaction verification failed: {error}"))?;
+
+    let (command, stdin_prompt) = build(&plan.prompt).ok_or_else(|| {
+        format!(
+            "adapter '{}' cannot resume a headless session in place",
+            adapter.name()
+        )
+    })?;
+    let (mut child, tap, _child_guard) = supervise::spawn_tapped(command, stdin_prompt)
+        .map_err(|error| format!("compact command failed to start: {error}"))?;
+    let outcome = supervise::supervise_child(
+        &mut child,
+        Instant::now() + timeout,
+        poll.max(Duration::from_millis(10)),
+        &mut || Tick::Continue,
+    )
+    .map_err(|error| format!("compact command failed: {error}"))?;
+    let _ = tap.drain_to_eof(supervise::FINAL_DRAIN_BUDGET);
+    match outcome {
+        Outcome::Exited(0) => {}
+        Outcome::Exited(code) => return Err(format!("compact command exited with code {code}")),
+        Outcome::TimedOut => return Err("compact command timed out".to_string()),
+        Outcome::StoppedByTick(reason) => {
+            return Err(format!("compact command stopped unexpectedly: {reason}"));
+        }
+    }
+
+    let verified = supervise::verify_compaction(&mut watcher, adapter, Instant::now() + timeout)
+        .map_err(|error| format!("compaction verification failed: {error}"))?;
+    if !verified {
+        return Err("compaction not verified".to_string());
+    }
+    Ok(())
 }
 
 fn build_command(command: &[String], repo: &Path) -> CtxResult<Command> {
@@ -1159,6 +1295,8 @@ fn run_with_clock_inner<W: Write>(
     // screening summary that has not changed since the last poll is
     // announced once for the whole run, not once per restart.
     let mut screening_announced: Option<String> = None;
+    let mut compact_budget = CompactBudget::default();
+    let compact_window = Duration::from_secs(cfg.supervise.interval_secs);
 
     loop {
         pace::wait_for_window(
@@ -1211,6 +1349,7 @@ fn run_with_clock_inner<W: Write>(
         // Fresh scorer per iteration, over the current session's transcript.
         let mut scorer = score::IncrementalScorer::new(transcript.clone());
         let mut rotted = false;
+        let mut compact_requested = false;
         let mut limit_hit = false;
         let mut nudged_by: Option<String> = None;
         // Issue #155, Phase 5(d): fresh per iteration too -- the child a
@@ -1236,6 +1375,9 @@ fn run_with_clock_inner<W: Write>(
             &announcer,
             &mut screening_announced,
             &mut rotted,
+            &mut compact_requested,
+            &mut compact_budget,
+            compact_window,
             &mut progressed,
             &tap,
             &mut limit_hit,
@@ -1369,6 +1511,99 @@ fn run_with_clock_inner<W: Write>(
             );
             session_guard.release();
             return Ok(EXIT_ACCOUNT_EXHAUSTED);
+        }
+
+        if compact_requested {
+            let extra: Vec<String> = policy_extra
+                .iter()
+                .cloned()
+                .chain(user_extra.iter().cloned())
+                .chain(prompt_args.iter().cloned())
+                .collect();
+            let compact_result = compact_in_place(
+                adapter.as_ref(),
+                Some(&transcript),
+                Duration::from_millis(cfg.wrap.inject_timeout_ms),
+                poll,
+                |compact_prompt| {
+                    let (mut compact, stdin_prompt) = headless_resume_launch(
+                        adapter.as_ref(),
+                        compact_prompt,
+                        &session,
+                        &extra,
+                        prompt_via_stdin,
+                    )?;
+                    compact.current_dir(repo);
+                    apply_session_env(&mut compact, &session);
+                    Some((compact, stdin_prompt))
+                },
+            )
+            .and_then(|()| {
+                let prompt_text = prompt
+                    .as_deref()
+                    .ok_or_else(|| "no prompt available for continuation".to_string())?;
+                let continuation = format!(
+                    "{prompt_text}\n\nContinue the same task after the verified in-place \
+                     compaction without redoing completed work."
+                );
+                let (mut command, stdin_prompt) = headless_resume_launch(
+                    adapter.as_ref(),
+                    &continuation,
+                    &session,
+                    &extra,
+                    prompt_via_stdin,
+                )
+                .ok_or_else(|| {
+                    format!(
+                        "adapter '{}' cannot resume a headless session in place",
+                        adapter.name()
+                    )
+                })?;
+                command.current_dir(repo);
+                apply_session_env(&mut command, &session);
+                Ok((command, stdin_prompt))
+            });
+
+            let verified = compact_result.is_ok();
+            announcer.emit(&super::announce::Event::Compact { verified });
+            match compact_result {
+                Ok((continued, continued_stdin)) => {
+                    let _ = log::append(
+                        &state,
+                        &log::Decision {
+                            ts: now_secs(),
+                            session: session.as_str(),
+                            verb: "exec",
+                            verdict: "compact",
+                            score: 0,
+                            action: "compact",
+                            detail: &transcript.display().to_string(),
+                        },
+                    );
+                    command = continued;
+                    stdin_prompt = continued_stdin;
+                    continue;
+                }
+                Err(reason) => {
+                    let _ = log::append(
+                        &state,
+                        &log::Decision {
+                            ts: now_secs(),
+                            session: session.as_str(),
+                            verb: "exec",
+                            verdict: "compact",
+                            score: 0,
+                            action: "compact-failed",
+                            detail: &reason,
+                        },
+                    );
+                    writeln!(
+                        w,
+                        "zirv ctx exec: {reason}; falling back to restart with handoff"
+                    )?;
+                    rotted = true;
+                }
+            }
         }
 
         match outcome {
@@ -2348,6 +2583,9 @@ fn supervise_run(
     announcer: &super::announce::Announcer,
     screening_announced: &mut Option<String>,
     rotted: &mut bool,
+    compact_requested: &mut bool,
+    compact_budget: &mut CompactBudget,
+    compact_window: Duration,
     // C3: set when this session reported a turn boundary of its own.
     progressed: &mut bool,
     tap: &supervise::OutputTap,
@@ -2408,10 +2646,19 @@ fn supervise_run(
             // just below: the session still did a turn's work.
             if received.session_id == session {
                 *progressed = true;
+                compact_budget.observe_progress();
             }
-            if should_stop_for_signal(&received, session) {
-                *rotted = true;
-                return Tick::Stop("rot");
+            match action_for_signal(&received, session) {
+                SignalAction::Stop => {
+                    *rotted = true;
+                    return Tick::Stop("rot");
+                }
+                SignalAction::Compact if compact_budget.ready(Instant::now(), compact_window) => {
+                    compact_budget.arm(Instant::now());
+                    *compact_requested = true;
+                    return Tick::Stop("compact");
+                }
+                SignalAction::Compact | SignalAction::Ignore => {}
             }
         }
         // N4: claiming the marker is atomic (`remove_file`), so exactly one
@@ -2501,10 +2748,22 @@ fn supervise_run(
             );
         }
         match poll_result {
-            Ok((Some(score), _)) if score.verdict == Verdict::Restart => {
-                *rotted = true;
-                Tick::Stop("rot")
-            }
+            Ok((Some(score), _)) => match action_for_verdict(score.verdict) {
+                SignalAction::Stop => {
+                    *rotted = true;
+                    Tick::Stop("rot")
+                }
+                SignalAction::Compact if compact_budget.ready(Instant::now(), compact_window) => {
+                    compact_budget.arm(Instant::now());
+                    *compact_requested = true;
+                    Tick::Stop("compact")
+                }
+                SignalAction::Compact => Tick::Continue,
+                SignalAction::Ignore => {
+                    compact_budget.observe_progress();
+                    Tick::Continue
+                }
+            },
             _ => Tick::Continue,
         }
     };
@@ -3806,23 +4065,23 @@ mod tests {
     }
 
     #[test]
-    fn only_a_restart_signal_stops_the_run() {
-        assert!(should_stop_for_signal(
-            &signal_with(Verdict::Restart, 95),
-            "s"
-        ));
-        assert!(!should_stop_for_signal(
-            &signal_with(Verdict::Compact, 65),
-            "s"
-        ));
-        assert!(!should_stop_for_signal(
-            &signal_with(Verdict::Advise, 45),
-            "s"
-        ));
-        assert!(!should_stop_for_signal(
-            &signal_with(Verdict::Healthy, 0),
-            "s"
-        ));
+    fn signal_actions_cover_restart_compact_and_ignore() {
+        assert_eq!(
+            action_for_signal(&signal_with(Verdict::Restart, 95), "s"),
+            SignalAction::Stop
+        );
+        assert_eq!(
+            action_for_signal(&signal_with(Verdict::Compact, 65), "s"),
+            SignalAction::Compact
+        );
+        assert_eq!(
+            action_for_signal(&signal_with(Verdict::Advise, 45), "s"),
+            SignalAction::Ignore
+        );
+        assert_eq!(
+            action_for_signal(&signal_with(Verdict::Healthy, 0), "s"),
+            SignalAction::Ignore
+        );
     }
 
     /// The socket path is derived from the first eight hex characters of a
@@ -3830,10 +4089,178 @@ mod tests {
     /// a healthy child on someone else's verdict is the failure to avoid.
     #[test]
     fn a_verdict_about_another_session_is_ignored() {
-        assert!(!should_stop_for_signal(
-            &signal_with(Verdict::Restart, 95),
-            "a-different-session"
-        ));
+        assert_eq!(
+            action_for_signal(&signal_with(Verdict::Restart, 95), "a-different-session"),
+            SignalAction::Ignore
+        );
+        assert_eq!(
+            action_for_signal(&signal_with(Verdict::Compact, 65), "a-different-session"),
+            SignalAction::Ignore
+        );
+    }
+
+    #[test]
+    fn compact_gate_rejects_an_adapter_without_a_command_and_a_missing_transcript() {
+        use std::cell::Cell;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript = dir.path().join("t.jsonl");
+        std::fs::write(&transcript, "{}\n").expect("write transcript");
+        let codex = crate::commands::ctx::adapters::codex::CodexAdapter::new(None);
+        let attempts = Cell::new(0);
+        assert_eq!(
+            compact_in_place(
+                &codex,
+                Some(&transcript),
+                Duration::ZERO,
+                Duration::ZERO,
+                |_| {
+                    attempts.set(attempts.get() + 1);
+                    None
+                },
+            )
+            .expect_err("codex cannot compact"),
+            "adapter 'codex' does not support in-place compaction"
+        );
+        assert_eq!(attempts.get(), 0, "unsupported adapter must not launch");
+
+        let claude = crate::commands::ctx::adapters::claude::ClaudeAdapter::new(None);
+        let attempts = Cell::new(0);
+        assert_eq!(
+            compact_in_place(&claude, None, Duration::ZERO, Duration::ZERO, |_| {
+                attempts.set(attempts.get() + 1);
+                None
+            },)
+            .expect_err("missing transcript must fail closed"),
+            "no transcript reported, compaction unverifiable"
+        );
+        assert_eq!(attempts.get(), 0, "missing transcript must not launch");
+    }
+
+    #[test]
+    fn compact_budget_arms_before_an_attempt_and_resets_only_after_progress_and_the_window() {
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+        let mut budget = CompactBudget::default();
+        assert!(budget.ready(now, window));
+
+        budget.arm(now);
+        assert!(!budget.ready(now, window));
+        budget.observe_progress();
+        assert!(!budget.ready(now + Duration::from_secs(59), window));
+        assert!(budget.ready(now + window, window));
+    }
+
+    #[test]
+    fn a_verified_compaction_resumes_and_continues_the_same_session() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let state = tmp.path().join("state");
+        let session = "abababab-2222-4333-8444-555555555555";
+        let modes = tmp.path().join("modes.txt");
+        let argv_log = tmp.path().join("argv.log");
+        std::fs::write(&modes, "compact-tier\nhealthy\n").expect("write modes");
+        let mut env = base_env(&state);
+        env.insert("ZIRV_CTX_INJECT_TIMEOUT_MS".to_string(), "2000".to_string());
+        env.insert("ZIRV_CTX_INTERVAL_SECS".to_string(), "0".to_string());
+
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let _fake_agent = crate::commands::ctx::testenv::VarGuard::set(&[
+            ("FAKE_AGENT_MODE_FILE", modes.to_str()),
+            ("FAKE_AGENT_SLEEP", Some("30")),
+            ("FAKE_AGENT_ARGV_LOG", argv_log.to_str()),
+        ]);
+        let args = ExecArgs {
+            agent: Some("claude".to_string()),
+            session_id: Some(session.to_string()),
+            transcript: Some(transcript_for(&home, tmp.path(), session)),
+            prompt: Some("do the work".to_string()),
+            max_restarts: Some(0),
+            budget_tokens: None,
+            max_tool_calls: None,
+            timeout_secs: Some(60),
+            simple: false,
+            command: fake_agent_command(session),
+        };
+        let mut out = Vec::new();
+        let code = run_with(&args, &mut out, tmp.path(), &|key| env.get(key).cloned());
+        assert_eq!(code.expect("runs"), 0);
+
+        let argv = std::fs::read_to_string(&argv_log).expect("argv log");
+        assert!(
+            argv.contains(&format!(
+                "/compact {} --resume {session}",
+                supervise::COMPACT_FOCUS
+            )),
+            "the compact command must resume the existing session: {argv}"
+        );
+        assert!(
+            argv.contains(&format!(
+                "Continue the same task after the verified in-place compaction without redoing \
+                 completed work. --resume {session}"
+            )),
+            "the continuation must resume the same session: {argv}"
+        );
+        assert_eq!(
+            argv.matches(&format!("--resume {session}")).count(),
+            2,
+            "exactly the compact and continuation launches resume: {argv}"
+        );
+        let log = std::fs::read_to_string(state.join("logs/decisions.jsonl")).expect("log");
+        assert!(log.contains("\"verdict\":\"compact\"") && log.contains("\"action\":\"compact\""));
+        assert!(!log.contains("\"action\":\"restart\""), "{log}");
+        assert_eq!(
+            transcripts_in(&home).len(),
+            1,
+            "same session, same transcript"
+        );
+    }
+
+    #[test]
+    fn an_unverified_compaction_falls_through_to_restart_with_the_reason() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let state = tmp.path().join("state");
+        let session = "acacacac-2222-4333-8444-555555555555";
+        let modes = tmp.path().join("modes.txt");
+        std::fs::write(&modes, "compact-tier\nhealthy\n").expect("write modes");
+        let mut env = base_env(&state);
+        env.insert("ZIRV_CTX_INJECT_TIMEOUT_MS".to_string(), "300".to_string());
+        env.insert("ZIRV_CTX_INTERVAL_SECS".to_string(), "0".to_string());
+
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let _fake_agent = crate::commands::ctx::testenv::VarGuard::set(&[
+            ("FAKE_AGENT_MODE_FILE", modes.to_str()),
+            ("FAKE_AGENT_SLEEP", Some("30")),
+            ("FAKE_AGENT_COMPACTION_EVENT", Some("0")),
+        ]);
+        let args = ExecArgs {
+            agent: Some("claude".to_string()),
+            session_id: Some(session.to_string()),
+            transcript: Some(transcript_for(&home, tmp.path(), session)),
+            prompt: Some("do the work".to_string()),
+            max_restarts: Some(1),
+            budget_tokens: None,
+            max_tool_calls: None,
+            timeout_secs: Some(60),
+            simple: false,
+            command: fake_agent_command(session),
+        };
+        let mut out = Vec::new();
+        let code = run_with(&args, &mut out, tmp.path(), &|key| env.get(key).cloned());
+        assert_eq!(code.expect("runs"), 0);
+
+        let log = std::fs::read_to_string(state.join("logs/decisions.jsonl")).expect("log");
+        assert!(
+            log.contains("\"action\":\"compact-failed\"")
+                && log.contains("\"detail\":\"compaction not verified\"")
+        );
+        assert!(log.contains("\"action\":\"restart\""), "{log}");
+        assert_eq!(
+            transcripts_in(&home).len(),
+            2,
+            "restart mints a new session"
+        );
     }
 
     /// Every restart is a new session, and the hook inside it reports whatever

--- a/src/commands/ctx/exec.rs
+++ b/src/commands/ctx/exec.rs
@@ -337,10 +337,13 @@ pub enum SignalAction {
     Stop,
 }
 
-pub(crate) fn action_for_verdict(verdict: Verdict) -> SignalAction {
+pub(crate) fn action_for_verdict(
+    adapter: &dyn adapters::AgentAdapter,
+    verdict: Verdict,
+) -> SignalAction {
     match verdict {
-        Verdict::Compact => SignalAction::Compact,
-        Verdict::Restart => SignalAction::Stop,
+        Verdict::Compact if adapter.supports_headless_compact() => SignalAction::Compact,
+        Verdict::Compact | Verdict::Restart => SignalAction::Stop,
         Verdict::Healthy | Verdict::Advise => SignalAction::Ignore,
     }
 }
@@ -348,11 +351,15 @@ pub(crate) fn action_for_verdict(verdict: Verdict) -> SignalAction {
 /// Maps a turn signal to an action only when it belongs to this supervisor's
 /// current session. The socket name is short enough that a stale hook can
 /// reach it, so ownership remains the first and non-negotiable gate.
-pub fn action_for_signal(signal: &TurnSignal, session: &str) -> SignalAction {
+pub fn action_for_signal(
+    adapter: &dyn adapters::AgentAdapter,
+    signal: &TurnSignal,
+    session: &str,
+) -> SignalAction {
     if signal.session_id != session {
         return SignalAction::Ignore;
     }
-    action_for_verdict(signal.verdict)
+    action_for_verdict(adapter, signal.verdict)
 }
 
 /// One bounded in-place attempt per cooldown window, and never another until
@@ -381,6 +388,14 @@ impl CompactBudget {
             self.progressed_after_attempt = true;
         }
     }
+}
+
+/// A provider-limit notice discovered by the final output drain outranks a
+/// compaction requested by the preceding supervision tick. The limit path
+/// parks or hands over; compacting and continuing here would discard that
+/// evidence and immediately spend the exhausted seat again.
+pub(crate) fn should_attempt_compact(compact_requested: bool, limit_hit: bool) -> bool {
+    compact_requested && !limit_hit
 }
 
 #[derive(Debug)]
@@ -1513,7 +1528,7 @@ fn run_with_clock_inner<W: Write>(
             return Ok(EXIT_ACCOUNT_EXHAUSTED);
         }
 
-        if compact_requested {
+        if should_attempt_compact(compact_requested, limit_hit) {
             let extra: Vec<String> = policy_extra
                 .iter()
                 .cloned()
@@ -2648,7 +2663,7 @@ fn supervise_run(
                 *progressed = true;
                 compact_budget.observe_progress();
             }
-            match action_for_signal(&received, session) {
+            match action_for_signal(adapter, &received, session) {
                 SignalAction::Stop => {
                     *rotted = true;
                     return Tick::Stop("rot");
@@ -2748,7 +2763,7 @@ fn supervise_run(
             );
         }
         match poll_result {
-            Ok((Some(score), _)) => match action_for_verdict(score.verdict) {
+            Ok((Some(score), _)) => match action_for_verdict(adapter, score.verdict) {
                 SignalAction::Stop => {
                     *rotted = true;
                     Tick::Stop("rot")
@@ -4066,22 +4081,39 @@ mod tests {
 
     #[test]
     fn signal_actions_cover_restart_compact_and_ignore() {
+        let claude = crate::commands::ctx::adapters::claude::ClaudeAdapter::new(None);
         assert_eq!(
-            action_for_signal(&signal_with(Verdict::Restart, 95), "s"),
+            action_for_signal(&claude, &signal_with(Verdict::Restart, 95), "s"),
             SignalAction::Stop
         );
         assert_eq!(
-            action_for_signal(&signal_with(Verdict::Compact, 65), "s"),
+            action_for_signal(&claude, &signal_with(Verdict::Compact, 65), "s"),
             SignalAction::Compact
         );
         assert_eq!(
-            action_for_signal(&signal_with(Verdict::Advise, 45), "s"),
+            action_for_signal(&claude, &signal_with(Verdict::Advise, 45), "s"),
             SignalAction::Ignore
         );
         assert_eq!(
-            action_for_signal(&signal_with(Verdict::Healthy, 0), "s"),
+            action_for_signal(&claude, &signal_with(Verdict::Healthy, 0), "s"),
             SignalAction::Ignore
         );
+    }
+
+    #[test]
+    fn codex_compact_verdict_restarts_without_arming_the_compact_budget() {
+        let codex = crate::commands::ctx::adapters::codex::CodexAdapter::new(None);
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+        let mut budget = CompactBudget::default();
+
+        let action = action_for_verdict(&codex, Verdict::Compact);
+        if action == SignalAction::Compact && budget.ready(now, window) {
+            budget.arm(now);
+        }
+
+        assert_eq!(action, SignalAction::Stop);
+        assert!(budget.attempted_at.is_none());
     }
 
     /// The socket path is derived from the first eight hex characters of a
@@ -4089,12 +4121,21 @@ mod tests {
     /// a healthy child on someone else's verdict is the failure to avoid.
     #[test]
     fn a_verdict_about_another_session_is_ignored() {
+        let claude = crate::commands::ctx::adapters::claude::ClaudeAdapter::new(None);
         assert_eq!(
-            action_for_signal(&signal_with(Verdict::Restart, 95), "a-different-session"),
+            action_for_signal(
+                &claude,
+                &signal_with(Verdict::Restart, 95),
+                "a-different-session",
+            ),
             SignalAction::Ignore
         );
         assert_eq!(
-            action_for_signal(&signal_with(Verdict::Compact, 65), "a-different-session"),
+            action_for_signal(
+                &claude,
+                &signal_with(Verdict::Compact, 65),
+                "a-different-session",
+            ),
             SignalAction::Ignore
         );
     }
@@ -4149,6 +4190,13 @@ mod tests {
         budget.observe_progress();
         assert!(!budget.ready(now + Duration::from_secs(59), window));
         assert!(budget.ready(now + window, window));
+    }
+
+    #[test]
+    fn a_final_drain_limit_preempts_an_already_requested_compaction() {
+        assert!(!should_attempt_compact(true, true));
+        assert!(should_attempt_compact(true, false));
+        assert!(!should_attempt_compact(false, false));
     }
 
     #[test]

--- a/src/commands/ctx/group.rs
+++ b/src/commands/ctx/group.rs
@@ -25,6 +25,10 @@ pub struct WorkGroup {
     pub child_limit: u32,
     #[serde(default)]
     pub token_budget: Option<u64>,
+    /// Completed child spend rolled up across this group's delegated work.
+    /// Older records predate the meter and therefore start at zero.
+    #[serde(default)]
+    pub spent_tokens: u64,
     #[serde(default)]
     pub deadline_secs: Option<u64>,
     /// Display-only (issue #155 review finding D2): the terms every child
@@ -126,10 +130,26 @@ pub fn close(state: &StateDir, id: &str, now: u64) -> CtxResult<()> {
     Ok(())
 }
 
-/// Issue #155 review finding D2: the sole place a child is admitted into a
-/// group. `Err` -- naming both the group and its limit -- once
-/// `admitted_children` has already reached `child_limit`; otherwise the
-/// count is incremented and saved. Called at both real admission choke
+#[derive(Debug)]
+struct AdmissionExhausted(String);
+
+impl std::fmt::Display for AdmissionExhausted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for AdmissionExhausted {}
+
+/// Whether an admission failed because the group's spend or deadline is
+/// exhausted. Callers map both to the existing budget-exhausted exit.
+pub fn is_admission_exhausted(error: &(dyn std::error::Error + 'static)) -> bool {
+    error.is::<AdmissionExhausted>()
+}
+
+/// The sole place a child is admitted into a group. Refuses exhausted token
+/// budgets, elapsed deadlines, and groups already at their child limit before
+/// incrementing the persisted count. Called at both real admission choke
 /// points: `agent::resolve_worker_budget` for a headless delegation, and
 /// `dash::fulfill_spawn_request` for a dashboard pane -- never both for the
 /// same request (a headless run that first tries to join a live dashboard
@@ -141,10 +161,24 @@ pub fn close(state: &StateDir, id: &str, now: u64) -> CtxResult<()> {
 /// mostly-sequential orchestrator activity, not a tight concurrent loop, so
 /// a lost update in a genuine race would at worst admit one child past the
 /// limit, never wrongly refuse legitimate work.
-pub fn admit_child(state: &StateDir, id: &str) -> CtxResult<()> {
+pub fn admit_child(state: &StateDir, id: &str, now: u64) -> CtxResult<()> {
     let Some(mut group) = load(state, id)? else {
         return Err(format!("no work group '{id}'").into());
     };
+    if group
+        .token_budget
+        .is_some_and(|budget| group.spent_tokens >= budget)
+    {
+        return Err(Box::new(AdmissionExhausted(format!(
+            "work group '{id}' token budget is exhausted ({} tokens spent)",
+            group.spent_tokens
+        ))));
+    }
+    if is_overdue(&group, now) {
+        return Err(Box::new(AdmissionExhausted(format!(
+            "work group '{id}' deadline has elapsed"
+        ))));
+    }
     if group.admitted_children >= group.child_limit {
         return Err(format!(
             "work group '{id}' already has its full {} children admitted",
@@ -155,6 +189,17 @@ pub fn admit_child(state: &StateDir, id: &str) -> CtxResult<()> {
     group.admitted_children += 1;
     create(state, &group)?;
     Ok(())
+}
+
+/// Adds one completed child's token spend to its group. Best-effort callers
+/// may ignore an I/O failure, but arithmetic never wraps and the same
+/// load-modify-write race trade-off as admission applies.
+pub fn add_spent_tokens(state: &StateDir, id: &str, spent: u64) -> CtxResult<()> {
+    let Some(mut group) = load(state, id)? else {
+        return Err(format!("no work group '{id}'").into());
+    };
+    group.spent_tokens = group.spent_tokens.saturating_add(spent);
+    create(state, &group)
 }
 
 /// Re-review (2026-08-27) finding 1: rolls back one admission granted by
@@ -216,12 +261,10 @@ pub fn discard_if_unused(state: &StateDir, id: &str) -> bool {
     std::fs::remove_file(record_path(state, id)).is_ok()
 }
 
-/// Issue #155 review finding D2: `deadline_secs` is surfaced as an overdue
-/// marker, never enforced -- nothing here kills a session or a group. `now`
-/// is a parameter, not `state::now_secs()`, for the same testability reason
-/// `run_create`/`run_close` already take one. A closed group is never
-/// overdue: it is evidence of what a batch finished under, not a still-
-/// running one a deadline can still be missed by.
+/// `now` is a parameter, not `state::now_secs()`, so both the status marker
+/// and admission gate stay deterministic in tests. A closed group is never
+/// overdue: it is evidence of what a batch finished under, not a still-running
+/// one a deadline can still be missed by.
 pub fn is_overdue(group: &WorkGroup, now: u64) -> bool {
     group.closed_at.is_none()
         && group
@@ -332,6 +375,7 @@ pub fn run_create<W: Write>(
         scope: args.scope.clone(),
         child_limit: args.child_limit,
         token_budget: args.token_budget,
+        spent_tokens: 0,
         deadline_secs: args.deadline_secs,
         completion_contract: args.completion_contract.clone(),
         created_at: now,
@@ -383,8 +427,8 @@ fn print_group<W: Write>(
     if let Some(sub) = &group.sub_orchestrator_session {
         write!(w, " sub-orchestrator={sub}")?;
     }
-    // Issue #155 review finding D2: display-only -- see `is_overdue`'s own
-    // doc comment. Nothing here kills or restarts anything on account of it.
+    // Status only marks the elapsed deadline. Admission enforcement lives in
+    // `admit_child`; neither path kills or restarts running work.
     if is_overdue(group, now) {
         write!(w, " OVERDUE")?;
     }
@@ -468,6 +512,7 @@ mod tests {
             scope: "phase 5 implementation".to_string(),
             child_limit: 3,
             token_budget: Some(400_000),
+            spent_tokens: 0,
             deadline_secs: Some(3_600),
             completion_contract: "every child reports a compact result by mail".to_string(),
             created_at: 1_700_000_000,
@@ -492,6 +537,7 @@ mod tests {
             scope: "phase 5 implementation".to_string(),
             child_limit: 3,
             token_budget: Some(400_000),
+            spent_tokens: 0,
             deadline_secs: Some(3_600),
             completion_contract: "every child reports a compact result by mail".to_string(),
             created_at: 1_700_000_000,
@@ -508,6 +554,31 @@ mod tests {
             None,
             "unknown id is None, not an error"
         );
+    }
+
+    #[test]
+    fn a_pre_spend_work_group_record_defaults_spent_tokens_to_zero() {
+        let group = sample_group("wg-old");
+        let mut old_shape = serde_json::to_value(group).expect("serialize group");
+        old_shape
+            .as_object_mut()
+            .expect("object")
+            .remove("spent_tokens");
+        let restored: WorkGroup = serde_json::from_value(old_shape).expect("deserialize old shape");
+
+        assert_eq!(restored.spent_tokens, 0);
+    }
+
+    #[test]
+    fn spent_tokens_round_trips_with_the_work_group_record() {
+        let mut group = sample_group("wg-spent");
+        group.spent_tokens = 123_456;
+        let json = serde_json::to_value(group).expect("serialize group");
+
+        let restored: WorkGroup = serde_json::from_value(json).expect("deserialize group");
+        let restored = serde_json::to_value(restored).expect("serialize restored group");
+
+        assert_eq!(restored["spent_tokens"], 123_456);
     }
 
     /// Closing is idempotent and preserves the terms: a closed group is
@@ -579,11 +650,11 @@ mod tests {
         let state = StateDir::from_root(tmp.path().to_path_buf());
         create(&state, &sample_group("wg-1")).expect("create"); // child_limit: 3
 
-        admit_child(&state, "wg-1").expect("first child admitted");
+        admit_child(&state, "wg-1", 1_700_000_100).expect("first child admitted");
         let group = load(&state, "wg-1").expect("load").expect("present");
         assert_eq!(group.admitted_children, 1);
 
-        admit_child(&state, "wg-1").expect("second child admitted");
+        admit_child(&state, "wg-1", 1_700_000_100).expect("second child admitted");
         assert_eq!(
             load(&state, "wg-1")
                 .expect("load")
@@ -605,8 +676,8 @@ mod tests {
         group.child_limit = 1;
         create(&state, &group).expect("create");
 
-        admit_child(&state, "wg-1").expect("the one allowed child is admitted");
-        let err = admit_child(&state, "wg-1").expect_err("the limit is reached");
+        admit_child(&state, "wg-1", 1_700_000_100).expect("the one allowed child is admitted");
+        let err = admit_child(&state, "wg-1", 1_700_000_100).expect_err("the limit is reached");
         assert!(err.to_string().contains("wg-1"), "got {err}");
         assert!(err.to_string().contains('1'), "names the limit: {err}");
         assert_eq!(
@@ -615,6 +686,48 @@ mod tests {
                 .expect("present")
                 .admitted_children,
             1,
+            "a refused admission must not advance the count"
+        );
+    }
+
+    #[test]
+    fn admit_child_refuses_when_the_group_token_budget_is_spent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().to_path_buf());
+        let mut group = sample_group("wg-spent");
+        group.spent_tokens = 400_000;
+        create(&state, &group).expect("create");
+
+        let err =
+            admit_child(&state, "wg-spent", 1_700_000_100).expect_err("the token budget is spent");
+        assert!(err.to_string().contains("wg-spent"), "got {err}");
+        assert_eq!(
+            load(&state, "wg-spent")
+                .expect("load")
+                .expect("present")
+                .admitted_children,
+            0,
+            "a refused admission must not advance the count"
+        );
+    }
+
+    #[test]
+    fn admit_child_refuses_when_the_group_deadline_has_elapsed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().to_path_buf());
+        let mut group = sample_group("wg-overdue");
+        group.created_at = 100;
+        group.deadline_secs = Some(10);
+        create(&state, &group).expect("create");
+
+        let err = admit_child(&state, "wg-overdue", 111).expect_err("the deadline elapsed");
+        assert!(err.to_string().contains("wg-overdue"), "got {err}");
+        assert_eq!(
+            load(&state, "wg-overdue")
+                .expect("load")
+                .expect("present")
+                .admitted_children,
+            0,
             "a refused admission must not advance the count"
         );
     }
@@ -628,8 +741,8 @@ mod tests {
         let state = StateDir::from_root(tmp.path().to_path_buf());
         create(&state, &sample_group("wg-1")).expect("create");
 
-        admit_child(&state, "wg-1").expect("first child admitted");
-        admit_child(&state, "wg-1").expect("second child admitted");
+        admit_child(&state, "wg-1", 1_700_000_100).expect("first child admitted");
+        admit_child(&state, "wg-1", 1_700_000_100).expect("second child admitted");
         assert_eq!(
             load(&state, "wg-1")
                 .expect("load")
@@ -670,6 +783,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn adding_group_spend_uses_saturating_arithmetic() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().to_path_buf());
+        let mut group = sample_group("wg-saturating");
+        group.spent_tokens = u64::MAX - 5;
+        create(&state, &group).expect("persist group");
+
+        add_spent_tokens(&state, "wg-saturating", 10).expect("roll up spend");
+
+        let persisted =
+            std::fs::read_to_string(record_path(&state, "wg-saturating")).expect("read group");
+        let persisted: serde_json::Value = serde_json::from_str(&persisted).expect("json");
+        assert_eq!(persisted["spent_tokens"], u64::MAX);
+    }
+
     /// Best-effort: a rollback naming an unknown group must not panic --
     /// `admit_child`'s own choke points call this from an error path that
     /// already has a real failure to report, and a second panic/error here
@@ -685,14 +814,14 @@ mod tests {
     fn admit_child_errors_on_an_unknown_group() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let state = StateDir::from_root(tmp.path().to_path_buf());
-        let err = admit_child(&state, "nope").expect_err("no such group");
+        let err = admit_child(&state, "nope", 0).expect_err("no such group");
         assert!(err.to_string().contains("nope"), "got {err}");
     }
 
-    /// Issue #155 review finding D2: `deadline_secs` is a display-only
-    /// marker -- an open group past its deadline is overdue; the same group
-    /// before the deadline, or with none set at all, is not; and a CLOSED
-    /// group is never overdue no matter how long ago its deadline passed.
+    /// The same predicate drives both the status marker and admission gate:
+    /// an open group past its deadline is overdue; the same group before the
+    /// deadline, or with none set at all, is not; and a CLOSED group is never
+    /// overdue no matter how long ago its deadline passed.
     #[test]
     fn is_overdue_marks_only_an_open_group_past_its_deadline() {
         let mut group = sample_group("wg-1"); // created_at 1_700_000_000, deadline_secs 3_600
@@ -800,7 +929,7 @@ mod tests {
         let state = StateDir::from_root(tmp.path().to_path_buf());
 
         create(&state, &sample_group("wg-admitted")).expect("create");
-        admit_child(&state, "wg-admitted").expect("admit");
+        admit_child(&state, "wg-admitted", 1_700_000_100).expect("admit");
         assert!(!discard_if_unused(&state, "wg-admitted"));
         assert!(load(&state, "wg-admitted").expect("load").is_some());
 

--- a/src/commands/ctx/group.rs
+++ b/src/commands/ctx/group.rs
@@ -10,7 +10,7 @@
 //! failing the whole read.
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -64,6 +64,51 @@ pub struct WorkGroup {
 
 fn record_path(state: &StateDir, id: &str) -> PathBuf {
     state.groups().join(format!("{id}.json"))
+}
+
+fn lock_path(state: &StateDir, id: &str) -> PathBuf {
+    state.groups().join(format!("{id}.lock"))
+}
+
+#[cfg(unix)]
+fn open_lock_file(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_lock_file(path: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+}
+
+/// One advisory OS lock per group record. The file intentionally remains
+/// after release: deleting a lock path can split two contenders across old
+/// and new inodes, while an unlocked empty file is harmless and lets the OS
+/// release a crashed process's lock automatically.
+struct GroupLock(std::fs::File);
+
+impl Drop for GroupLock {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
+
+fn lock_group(state: &StateDir, id: &str) -> CtxResult<GroupLock> {
+    create_private_dir_all(&state.groups())?;
+    let file = open_lock_file(&lock_path(state, id))?;
+    file.lock()?;
+    Ok(GroupLock(file))
 }
 
 /// Writes a group's record. Matches `sessions::write_record`'s own
@@ -120,6 +165,7 @@ pub fn list(state: &StateDir) -> Vec<WorkGroup> {
 /// a closed group is evidence of what a batch was launched under, not a
 /// tombstone, and the first close time is the one that stands.
 pub fn close(state: &StateDir, id: &str, now: u64) -> CtxResult<()> {
+    let _lock = lock_group(state, id)?;
     let Some(mut group) = load(state, id)? else {
         return Err(format!("no work group '{id}'").into());
     };
@@ -156,15 +202,16 @@ pub fn is_admission_exhausted(error: &(dyn std::error::Error + 'static)) -> bool
 /// admits nowhere in `agent.rs` itself; whichever side actually ends up
 /// spawning is the one that calls this).
 ///
-/// Load-modify-write, like every other mutation in this file
-/// (`close` above) -- not a distributed lock. zirv's own callers are
-/// mostly-sequential orchestrator activity, not a tight concurrent loop, so
-/// a lost update in a genuine race would at worst admit one child past the
-/// limit, never wrongly refuse legitimate work.
-pub fn admit_child(state: &StateDir, id: &str, now: u64) -> CtxResult<()> {
+/// The complete read/check/increment/write transaction is serialized by the
+/// group's interprocess lock, as are every other mutation below it.
+pub fn admit_child(state: &StateDir, id: &str, now: u64) -> CtxResult<WorkGroup> {
+    let _lock = lock_group(state, id)?;
     let Some(mut group) = load(state, id)? else {
         return Err(format!("no work group '{id}'").into());
     };
+    if group.closed_at.is_some() {
+        return Err(format!("work group '{id}' is closed").into());
+    }
     if group
         .token_budget
         .is_some_and(|budget| group.spent_tokens >= budget)
@@ -188,13 +235,14 @@ pub fn admit_child(state: &StateDir, id: &str, now: u64) -> CtxResult<()> {
     }
     group.admitted_children += 1;
     create(state, &group)?;
-    Ok(())
+    Ok(group)
 }
 
 /// Adds one completed child's token spend to its group. Best-effort callers
-/// may ignore an I/O failure, but arithmetic never wraps and the same
-/// load-modify-write race trade-off as admission applies.
+/// may ignore an I/O failure, but arithmetic never wraps and the complete
+/// update is serialized with admission and the other group mutations.
 pub fn add_spent_tokens(state: &StateDir, id: &str, spent: u64) -> CtxResult<()> {
+    let _lock = lock_group(state, id)?;
     let Some(mut group) = load(state, id)? else {
         return Err(format!("no work group '{id}'").into());
     };
@@ -213,11 +261,14 @@ pub fn add_spent_tokens(state: &StateDir, id: &str, spent: u64) -> CtxResult<()>
 /// Best-effort, unlike `admit_child`: logs to stderr and returns rather than
 /// propagating a second error over the original spawn failure that triggered
 /// the rollback -- an operator who already sees a spawn error must not also
-/// see "the state file wouldn't decrement" stacked on top of it. Same
-/// load-modify-write, non-locking pattern as `admit_child`/`close`: losing a
-/// rollback to a race just leaves the count one high until the group is
-/// inspected, never wrongly grants an extra admission.
+/// see "the state file wouldn't decrement" stacked on top of it. The same
+/// per-group lock as `admit_child`/`close` keeps this rollback from losing a
+/// concurrent mutation.
 pub fn rollback_admission(state: &StateDir, id: &str) {
+    let Ok(_lock) = lock_group(state, id) else {
+        eprintln!("zirv ctx: failed to lock work group '{id}' for admission rollback");
+        return;
+    };
     match load(state, id) {
         Ok(Some(mut group)) => {
             group.admitted_children = group.admitted_children.saturating_sub(1);
@@ -249,6 +300,9 @@ pub fn rollback_admission(state: &StateDir, id: &str) {
 /// best-effort otherwise: the delegation being unwound is the caller's real
 /// news, never this.
 pub fn discard_if_unused(state: &StateDir, id: &str) -> bool {
+    let Ok(_lock) = lock_group(state, id) else {
+        return false;
+    };
     let Ok(Some(group)) = load(state, id) else {
         return false;
     };
@@ -280,6 +334,7 @@ pub fn is_overdue(group: &WorkGroup, now: u64) -> bool {
 /// claimant simply never becomes the one `agent::run_with` auto-closes it
 /// for). Load-modify-write, like every other mutation in this file.
 pub fn claim_sub_orchestrator(state: &StateDir, id: &str, session: &str) -> CtxResult<()> {
+    let _lock = lock_group(state, id)?;
     let Some(mut group) = load(state, id)? else {
         return Err(format!("no work group '{id}'").into());
     };
@@ -732,6 +787,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn admit_child_refuses_a_closed_group_without_advancing_the_count() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().to_path_buf());
+        let mut group = sample_group("wg-closed");
+        group.closed_at = Some(1_700_000_050);
+        create(&state, &group).expect("create");
+
+        let err = admit_child(&state, "wg-closed", 1_700_000_100)
+            .expect_err("a closed group cannot admit another child");
+
+        assert!(err.to_string().contains("closed"), "got {err}");
+        assert_eq!(
+            load(&state, "wg-closed")
+                .expect("load")
+                .expect("present")
+                .admitted_children,
+            0,
+            "a refused admission must not advance the count"
+        );
+    }
+
     /// Re-review (2026-08-27) finding 1: a rollback after a real admission
     /// restores exactly the slot it undoes, leaving any other admissions on
     /// the group untouched.
@@ -797,6 +874,48 @@ mod tests {
             std::fs::read_to_string(record_path(&state, "wg-saturating")).expect("read group");
         let persisted: serde_json::Value = serde_json::from_str(&persisted).expect("json");
         assert_eq!(persisted["spent_tokens"], u64::MAX);
+    }
+
+    #[test]
+    fn group_mutations_wait_for_the_same_interprocess_lock() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = StateDir::from_root(tmp.path().to_path_buf());
+        create(&state, &sample_group("wg-locked")).expect("create");
+        let held = lock_group(&state, "wg-locked").expect("hold group lock");
+
+        let worker_state = state.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(0);
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).expect("announce start");
+            let result =
+                add_spent_tokens(&worker_state, "wg-locked", 10).map_err(|e| e.to_string());
+            done_tx.send(result).expect("announce finish");
+        });
+
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("worker started");
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "the mutation must wait while another holder owns the group lock"
+        );
+
+        drop(held);
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("mutation finished after release")
+            .expect("mutation succeeded");
+        worker.join().expect("worker joins");
+        assert_eq!(
+            load(&state, "wg-locked")
+                .expect("load")
+                .expect("present")
+                .spent_tokens,
+            10
+        );
     }
 
     /// Best-effort: a rollback naming an unknown group must not panic --

--- a/src/commands/ctx/hook.rs
+++ b/src/commands/ctx/hook.rs
@@ -1030,9 +1030,11 @@ mod tests {
                 tool_failure_rate: 1.0,
                 repetition_hits: 0,
                 max_repeat: 1,
+                provider_overflows: 0,
                 marker_miss_rate: Some(1.0),
             },
             context_tokens: 170_000,
+            model_change: None,
         }
     }
 
@@ -1693,8 +1695,10 @@ mod tests {
                 tool_failure_rate: 0.0,
                 repetition_hits: 0,
                 max_repeat: 0,
+                provider_overflows: 0,
                 marker_miss_rate: None,
             },
+            model_change: None,
         }
     }
 

--- a/src/commands/ctx/mod.rs
+++ b/src/commands/ctx/mod.rs
@@ -196,6 +196,33 @@ pub(crate) mod testenv {
         }
     }
 
+    /// Stubs an executable-named file for every entry in
+    /// [`super::adapters::ADAPTERS`] on a fresh, otherwise-empty `PATH`, so
+    /// issue #298's liveness probe (`adapters::liveness_probe`) confirms
+    /// every registered adapter `Live` no matter what the host running the
+    /// test actually has installed. Without this, any test that needs a
+    /// non-empty harness roster is really asserting on the developer
+    /// machine's own `PATH` -- true where `claude`/`codex` happen to be
+    /// installed, false on a CI runner that carries neither, which is
+    /// exactly the split issue #298 introduced (see its own roster-omission
+    /// tests earlier in `adapters::tests` for the pattern this factors out).
+    ///
+    /// Returns both guards: the `TempDir` must outlive the `VarGuard` (drop
+    /// order matters only in that dropping the directory first would delete
+    /// the stub files while `PATH` still names it), so bind the whole tuple
+    /// for the caller's scope rather than discarding either half.
+    pub(crate) fn stub_live_adapters_on_path() -> (tempfile::TempDir, VarGuard) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (name, _) in super::adapters::ADAPTERS {
+            std::fs::write(dir.path().join(name), "").expect("write stub");
+        }
+        let guard = VarGuard::set(&[(
+            "PATH",
+            Some(dir.path().to_str().expect("utf8 tempdir path")),
+        )]);
+        (dir, guard)
+    }
+
     /// Enters `dir` and returns to the previous working directory on drop --
     /// including on a panicking assertion, which is the whole point.
     ///

--- a/src/commands/ctx/optimize.rs
+++ b/src/commands/ctx/optimize.rs
@@ -5212,9 +5212,11 @@ mod tests {
                 tool_failure_rate,
                 repetition_hits: 0,
                 max_repeat: 1,
+                provider_overflows: 0,
                 marker_miss_rate: None,
             },
             context_tokens: 120_000,
+            model_change: None,
         }
     }
 

--- a/src/commands/ctx/pace.rs
+++ b/src/commands/ctx/pace.rs
@@ -1,5 +1,35 @@
 use super::config::PaceConfig;
+use super::event::{ModelChange, NormalizedEvent, ProviderErrorClass};
 use super::window::{FIVE_HOUR_SECS, SEVEN_DAY_SECS, UsageWindows, Window, age_secs};
+
+/// Provider rate limits found in transcript events enter the same park path as
+/// the established stdout wording scan. Overflow and other provider failures
+/// stay out: rot and ordinary failure handling own those respectively.
+pub fn provider_events_hit_limit(events: &[NormalizedEvent]) -> bool {
+    events.iter().any(|event| {
+        matches!(
+            event,
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::RateLimit
+            }
+        )
+    })
+}
+
+/// A downward move on the adapter's own verified ladder is limit-pressure
+/// context for reporting. Unknown ids and lateral/upward moves are not hints.
+pub fn model_change_is_limit_pressure(
+    adapter: &dyn super::adapters::AgentAdapter,
+    change: &ModelChange,
+) -> bool {
+    let Some(from) = adapter.model_strength(&change.from) else {
+        return false;
+    };
+    let Some(to) = adapter.model_strength(&change.to) else {
+        return false;
+    };
+    to < from
+}
 
 /// Which data layer the decision rests on. Ordered by authority.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2308,6 +2338,49 @@ mod tests {
         ] {
             assert!(!is_limit_hit(line), "false positive on {line:?}");
         }
+    }
+
+    #[test]
+    fn classified_provider_rate_limits_reach_the_existing_limit_path() {
+        use crate::commands::ctx::event::{NormalizedEvent, ProviderErrorClass};
+
+        let events = [
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::Other,
+            },
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::RateLimit,
+            },
+        ];
+        assert!(provider_events_hit_limit(&events));
+        assert!(!provider_events_hit_limit(&[
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::Overflow,
+            }
+        ]));
+    }
+
+    #[test]
+    fn only_a_model_downgrade_is_a_limit_pressure_hint() {
+        use crate::commands::ctx::adapters::claude::ClaudeAdapter;
+        use crate::commands::ctx::event::ModelChange;
+
+        let adapter = ClaudeAdapter::new(None);
+        let downgrade = ModelChange {
+            from: "claude-opus-5".to_string(),
+            to: "claude-sonnet-5".to_string(),
+            turns_ago: 0,
+            limit_pressure: false,
+        };
+        let upgrade = ModelChange {
+            from: "claude-sonnet-5".to_string(),
+            to: "claude-opus-5".to_string(),
+            turns_ago: 0,
+            limit_pressure: false,
+        };
+
+        assert!(model_change_is_limit_pressure(&adapter, &downgrade));
+        assert!(!model_change_is_limit_pressure(&adapter, &upgrade));
     }
 
     #[test]

--- a/src/commands/ctx/prompt.rs
+++ b/src/commands/ctx/prompt.rs
@@ -657,6 +657,15 @@ pub struct HarnessRosterInjection {
     pub raw_bytes: usize,
     pub delivered_bytes: usize,
     pub truncated: bool,
+    /// Issue #298: adapter lines omitted for a confirmed-absent `Liveness`
+    /// (or a disabled adapter). Always `0` from `harness_roster_injection`
+    /// itself, which knows nothing about liveness -- `compile::compile_
+    /// with_harness_roster` fills this in from its own `adapters::
+    /// HarnessRosterReport` after calling this function.
+    pub omitted: usize,
+    /// Bytes the omitted lines would have cost had they still been
+    /// rendered the pre-#298 way. See `omitted`'s own doc comment.
+    pub omitted_bytes: usize,
 }
 
 /// Joins `lines` the same way `compose` always has (`"\n"`-separated) and
@@ -679,6 +688,8 @@ pub fn harness_roster_injection(lines: &[String], cap: usize) -> (String, Harnes
             raw_bytes,
             delivered_bytes,
             truncated: delivered_bytes < raw_bytes,
+            omitted: 0,
+            omitted_bytes: 0,
         },
     )
 }

--- a/src/commands/ctx/rot.rs
+++ b/src/commands/ctx/rot.rs
@@ -198,6 +198,7 @@ pub fn signals(events: &[NormalizedEvent], caps: Capabilities, cfg: &ScoreConfig
 struct Segment {
     calls: Vec<(String, u64)>,
     results: Vec<bool>,
+    #[serde(default)]
     provider_overflows: usize,
 }
 
@@ -216,6 +217,7 @@ pub struct RotState {
     /// Turn finals already closed by a later `TurnStart`.
     closed_turns: usize,
     /// Closed turn finals since the latest compaction boundary.
+    #[serde(default)]
     behavioral_closed_turns: usize,
     /// `has_marker` of the last `window` closed finals, oldest first.
     closed_markers: VecDeque<bool>,

--- a/src/commands/ctx/rot.rs
+++ b/src/commands/ctx/rot.rs
@@ -4,7 +4,7 @@ use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::config::ScoreConfig;
-use super::event::{Capabilities, NormalizedEvent};
+use super::event::{Capabilities, ModelChange, NormalizedEvent, ProviderErrorClass};
 
 /// Leading characters a model tends to put before a reply prefix. Ported from
 /// the shell canary's `^[ \t>*_`#~-]*` allowance.
@@ -16,6 +16,7 @@ pub struct Signals {
     pub tool_failure_rate: f64,
     pub repetition_hits: usize,
     pub max_repeat: usize,
+    pub provider_overflows: usize,
     /// `None` means the signal is unavailable, not that it scored zero.
     pub marker_miss_rate: Option<f64>,
 }
@@ -47,6 +48,12 @@ pub fn turn_final_texts(events: &[NormalizedEvent]) -> Vec<String> {
             }
             NormalizedEvent::AssistantFinal { text, .. } if !text.trim().is_empty() => {
                 current = Some(text.clone());
+            }
+            NormalizedEvent::Compaction => {
+                if in_turn && let Some(text) = current.take() {
+                    finals.push(text);
+                }
+                in_turn = false;
             }
             _ => {}
         }
@@ -128,12 +135,18 @@ fn miss_rate(marked: &[bool]) -> f64 {
 }
 
 pub fn signals(events: &[NormalizedEvent], caps: Capabilities, cfg: &ScoreConfig) -> Signals {
-    let finals = turn_final_texts(events);
-    let turns = finals.len();
+    let turns = turn_final_texts(events).len();
+    let boundary = events
+        .iter()
+        .rposition(|event| matches!(event, NormalizedEvent::Compaction))
+        .map_or(events, |index| &events[index + 1..]);
+    let finals = turn_final_texts(boundary);
 
     let marker_ever = finals.iter().any(|t| has_marker(t, &cfg.marker));
-    let marker_active =
-        caps.marker_signal && !cfg.marker.is_empty() && marker_ever && turns >= cfg.min_turns;
+    let marker_active = caps.marker_signal
+        && !cfg.marker.is_empty()
+        && marker_ever
+        && finals.len() >= cfg.min_turns;
 
     let marker_miss_rate = marker_active.then(|| {
         let marked: Vec<bool> = last_window(&finals, cfg.window)
@@ -143,7 +156,7 @@ pub fn signals(events: &[NormalizedEvent], caps: Capabilities, cfg: &ScoreConfig
         miss_rate(&marked)
     });
 
-    let tail = events_in_last_turns(events, cfg.window);
+    let tail = events_in_last_turns(boundary, cfg.window);
 
     let tool_failure_rate = failure_rate(tail.iter().filter_map(|e| match e {
         NormalizedEvent::ToolResult { is_error } => Some(*is_error),
@@ -157,12 +170,24 @@ pub fn signals(events: &[NormalizedEvent], caps: Capabilities, cfg: &ScoreConfig
         }),
         cfg.repetition_threshold,
     );
+    let provider_overflows = tail
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                NormalizedEvent::ProviderError {
+                    class: ProviderErrorClass::Overflow
+                }
+            )
+        })
+        .count();
 
     Signals {
         turns,
         tool_failure_rate,
         repetition_hits,
         max_repeat,
+        provider_overflows,
         marker_miss_rate,
     }
 }
@@ -173,6 +198,7 @@ pub fn signals(events: &[NormalizedEvent], caps: Capabilities, cfg: &ScoreConfig
 struct Segment {
     calls: Vec<(String, u64)>,
     results: Vec<bool>,
+    provider_overflows: usize,
 }
 
 /// Exactly what `signals` and `context_tokens` read out of a full event
@@ -189,6 +215,8 @@ pub struct RotState {
     window: usize,
     /// Turn finals already closed by a later `TurnStart`.
     closed_turns: usize,
+    /// Closed turn finals since the latest compaction boundary.
+    behavioral_closed_turns: usize,
     /// `has_marker` of the last `window` closed finals, oldest first.
     closed_markers: VecDeque<bool>,
     marker_seen: bool,
@@ -213,6 +241,7 @@ impl RotState {
             marker: cfg.marker.clone(),
             window: cfg.window,
             closed_turns: 0,
+            behavioral_closed_turns: 0,
             closed_markers: VecDeque::new(),
             marker_seen: false,
             in_turn: false,
@@ -272,17 +301,38 @@ impl RotState {
                     segment.results.push(*is_error);
                 }
             }
-            NormalizedEvent::Compaction => {}
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::Overflow,
+            } => {
+                if let Some(segment) = self.segments.back_mut() {
+                    segment.provider_overflows += 1;
+                }
+            }
+            NormalizedEvent::ProviderError { .. } | NormalizedEvent::ModelId { .. } => {}
+            NormalizedEvent::Compaction => self.reset_behavioral_window(),
         }
     }
 
     fn close_turn(&mut self, marked: bool) {
         self.closed_turns += 1;
+        self.behavioral_closed_turns += 1;
         self.marker_seen |= marked;
         self.closed_markers.push_back(marked);
         if self.closed_markers.len() > self.window {
             self.closed_markers.pop_front();
         }
+    }
+
+    fn reset_behavioral_window(&mut self) {
+        if self.in_turn && self.open_marker.is_some() {
+            self.closed_turns += 1;
+        }
+        self.behavioral_closed_turns = 0;
+        self.closed_markers.clear();
+        self.marker_seen = false;
+        self.in_turn = false;
+        self.open_marker = None;
+        self.segments = VecDeque::from([Segment::default()]);
     }
 
     /// `None` when `cfg` no longer matches the rules this state was folded
@@ -303,9 +353,13 @@ impl RotState {
         // The open turn's text is a turn final too: a full parse flushes it at
         // the end of the stream even though no later `TurnStart` closed it.
         let turns = self.closed_turns + usize::from(self.open_marker.is_some());
+        let behavioral_turns =
+            self.behavioral_closed_turns + usize::from(self.open_marker.is_some());
         let marker_ever = self.marker_seen || self.open_marker == Some(true);
-        let marker_active =
-            caps.marker_signal && !cfg.marker.is_empty() && marker_ever && turns >= cfg.min_turns;
+        let marker_active = caps.marker_signal
+            && !cfg.marker.is_empty()
+            && marker_ever
+            && behavioral_turns >= cfg.min_turns;
 
         let marker_miss_rate = marker_active.then(|| {
             let mut marked: Vec<bool> = self.closed_markers.iter().copied().collect();
@@ -324,12 +378,18 @@ impl RotState {
                 .flat_map(|s| s.calls.iter().map(|(name, hash)| (name.as_str(), *hash))),
             cfg.repetition_threshold,
         );
+        let provider_overflows = self
+            .segments
+            .iter()
+            .map(|segment| segment.provider_overflows)
+            .sum();
 
         Signals {
             turns,
             tool_failure_rate,
             repetition_hits,
             max_repeat,
+            provider_overflows,
             marker_miss_rate,
         }
     }
@@ -363,6 +423,8 @@ pub struct Score {
     pub verdict: Verdict,
     pub signals: Signals,
     pub context_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_change: Option<ModelChange>,
 }
 
 /// Zero below the threshold, then a linear ramp that saturates at
@@ -475,11 +537,18 @@ pub fn score_from(signals: Signals, tokens: u64, cfg: &ScoreConfig, caps: Capabi
         + cfg.weight_marker * signals.marker_miss_rate.unwrap_or(0.0);
     let score = raw.round().clamp(0.0, 100.0) as u32;
 
+    let overflow_verdict = match signals.provider_overflows {
+        0 => Verdict::Healthy,
+        1 => Verdict::Compact,
+        _ => Verdict::Restart,
+    };
+
     Score {
         score,
-        verdict: verdict_for(score, tokens, cfg, caps),
+        verdict: verdict_for(score, tokens, cfg, caps).max(overflow_verdict),
         signals,
         context_tokens: tokens,
+        model_change: None,
     }
 }
 
@@ -487,7 +556,9 @@ pub fn score_from(signals: Signals, tokens: u64, cfg: &ScoreConfig, caps: Capabi
 mod tests {
     use super::*;
     use crate::commands::ctx::config::ScoreConfig;
-    use crate::commands::ctx::event::{Capabilities, NormalizedEvent, input_hash};
+    use crate::commands::ctx::event::{
+        Capabilities, NormalizedEvent, ProviderErrorClass, input_hash,
+    };
 
     /// Issue #155, Phase 6(c): `rot.rs` stays pure -- no filesystem, clock,
     /// env, network, AND no visibility into quota/usage data (`pace`/
@@ -1216,6 +1287,75 @@ mod tests {
         assert_eq!(result.verdict, Verdict::Healthy);
         assert_eq!(result.context_tokens, 0);
         assert_eq!(result.signals.turns, 0);
+    }
+
+    #[test]
+    fn provider_overflow_escalates_even_below_the_token_floor() {
+        let cfg = ScoreConfig::default();
+        let overflow = NormalizedEvent::ProviderError {
+            class: ProviderErrorClass::Overflow,
+        };
+
+        let once = score_events(std::slice::from_ref(&overflow), full_caps(), &cfg);
+        assert_eq!(once.score, 0);
+        assert_eq!(once.context_tokens, 0);
+        assert_eq!(once.signals.provider_overflows, 1);
+        assert_eq!(once.verdict, Verdict::Compact);
+
+        let twice = score_events(&[overflow.clone(), overflow], full_caps(), &cfg);
+        assert_eq!(twice.signals.provider_overflows, 2);
+        assert_eq!(twice.verdict, Verdict::Restart);
+    }
+
+    #[test]
+    fn non_overflow_provider_events_and_model_ids_do_not_change_the_verdict() {
+        let cfg = ScoreConfig::default();
+        let baseline = score_events(&[], full_caps(), &cfg);
+        let events = [
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::RateLimit,
+            },
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::Other,
+            },
+            NormalizedEvent::ModelId {
+                id: "claude-sonnet-5".to_string(),
+            },
+        ];
+
+        assert_eq!(score_events(&events, full_caps(), &cfg), baseline);
+    }
+
+    #[test]
+    fn compaction_clears_behavioral_state_but_preserves_lifetime_turns_and_tokens() {
+        let cfg = ScoreConfig::default();
+        let mut events = looping_turns(3, "", "[zirv] ok", true, 120_000);
+        events.extend([
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::Overflow,
+            },
+            NormalizedEvent::ProviderError {
+                class: ProviderErrorClass::Overflow,
+            },
+        ]);
+        let before = score_events(&events, full_caps(), &cfg);
+        assert_eq!(before.signals.turns, 3);
+        assert_eq!(before.signals.max_repeat, 3);
+        assert_eq!(before.signals.tool_failure_rate, 1.0);
+        assert_eq!(before.signals.provider_overflows, 2);
+
+        events.push(NormalizedEvent::Compaction);
+        let after = score_events(&events, full_caps(), &cfg);
+        assert_eq!(after.signals.turns, 3, "turn count is lifetime state");
+        assert_eq!(after.signals.max_repeat, 0);
+        assert_eq!(after.signals.tool_failure_rate, 0.0);
+        assert_eq!(after.signals.marker_miss_rate, None);
+        assert_eq!(after.signals.provider_overflows, 0);
+        assert_eq!(after.context_tokens, 120_000, "tokens self-correct later");
+
+        let mut state = RotState::new(&cfg).expect("bounded state");
+        state.feed_all(&events);
+        assert_eq!(state.score(full_caps(), &cfg), Some(after));
     }
 
     #[test]

--- a/src/commands/ctx/run_loop.rs
+++ b/src/commands/ctx/run_loop.rs
@@ -506,24 +506,26 @@ pub(crate) fn run_with_clock<W: Write>(
                     );
                 }
                 match poll_result {
-                    Ok((Some(score), _)) => match super::exec::action_for_verdict(score.verdict) {
-                        super::exec::SignalAction::Stop => {
-                            rotted = true;
-                            Tick::Stop("rot")
+                    Ok((Some(score), _)) => {
+                        match super::exec::action_for_verdict(adapter.as_ref(), score.verdict) {
+                            super::exec::SignalAction::Stop => {
+                                rotted = true;
+                                Tick::Stop("rot")
+                            }
+                            super::exec::SignalAction::Compact
+                                if compact_budget.ready(Instant::now(), compact_window) =>
+                            {
+                                compact_budget.arm(Instant::now());
+                                compact_requested = true;
+                                Tick::Stop("compact")
+                            }
+                            super::exec::SignalAction::Compact => Tick::Continue,
+                            super::exec::SignalAction::Ignore => {
+                                compact_budget.observe_progress();
+                                Tick::Continue
+                            }
                         }
-                        super::exec::SignalAction::Compact
-                            if compact_budget.ready(Instant::now(), compact_window) =>
-                        {
-                            compact_budget.arm(Instant::now());
-                            compact_requested = true;
-                            Tick::Stop("compact")
-                        }
-                        super::exec::SignalAction::Compact => Tick::Continue,
-                        super::exec::SignalAction::Ignore => {
-                            compact_budget.observe_progress();
-                            Tick::Continue
-                        }
-                    },
+                    }
                     _ => Tick::Continue,
                 }
             };
@@ -546,7 +548,7 @@ pub(crate) fn run_with_clock<W: Write>(
                 );
             }
 
-            if compact_requested {
+            if super::exec::should_attempt_compact(compact_requested, limit_hit) {
                 let compact_result = super::exec::compact_in_place(
                     adapter.as_ref(),
                     Some(&transcript),

--- a/src/commands/ctx/run_loop.rs
+++ b/src/commands/ctx/run_loop.rs
@@ -5,7 +5,6 @@ use std::time::{Duration, Instant};
 use super::config::{CtxConfig, EnvLookup, env_from_process};
 use super::event::{SessionId, SessionRef};
 use super::pace;
-use super::rot::Verdict;
 use super::state::{StateDir, now_secs};
 use super::supervise::{self, Outcome, Tick};
 use super::{CtxResult, adapters, log, score};
@@ -399,7 +398,7 @@ pub(crate) fn run_with_clock<W: Write>(
         // path). Probed the same way exec.rs now does: the real headless
         // launcher prefix, no prompt token yet, checked with `launch_
         // reparses_through_shim`, which covers both forms.
-        let (mut command, stdin_prompt) =
+        let (mut command, mut stdin_prompt) =
             if prompt_delivery_via_stdin(adapter.as_ref(), &session, &extra) {
                 match adapter.headless_cmd_stdin(&session, &extra) {
                     Some(command) => (command, Some(prompt.clone())),
@@ -415,47 +414,50 @@ pub(crate) fn run_with_clock<W: Write>(
         // agent's session inherited that session's `ZIRV_CTX_SESSION` and
         // `ZIRV_CTX_SOCKET` and reported its own turn boundaries into the
         // outer supervisor's rot engine.
-        super::sessions::scrub_supervision_env_cmd(&mut command);
-        // Names the same fact `ctx.toml`'s own `agent` key would, so a nested
-        // `zirv ctx ...` call inside this cycle's own child processes
-        // defaults to this cycle's harness rather than re-resolving from
-        // scratch.
-        command.env(super::adapters::AGENT_ENV, adapter.name());
+        let apply_session_env = |command: &mut std::process::Command| {
+            super::sessions::scrub_supervision_env_cmd(command);
+            // Names the same fact `ctx.toml`'s own `agent` key would, so a
+            // nested `zirv ctx ...` call inside this cycle's own child
+            // processes defaults to this cycle's harness rather than
+            // re-resolving from scratch.
+            command.env(super::adapters::AGENT_ENV, adapter.name());
+        };
+        apply_session_env(&mut command);
 
         writeln!(w, "zirv ctx loop: cycle {cycle} session {session}")?;
-        // P2/P3: see the matching comment in `exec.rs` -- this cycle's child
-        // is registered for the console-close sweep and held in a
-        // kill-on-close job for as long as `_child_guard` is in scope, which
-        // is this cycle.
-        let (mut child, tap, _child_guard) = supervise::spawn_tapped(command, stdin_prompt)?;
-        // Item 3: consumed right after this cycle's own spawn has actually
-        // succeeded, so the next cycle's fresh `mail::list` does not pick
-        // the same message up again -- but a launch that never got this far
-        // (spawn_tapped failed, or `?` above already returned) leaves it
-        // unread. A failed consume must not stop the cycle: the mail has
-        // already reached the prompt either way, and housekeeping failures
-        // are best-effort throughout the state dir.
-        for (path, _) in mail_entries.drain(..) {
-            let _ = super::mail::consume_and_log(
-                &state,
-                &mail_slug,
-                &path,
-                &session_short,
-                "loop",
-                "loop:cycle-prompt",
-            );
-        }
-        let mut scorer = score::IncrementalScorer::new(transcript.clone());
-        let mut rotted = false;
-        let mut limit_hit = false;
         // C7: the stable registry address this run answers to, resolved once
-        // per cycle so the tick closure below borrows a plain `String`
-        // rather than the `Option` the loop keeps mutating.
+        // per cycle so each tick closure below borrows a plain `String`
+        // rather than the `Option` the outer loop keeps mutating.
         let nudge_address = registry_short
             .clone()
             .unwrap_or_else(|| session_short.clone());
+        let prompt_via_stdin = prompt_delivery_via_stdin(adapter.as_ref(), &session, &extra);
+        let mut compact_budget = super::exec::CompactBudget::default();
+        let compact_window = Duration::from_secs(cfg.supervise.interval_secs);
 
-        let outcome = {
+        let (outcome, rotted, limit_hit) = loop {
+            // P2/P3: see the matching comment in `exec.rs` -- each child in
+            // this cycle is registered for the console-close sweep and held
+            // in a kill-on-close job for exactly that child's life.
+            let (mut child, tap, _child_guard) =
+                supervise::spawn_tapped(command, stdin_prompt.clone())?;
+            // Item 3: consumed right after the first spawn that actually
+            // carried this cycle's prompt. The drain makes every in-place
+            // continuation a no-op here.
+            for (path, _) in mail_entries.drain(..) {
+                let _ = super::mail::consume_and_log(
+                    &state,
+                    &mail_slug,
+                    &path,
+                    &session_short,
+                    "loop",
+                    "loop:cycle-prompt",
+                );
+            }
+            let mut scorer = score::IncrementalScorer::new(transcript.clone());
+            let mut rotted = false;
+            let mut compact_requested = false;
+            let mut limit_hit = false;
             let mut tick = || {
                 if pace::scan_for_limit(
                     &tap.try_lines(),
@@ -504,30 +506,130 @@ pub(crate) fn run_with_clock<W: Write>(
                     );
                 }
                 match poll_result {
-                    Ok((Some(score), _)) if score.verdict == Verdict::Restart => {
-                        rotted = true;
-                        Tick::Stop("rot")
-                    }
+                    Ok((Some(score), _)) => match super::exec::action_for_verdict(score.verdict) {
+                        super::exec::SignalAction::Stop => {
+                            rotted = true;
+                            Tick::Stop("rot")
+                        }
+                        super::exec::SignalAction::Compact
+                            if compact_budget.ready(Instant::now(), compact_window) =>
+                        {
+                            compact_budget.arm(Instant::now());
+                            compact_requested = true;
+                            Tick::Stop("compact")
+                        }
+                        super::exec::SignalAction::Compact => Tick::Continue,
+                        super::exec::SignalAction::Ignore => {
+                            compact_budget.observe_progress();
+                            Tick::Continue
+                        }
+                    },
                     _ => Tick::Continue,
                 }
             };
-            supervise::supervise_child(&mut child, Instant::now() + max_cycle, poll, &mut tick)?
-        };
+            let outcome = supervise::supervise_child(
+                &mut child,
+                Instant::now() + max_cycle,
+                poll,
+                &mut tick,
+            )?;
 
-        // See the matching comment in exec.rs: supervise_child checks the
-        // child's exit status before calling the tick, so a fast limit-hit
-        // exit can race past the last tick that would have caught it.
-        // `drain_to_eof`, not `try_lines`: see `supervise.rs`'s own doc
-        // comment on it for why `try_lines` alone does not close this race.
-        if !limit_hit {
-            limit_hit = pace::scan_for_limit(
-                &tap.drain_to_eof(supervise::FINAL_DRAIN_BUDGET),
-                &state,
-                session.as_str(),
-                "loop",
-                &mut std::io::stderr(),
-            );
-        }
+            // See the matching comment in exec.rs: supervise_child checks
+            // exit before the tick, so final output needs one bounded drain.
+            if !limit_hit {
+                limit_hit = pace::scan_for_limit(
+                    &tap.drain_to_eof(supervise::FINAL_DRAIN_BUDGET),
+                    &state,
+                    session.as_str(),
+                    "loop",
+                    &mut std::io::stderr(),
+                );
+            }
+
+            if compact_requested {
+                let compact_result = super::exec::compact_in_place(
+                    adapter.as_ref(),
+                    Some(&transcript),
+                    Duration::from_millis(cfg.wrap.inject_timeout_ms),
+                    poll,
+                    |compact_prompt| {
+                        let (mut compact, stdin_prompt) = super::exec::headless_resume_launch(
+                            adapter.as_ref(),
+                            compact_prompt,
+                            &session,
+                            &extra,
+                            prompt_via_stdin,
+                        )?;
+                        compact.current_dir(repo);
+                        apply_session_env(&mut compact);
+                        Some((compact, stdin_prompt))
+                    },
+                )
+                .and_then(|()| {
+                    let continuation = format!(
+                        "{prompt}\n\nContinue the same loop cycle after the verified in-place \
+                         compaction without redoing completed work."
+                    );
+                    let (mut continued, stdin_prompt) = super::exec::headless_resume_launch(
+                        adapter.as_ref(),
+                        &continuation,
+                        &session,
+                        &extra,
+                        prompt_via_stdin,
+                    )
+                    .ok_or_else(|| {
+                        format!(
+                            "adapter '{}' cannot resume a headless session in place",
+                            adapter.name()
+                        )
+                    })?;
+                    continued.current_dir(repo);
+                    apply_session_env(&mut continued);
+                    Ok((continued, stdin_prompt))
+                });
+                let verified = compact_result.is_ok();
+                announcer.emit(&super::announce::Event::Compact { verified });
+                match compact_result {
+                    Ok((continued, continued_stdin)) => {
+                        let _ = log::append(
+                            &state,
+                            &log::Decision {
+                                ts: now_secs(),
+                                session: session.as_str(),
+                                verb: "loop",
+                                verdict: "compact",
+                                score: 0,
+                                action: "compact",
+                                detail: &transcript.display().to_string(),
+                            },
+                        );
+                        command = continued;
+                        stdin_prompt = continued_stdin;
+                        continue;
+                    }
+                    Err(reason) => {
+                        let _ = log::append(
+                            &state,
+                            &log::Decision {
+                                ts: now_secs(),
+                                session: session.as_str(),
+                                verb: "loop",
+                                verdict: "compact",
+                                score: 0,
+                                action: "compact-failed",
+                                detail: &reason,
+                            },
+                        );
+                        writeln!(
+                            w,
+                            "zirv ctx loop: {reason}; falling back to the next fresh cycle"
+                        )?;
+                        rotted = true;
+                    }
+                }
+            }
+            break (outcome, rotted, limit_hit);
+        };
 
         let (action, failed) = match outcome {
             // A usage limit is the window's fault, not the cycle's: park and
@@ -874,6 +976,51 @@ mod tests {
             }
         }
         found
+    }
+
+    #[test]
+    fn a_compact_tier_loop_cycle_compacts_and_continues_the_same_session() {
+        let tmp = crate::commands::ctx::testenv::repo();
+        let home = tmp.path().join("home");
+        let state = tmp.path().join("state");
+        let modes = tmp.path().join("modes.txt");
+        let argv_log = tmp.path().join("argv.log");
+        std::fs::write(&modes, "compact-tier\nhealthy\n").expect("write modes");
+        let mut env = base_env(&state);
+        env.insert("ZIRV_CTX_INJECT_TIMEOUT_MS".to_string(), "2000".to_string());
+        env.insert("ZIRV_CTX_INTERVAL_SECS".to_string(), "0".to_string());
+
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+        let _fake_agent = crate::commands::ctx::testenv::VarGuard::set(&[
+            ("FAKE_AGENT_MODE_FILE", modes.to_str()),
+            ("FAKE_AGENT_SLEEP", Some("3")),
+            ("FAKE_AGENT_ARGV_LOG", argv_log.to_str()),
+        ]);
+        let mut out = Vec::new();
+        let code = run_with(&args_for(1), &mut out, tmp.path(), &|key| {
+            env.get(key).cloned()
+        });
+        assert_eq!(code.expect("runs"), 0);
+
+        let argv = std::fs::read_to_string(&argv_log).expect("argv log");
+        assert!(
+            argv.contains("/compact"),
+            "compact command was launched: {argv}"
+        );
+        assert!(
+            argv.contains("--resume"),
+            "the same session was resumed: {argv}"
+        );
+        let log = std::fs::read_to_string(state.join("logs/decisions.jsonl")).expect("log");
+        assert!(
+            log.contains("\"verb\":\"loop\"") && log.contains("\"action\":\"compact\""),
+            "{log}"
+        );
+        assert_eq!(
+            transcripts_in(&home).len(),
+            1,
+            "in-place continuation keeps the cycle's session id"
+        );
     }
 
     #[test]

--- a/src/commands/ctx/run_loop.rs
+++ b/src/commands/ctx/run_loop.rs
@@ -503,6 +503,10 @@ pub(crate) fn run_with_clock<W: Write>(
                         &mut screening_announced,
                     );
                 }
+                if scorer.provider_limit_hit() {
+                    limit_hit = true;
+                    return Tick::Stop("limit");
+                }
                 match poll_result {
                     Ok((Some(score), _)) if score.verdict == Verdict::Restart => {
                         rotted = true;
@@ -513,6 +517,11 @@ pub(crate) fn run_with_clock<W: Write>(
             };
             supervise::supervise_child(&mut child, Instant::now() + max_cycle, poll, &mut tick)?
         };
+
+        if !limit_hit {
+            let _ = scorer.poll(adapter.as_ref(), &cfg.score);
+            limit_hit = scorer.provider_limit_hit();
+        }
 
         // See the matching comment in exec.rs: supervise_child checks the
         // child's exit status before calling the tick, so a fast limit-hit

--- a/src/commands/ctx/score.rs
+++ b/src/commands/ctx/score.rs
@@ -1446,6 +1446,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_pre_compaction_reset_checkpoint_without_new_rot_fields_still_loads() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript = dir.path().join("session.jsonl");
+        std::fs::write(&transcript, "").expect("transcript");
+        let path = dir.path().join("checkpoint.json");
+        let cfg = ScoreConfig::default();
+        let adapter = super::adapters::claude::ClaudeAdapter::new(None);
+        let fingerprint = fingerprint(&adapter, &cfg);
+        let checkpoint = Checkpoint {
+            version: CHECKPOINT_VERSION,
+            transcript: transcript.display().to_string(),
+            fingerprint,
+            offset: 0,
+            consumed: 0,
+            state: RotState::new(&cfg).expect("bounded state"),
+            model: None,
+            model_tracker: ModelTracker::default(),
+        };
+        let mut json = serde_json::to_value(checkpoint).expect("serialize checkpoint");
+        let state = json["state"].as_object_mut().expect("state object");
+        state.remove("behavioral_closed_turns");
+        for segment in state["segments"].as_array_mut().expect("segments") {
+            segment
+                .as_object_mut()
+                .expect("segment object")
+                .remove("provider_overflows");
+        }
+        std::fs::write(&path, json.to_string()).expect("legacy checkpoint");
+
+        assert!(
+            load_checkpoint(&path, &transcript, fingerprint, &cfg).is_some(),
+            "a checkpoint written before the compaction-reset fields existed must deserialize \
+             with their zero defaults"
+        );
+    }
+
     /// Every way a checkpoint can stop describing the file it was written for.
     /// All of them have to land on the full-parse answer, silently.
     #[test]

--- a/src/commands/ctx/score.rs
+++ b/src/commands/ctx/score.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::adapters::AgentAdapter;
 use super::config::{CtxConfig, EnvLookup, ScoreConfig, env_from_process};
-use super::event::{SessionId, SessionRef, input_hash};
+use super::event::{ModelChange, NormalizedEvent, SessionId, SessionRef, input_hash};
 use super::rot::{self, RotState, Score};
 use super::screen::{self, ScreenReport};
 use super::state::StateDir;
@@ -20,6 +20,69 @@ pub struct ScoreArgs {
     /// Adapter name: claude or codex. Defaults to config, then claude.
     #[arg(long)]
     pub agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct ModelTracker {
+    turns: usize,
+    current: Option<String>,
+    latest_change: Option<TrackedModelChange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TrackedModelChange {
+    from: String,
+    to: String,
+    turn: usize,
+}
+
+impl ModelTracker {
+    fn feed_all(&mut self, events: &[NormalizedEvent]) {
+        for event in events {
+            match event {
+                NormalizedEvent::TurnStart => self.turns += 1,
+                NormalizedEvent::ModelId { id } => self.feed_model(id),
+                _ => {}
+            }
+        }
+    }
+
+    fn feed_model(&mut self, id: &str) {
+        let Some(from) = self.current.as_ref() else {
+            self.current = Some(id.to_string());
+            return;
+        };
+        if from.eq_ignore_ascii_case(id) {
+            return;
+        }
+        self.latest_change = Some(TrackedModelChange {
+            from: from.clone(),
+            to: id.to_string(),
+            turn: self.turns,
+        });
+        self.current = Some(id.to_string());
+    }
+
+    fn report(&self, adapter: &dyn AgentAdapter) -> Option<ModelChange> {
+        let change = self.latest_change.as_ref()?;
+        let mut report = ModelChange {
+            from: change.from.clone(),
+            to: change.to.clone(),
+            turns_ago: self.turns.saturating_sub(change.turn),
+            limit_pressure: false,
+        };
+        report.limit_pressure = super::pace::model_change_is_limit_pressure(adapter, &report);
+        Some(report)
+    }
+}
+
+fn attach_model_change(
+    mut score: Score,
+    tracker: &ModelTracker,
+    adapter: &dyn AgentAdapter,
+) -> Score {
+    score.model_change = tracker.report(adapter);
+    score
 }
 
 /// Read a whole transcript, parse it with the selected adapter, score it. The
@@ -54,8 +117,15 @@ fn full_score(
     // into `capabilities_for_model` rather than the conservative "unstated
     // model" default `capabilities()` always carries. A `[1m]` claude seat's
     // real 1M window now reaches rot's token gates on every full parse.
+    let events = adapter.parse_events(&jsonl);
     let caps = adapter.capabilities_for_model(adapter.model_hint(&jsonl).as_deref());
-    Ok(rot::score_events(&adapter.parse_events(&jsonl), caps, cfg))
+    let mut tracker = ModelTracker::default();
+    tracker.feed_all(&events);
+    Ok(attach_model_change(
+        rot::score_events(&events, caps, cfg),
+        &tracker,
+        adapter,
+    ))
 }
 
 /// One-shot scoring, used by the `score` verb itself: no state is kept, so the
@@ -69,6 +139,26 @@ pub fn score_transcript(
     let cfg = CtxConfig::load(repo, env)?;
     let adapter = adapters::select(agent.or(cfg.agent.as_deref()), &[], &cfg)?;
     full_score(adapter.as_ref(), transcript, &cfg.score)
+}
+
+/// Best-effort model-change lookup for one registered session. Status is the
+/// consumer: transcript resolution and reading stay at this I/O layer rather
+/// than leaking into the pure rot fold or the renderer.
+pub fn model_change_for_session(
+    agent: &str,
+    session_id: &str,
+    repo: &Path,
+    env: EnvLookup<'_>,
+) -> Option<ModelChange> {
+    let cfg = CtxConfig::load(repo, env).ok()?;
+    let adapter = adapters::select(Some(agent), &[], &cfg).ok()?;
+    let transcript = adapter.transcript_path(&SessionRef {
+        id: SessionId::parse(session_id),
+        cwd: repo.to_path_buf(),
+    });
+    full_score(adapter.as_ref(), &transcript, &cfg.score)
+        .ok()?
+        .model_change
 }
 
 /// Folds a growing transcript into a `RotState` so each pass costs the bytes
@@ -86,6 +176,8 @@ pub struct IncrementalScorer {
     /// not to mention a model (e.g. a lone tool-result line) must not read
     /// as "no model at all" -- it keeps whatever was last resolved.
     model: Option<String>,
+    model_tracker: ModelTracker,
+    provider_limit_hit: bool,
 }
 
 impl IncrementalScorer {
@@ -95,6 +187,8 @@ impl IncrementalScorer {
             transcript,
             state: None,
             model: None,
+            model_tracker: ModelTracker::default(),
+            provider_limit_hit: false,
         }
     }
 
@@ -105,12 +199,15 @@ impl IncrementalScorer {
         consumed: u64,
         state: RotState,
         model: Option<String>,
+        model_tracker: ModelTracker,
     ) -> Self {
         Self {
             watcher: Watcher::resuming(transcript.clone(), offset, consumed),
             transcript,
             state: Some(state),
             model,
+            model_tracker,
+            provider_limit_hit: false,
         }
     }
 
@@ -124,6 +221,10 @@ impl IncrementalScorer {
 
     fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    pub fn provider_limit_hit(&self) -> bool {
+        self.provider_limit_hit
     }
 
     /// `None` when the transcript has not changed since the last poll, which
@@ -183,6 +284,7 @@ impl IncrementalScorer {
         adapter: &dyn AgentAdapter,
         cfg: &ScoreConfig,
     ) -> CtxResult<(Option<Score>, Option<ScreenReport>)> {
+        self.provider_limit_hit = false;
         if !adapter.capabilities().events {
             return Ok((None, None));
         }
@@ -204,6 +306,7 @@ impl IncrementalScorer {
             // different session entirely -- issue #155 D1 -- so a model
             // resolved off the old one must not linger past the rebuild.
             self.model = None;
+            self.model_tracker = ModelTracker::default();
         }
         // Issue #155 D1: resolved off the committed lines every poll, newest
         // wins, kept across polls (see the `model` field's own doc comment).
@@ -214,38 +317,48 @@ impl IncrementalScorer {
             self.model = Some(model);
         }
         let model = self.model.clone();
+        let events = adapter.parse_events(&appended.lines);
+        self.provider_limit_hit = super::pace::provider_events_hit_limit(&events);
+        self.model_tracker.feed_all(&events);
         let Some(state) = self.state.as_mut() else {
             // An unbounded window has no bounded state to fold into.
             let score = full_score(adapter, &self.transcript, cfg)?;
             return Ok((Some(score), screening));
         };
-        state.feed_all(&adapter.parse_events(&appended.lines));
+        state.feed_all(&events);
 
         // The line the agent is still writing counts towards this pass's score
         // -- a full parse would see it too -- but is never committed to the
         // state, because the next poll reads it again, complete.
         if appended.partial.is_empty() {
             let caps = adapter.capabilities_for_model(model.as_deref());
-            return Ok((state.score(caps, cfg), screening));
+            let score = state
+                .score(caps, cfg)
+                .map(|score| attach_model_change(score, &self.model_tracker, adapter));
+            return Ok((score, screening));
         }
+        let partial_events = adapter.parse_events(&appended.partial);
+        self.provider_limit_hit |= super::pace::provider_events_hit_limit(&partial_events);
         let mut with_partial = state.clone();
-        with_partial.feed_all(&adapter.parse_events(&appended.partial));
+        with_partial.feed_all(&partial_events);
+        let mut partial_tracker = self.model_tracker.clone();
+        partial_tracker.feed_all(&partial_events);
         // The partial line might be the only place a fresh model switch shows
         // up so far; it is never committed to `self.model` (mirroring
         // `state`/`with_partial` above), only used for this one score.
         let partial_model = adapter.model_hint(&appended.partial).or(model);
         let caps = adapter.capabilities_for_model(partial_model.as_deref());
-        Ok((with_partial.score(caps, cfg), screening))
+        let score = with_partial
+            .score(caps, cfg)
+            .map(|score| attach_model_change(score, &partial_tracker, adapter));
+        Ok((score, screening))
     }
 }
 
 /// Bumped whenever the checkpoint or `RotState` changes shape, so an older
-/// file is ignored and rebuilt instead of misread. Issue #155 D1: bumped to
-/// 2 for the new `model` field -- a checkpoint written before that field
-/// existed would otherwise resume with `model: None` until the next poll
-/// happens to carry a fresh assistant line, which is usually immediate but
-/// not guaranteed; the version bump forces one clean rebuild instead.
-const CHECKPOINT_VERSION: u32 = 2;
+/// file is ignored and rebuilt instead of misread. Version 3 adds the model
+/// history needed to report changes across fresh-process Stop-hook polls.
+const CHECKPOINT_VERSION: u32 = 3;
 
 /// What a fresh process needs to carry on folding where the last one stopped.
 #[derive(Debug, Serialize, Deserialize)]
@@ -268,6 +381,8 @@ struct Checkpoint {
     /// the version bump above.
     #[serde(default)]
     model: Option<String>,
+    #[serde(default)]
+    model_tracker: ModelTracker,
 }
 
 /// Everything outside the transcript that decides what the same bytes score
@@ -330,6 +445,7 @@ fn save_checkpoint(path: &Path, transcript: &Path, fingerprint: u64, scorer: &In
         consumed,
         state: state.clone(),
         model: scorer.model().map(str::to_string),
+        model_tracker: scorer.model_tracker.clone(),
     }) else {
         return;
     };
@@ -407,6 +523,7 @@ fn score_with_checkpoint(
             checkpoint.consumed,
             checkpoint.state,
             checkpoint.model,
+            checkpoint.model_tracker,
         ),
         None => IncrementalScorer::new(transcript.to_path_buf()),
     };
@@ -1065,6 +1182,45 @@ mod tests {
             rot::Verdict::Healthy,
             "the same token count must escalate at the 200k default ceiling: {baseline:?}"
         );
+    }
+
+    #[test]
+    fn score_reports_model_identity_drift_without_using_it_as_rot_evidence() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript = fixture_path("claude-provider-errors-model-drift.jsonl");
+        let score =
+            score_transcript(&transcript, Some("claude"), dir.path(), &|_| None).expect("score");
+        let change = score.model_change.expect("model change");
+
+        assert_eq!(change.from, "claude-opus-5");
+        assert_eq!(change.to, "claude-sonnet-5");
+        assert_eq!(change.turns_ago, 0);
+        assert!(change.limit_pressure);
+        assert_eq!(score.score, 0, "model drift is not a weighted rot signal");
+        assert_eq!(
+            score.verdict,
+            rot::Verdict::Compact,
+            "overflow alone escalates"
+        );
+    }
+
+    #[test]
+    fn incremental_scoring_routes_a_provider_rate_limit_into_pace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript = dir.path().join("t.jsonl");
+        std::fs::write(
+            &transcript,
+            std::fs::read_to_string(fixture_path("claude-provider-errors-model-drift.jsonl"))
+                .expect("fixture"),
+        )
+        .expect("write transcript");
+        let adapter = super::adapters::claude::ClaudeAdapter::new(None);
+        let mut scorer = IncrementalScorer::new(transcript);
+
+        scorer
+            .poll(&adapter, &ScoreConfig::default())
+            .expect("poll");
+        assert!(scorer.provider_limit_hit());
     }
 
     /// Issue #155 D1: `exec`/`loop`'s own rot-restart gate polls through

--- a/src/commands/ctx/state.rs
+++ b/src/commands/ctx/state.rs
@@ -438,6 +438,19 @@ impl StateDir {
         self.0.join("approvals")
     }
 
+    /// Issue #298: cached harness-liveness probe verdicts, one file per
+    /// repository slug (`<state>/probes/<repo-slug>.json`). Keyed by repo
+    /// rather than by session id, unlike `adoption()`/`status_snapshots()`
+    /// above: a session id is minted fresh per harness process (see
+    /// `adoption()`'s own doc comment), and `run_loop` in particular mints a
+    /// new one every cycle, so a strictly per-session file would never be
+    /// read back by the one launch path that most needs reuse. See
+    /// `adapters::ProbeCache`'s own doc comment for the TTL that keeps a
+    /// repo-scoped cache from going stale forever instead.
+    pub fn probes(&self) -> PathBuf {
+        self.0.join("probes")
+    }
+
     /// First 8 hex characters of the session id keep the socket path short.
     pub fn socket_for(&self, session: &str) -> PathBuf {
         let short: String = session

--- a/src/commands/ctx/status.rs
+++ b/src/commands/ctx/status.rs
@@ -28,6 +28,33 @@ fn label(colour: bool, title: &str) -> String {
     style::paint(title, Tone::Emphasis, colour)
 }
 
+/// Keep a transcript-derived model identifier on one terminal row.
+fn terminal_safe_model_id(raw: &str) -> String {
+    let mut safe = String::with_capacity(raw.len());
+    let mut in_control_run = false;
+    for character in raw.chars() {
+        if character.is_control() {
+            if !in_control_run {
+                safe.push(' ');
+                in_control_run = true;
+            }
+        } else {
+            safe.push(character);
+            in_control_run = false;
+        }
+    }
+    safe
+}
+
+fn model_change_status_text(change: &super::event::ModelChange) -> String {
+    format!(
+        "model changed mid-session {} turns ago: `{}` -> `{}`",
+        change.turns_ago,
+        terminal_safe_model_id(&change.from),
+        terminal_safe_model_id(&change.to)
+    )
+}
+
 /// Issue #139: whether `record`'s pinned launch-time safety-policy
 /// fingerprint (`sessions::Record::safety_policy_sha256`) differs from the
 /// fingerprint of the policy `record.repo` resolves to RIGHT NOW. Degrades
@@ -160,14 +187,7 @@ fn sessions_lines(
             ) {
                 line.push_str(&format!(
                     "  {}",
-                    style::paint(
-                        &format!(
-                            "model changed mid-session {} turns ago: `{}` -> `{}`",
-                            change.turns_ago, change.from, change.to
-                        ),
-                        Tone::Warn,
-                        colour
-                    )
+                    style::paint(&model_change_status_text(&change), Tone::Warn, colour)
                 ));
             }
             let delivery = mail::session_delivery_metrics(state, &record.short, now);
@@ -3961,6 +3981,26 @@ mod tests {
         assert!(
             text.contains("sessions:"),
             "the sessions section changed: {text}"
+        );
+    }
+
+    #[test]
+    fn model_identity_drift_text_cannot_forge_terminal_rows() {
+        let text = model_change_status_text(&crate::commands::ctx::event::ModelChange {
+            from: "claude-opus-5\nforged\u{1b}[31m".to_string(),
+            to: "claude-sonnet-5\nforged\u{1b}[2J".to_string(),
+            turns_ago: 2,
+            limit_pressure: true,
+        });
+
+        assert_eq!(
+            text,
+            "model changed mid-session 2 turns ago: `claude-opus-5 forged [31m` -> \
+             `claude-sonnet-5 forged [2J`"
+        );
+        assert!(
+            !text.chars().any(char::is_control),
+            "no transcript-derived control character may reach status output: {text:?}"
         );
     }
 

--- a/src/commands/ctx/status.rs
+++ b/src/commands/ctx/status.rs
@@ -3061,6 +3061,7 @@ mod tests {
             scope: scope.to_string(),
             child_limit: 3,
             token_budget: None,
+            spent_tokens: 0,
             deadline_secs: None,
             completion_contract: "report by mail".to_string(),
             created_at: 1_700_000_000,

--- a/src/commands/ctx/status.rs
+++ b/src/commands/ctx/status.rs
@@ -152,6 +152,24 @@ fn sessions_lines(
                     style::paint(&format!("screening: {summary}"), Tone::Warn, colour)
                 ));
             }
+            if let Some(change) = super::score::model_change_for_session(
+                &record.agent,
+                &record.session,
+                &record.repo,
+                env,
+            ) {
+                line.push_str(&format!(
+                    "  {}",
+                    style::paint(
+                        &format!(
+                            "model changed mid-session {} turns ago: `{}` -> `{}`",
+                            change.turns_ago, change.from, change.to
+                        ),
+                        Tone::Warn,
+                        colour
+                    )
+                ));
+            }
             let delivery = mail::session_delivery_metrics(state, &record.short, now);
             line.push_str(&format!(
                 "  {}",
@@ -3842,6 +3860,107 @@ mod tests {
         assert!(
             !text.contains("no supervised sessions"),
             "unrelated sections must not print: {text}"
+        );
+    }
+
+    #[test]
+    fn status_and_diff_report_model_identity_drift_with_turn_distance() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let _home = crate::commands::ctx::testenv::HomeGuard::set(&home);
+
+        let state = StateDir::from_root(tmp.path().join("state"));
+        state.ensure().expect("state");
+        let session = "abcdef12-3456-4789-8abc-def012345678";
+        let record = crate::commands::ctx::sessions::Record::new(
+            session,
+            "claude",
+            &repo,
+            crate::commands::ctx::sessions::Verb::Exec,
+        );
+        let _guard = crate::commands::ctx::sessions::SessionGuard::register(&state, record);
+
+        let transcript_dir = home
+            .join(".claude/projects")
+            .join(crate::commands::ctx::adapters::claude::project_slug(&repo));
+        std::fs::create_dir_all(&transcript_dir).expect("transcript dir");
+        let transcript = transcript_dir.join(format!("{session}.jsonl"));
+        let first = concat!(
+            r#"{"type":"user","message":{"content":"one"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"[zirv] one"}],"usage":{"input_tokens":1}}}"#,
+            "\n",
+        );
+        std::fs::write(&transcript, first).expect("first turn");
+
+        let mut env = env_for_session(state.root(), session);
+        env.insert("ZIRV_CTX_AGENT".to_string(), "claude".to_string());
+        let args = StatusArgs {
+            decisions: 10,
+            brief: false,
+            diff: true,
+        };
+        let mut first_out = Vec::new();
+        run_with(
+            &args,
+            &mut first_out,
+            &repo,
+            &|key| env.get(key).cloned(),
+            false,
+        )
+        .expect("initial snapshot");
+
+        let second = concat!(
+            r#"{"type":"user","message":{"content":"two"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-sonnet-5","content":[{"type":"text","text":"[zirv] two"}],"usage":{"input_tokens":2}}}"#,
+            "\n",
+        );
+        std::fs::write(&transcript, format!("{first}{second}")).expect("second turn");
+
+        let mut status_out = Vec::new();
+        run_with(
+            &StatusArgs {
+                decisions: 10,
+                brief: false,
+                diff: false,
+            },
+            &mut status_out,
+            &repo,
+            &|key| env.get(key).cloned(),
+            false,
+        )
+        .expect("status");
+        let status_text = String::from_utf8(status_out).expect("utf8");
+        assert!(
+            status_text.contains(
+                "model changed mid-session 0 turns ago: `claude-opus-5` -> `claude-sonnet-5`"
+            ),
+            "got {status_text}"
+        );
+
+        let mut diff_out = Vec::new();
+        run_with(
+            &args,
+            &mut diff_out,
+            &repo,
+            &|key| env.get(key).cloned(),
+            false,
+        )
+        .expect("diff");
+        let text = String::from_utf8(diff_out).expect("utf8");
+        assert!(
+            text.contains(
+                "model changed mid-session 0 turns ago: `claude-opus-5` -> `claude-sonnet-5`"
+            ),
+            "got {text}"
+        );
+        assert!(
+            text.contains("sessions:"),
+            "the sessions section changed: {text}"
         );
     }
 

--- a/src/commands/ctx/supervise.rs
+++ b/src/commands/ctx/supervise.rs
@@ -5,7 +5,18 @@ use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime};
 
 use super::CtxResult;
+use super::adapters::AgentAdapter;
+use super::event::NormalizedEvent;
 use super::sessions::is_alive;
+
+/// Sent beside an adapter's compaction command. PreCompact hooks cannot add
+/// instructions to a compaction, so both interactive and headless supervisors
+/// use this one composition seam.
+pub const COMPACT_FOCUS: &str = "Preserve the current task and its acceptance criteria, the file paths touched so far, any unresolved errors or failing tests, and the exact next step. Drop resolved tangents and full file dumps.";
+
+pub fn compact_prompt(compact_command: &str) -> String {
+    format!("{compact_command} {COMPACT_FOCUS}")
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tick {
@@ -665,6 +676,28 @@ impl Watcher {
         self.consumed = consumed_fingerprint(&mut file, self.offset)?;
         Ok(Some(appended))
     }
+}
+
+/// Watches only transcript bytes appended after `watcher` was primed. There
+/// are no blind retries: either the adapter records a compaction event before
+/// the deadline or the caller must use its heavier fallback.
+pub fn verify_compaction(
+    watcher: &mut Watcher,
+    adapter: &dyn AgentAdapter,
+    deadline: Instant,
+) -> CtxResult<bool> {
+    while Instant::now() < deadline {
+        if let Some(appended) = watcher.read_appended()?
+            && adapter
+                .parse_events(&appended.lines)
+                .iter()
+                .any(|event| matches!(event, NormalizedEvent::Compaction))
+        {
+            return Ok(true);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Ok(false)
 }
 
 /// Runs an `on_failure` hook the way the script runner runs commands.

--- a/src/commands/ctx/wrap.rs
+++ b/src/commands/ctx/wrap.rs
@@ -39,14 +39,15 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use super::adapters::AgentAdapter;
 use super::announce::{Announcer, Event};
 use super::config::{CtxConfig, EnvLookup, env_from_process};
-use super::event::NormalizedEvent;
 use super::handoff::{self, Handoff};
 use super::pace;
 use super::prompt::PromptRole;
 use super::rot::Verdict;
 use super::signal::TurnSignal;
 use super::state::StateDir;
-use super::supervise::Watcher;
+#[cfg(test)]
+use super::supervise::COMPACT_FOCUS;
+use super::supervise::{Watcher, compact_prompt, verify_compaction};
 use super::term::{RawGuard, STDIN_FD, window_size};
 use super::{CtxResult, INJECTION_SUBMIT_DELAY, adapters};
 
@@ -605,10 +606,6 @@ pub fn mail_inject_ready(
         signal_less_mail_ready(state, now, idle_quiet)
     }
 }
-
-/// Sent as arguments to the adapter's compaction command. PreCompact hooks
-/// cannot add instructions to a compaction, so this is the only channel for them.
-pub const COMPACT_FOCUS: &str = "Preserve the current task and its acceptance criteria, the file paths touched so far, any unresolved errors or failing tests, and the exact next step. Drop resolved tangents and full file dumps.";
 
 pub const TRANSCRIPT_ENV: &str = "ZIRV_CTX_TRANSCRIPT";
 
@@ -1229,7 +1226,7 @@ pub fn inject_compact(sink: &mut dyn Write, compact_command: &str, defer: bool) 
     // directly on a generic sink can fragment one format string across
     // several `write_all` calls, which would blur the phase boundary this
     // function depends on.
-    let text = format!("{compact_command} {COMPACT_FOCUS}");
+    let text = compact_prompt(compact_command);
     if !defer {
         sink.write_all(format!("{text}\r").as_bytes())?;
         sink.flush()?;
@@ -1245,27 +1242,6 @@ pub fn inject_compact(sink: &mut dyn Write, compact_command: &str, defer: bool) 
     sink.write_all(b"\r")?;
     sink.flush()?;
     Ok(())
-}
-
-/// Watches the transcript for the compaction the injection was supposed to
-/// cause. No blind keystroke retries: either it is recorded or wrap retreats.
-pub fn verify_compaction(
-    watcher: &mut Watcher,
-    adapter: &dyn AgentAdapter,
-    deadline: Instant,
-) -> CtxResult<bool> {
-    while Instant::now() < deadline {
-        if let Some(appended) = watcher.read_appended()?
-            && adapter
-                .parse_events(&appended.lines)
-                .iter()
-                .any(|event| matches!(event, NormalizedEvent::Compaction))
-        {
-            return Ok(true);
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    Ok(false)
 }
 
 pub fn restart_prompt(handoff: &Handoff) -> String {

--- a/src/commands/workflow/deploy.rs
+++ b/src/commands/workflow/deploy.rs
@@ -70,9 +70,11 @@ pub fn production_gate_satisfied(state_dir: &StateDir, state: &WorkflowState) ->
     }
 
     if !super::verification::latest_is_fresh_and_passing(state_dir, &state.repo, true)? {
-        return Err(
-            "production deploy requires fresh passing final verification; run `zirv verify`".into(),
-        );
+        let announcement = super::verification::gate_announcement(state_dir, &state.repo, true);
+        return Err(format!(
+            "production deploy requires fresh passing final verification; run `zirv verify`\n{announcement}"
+        )
+        .into());
     }
 
     Ok(())

--- a/src/commands/workflow/engine.rs
+++ b/src/commands/workflow/engine.rs
@@ -1716,8 +1716,10 @@ pub fn advance_with_evidence(
                     } else {
                         "zirv test changed"
                     };
+                    let announcement =
+                        super::verification::gate_announcement(state_dir, &state.repo, final_only);
                     return Err(format!(
-                        "step '{}' requires fresh passing evidence for the current change set; run `{command}`",
+                        "step '{}' requires fresh passing evidence for the current change set; run `{command}`\n{announcement}",
                         current.id
                     )
                     .into());
@@ -3746,6 +3748,7 @@ mod tests {
                 duration_ms: 1,
                 failure_output: None,
                 failure_test_names: Vec::new(),
+                inconclusive_reason: None,
             }],
         };
         super::super::verification::save_report(&state_dir, &evidence_report).unwrap();

--- a/src/commands/workflow/mod.rs
+++ b/src/commands/workflow/mod.rs
@@ -88,6 +88,13 @@ pub(crate) struct RepoGates {
     /// not even be read, same fail-closed posture as `checks`/`skills`/
     /// `agents` above.
     pub check_env_passthrough: Vec<String>,
+    /// Operator-owned `[workflow] allow_empty_verify` (REPO_FORBIDDEN,
+    /// `~/.zirv/ctx.toml`/`ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY`/flags only,
+    /// issue #268) -- lets `verification::run_mode` report `Passed` instead
+    /// of `Inconclusive` when zero checks are configured or discoverable.
+    /// `false` (the stricter, fail-closed reading) when the config could
+    /// not even be read, same posture as `checks`/`skills`/`agents` above.
+    pub allow_empty_verify: bool,
 }
 
 /// Resolves both gates, failing **closed** when the configuration cannot be
@@ -110,6 +117,7 @@ pub(crate) fn repo_gates(repo: &std::path::Path) -> RepoGates {
             skills: cfg.workflow.repo_skills_enabled,
             agents: cfg.workflow.repo_agents_enabled,
             check_env_passthrough: cfg.workflow.check_env_passthrough,
+            allow_empty_verify: cfg.workflow.allow_empty_verify,
         },
         Err(error) => {
             announce_unreadable_config(&error.to_string());
@@ -118,6 +126,7 @@ pub(crate) fn repo_gates(repo: &std::path::Path) -> RepoGates {
                 skills: false,
                 agents: false,
                 check_env_passthrough: Vec::new(),
+                allow_empty_verify: false,
             }
         }
     }

--- a/src/commands/workflow/review.rs
+++ b/src/commands/workflow/review.rs
@@ -4048,6 +4048,7 @@ checksum = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f80"
                     names.len()
                 )),
                 failure_test_names: Vec::new(),
+                inconclusive_reason: None,
             }],
         }
     }

--- a/src/commands/workflow/verification.rs
+++ b/src/commands/workflow/verification.rs
@@ -694,13 +694,25 @@ impl VerificationReport {
                 .all(|check| check.status == CheckStatus::Passed)
     }
 
-    /// The report's three-valued [`GateOutcome`] (issue #268). The first
-    /// `Inconclusive` check wins the reported reason -- there is exactly one
-    /// gate verdict to announce, and `Inconclusive` already blocks a gate no
-    /// less than `Fail` does (see `passed`), so which of possibly several
-    /// non-provative checks gets named is a display choice, not a policy
-    /// one.
+    /// The report's three-valued [`GateOutcome`] (issue #268), ranked with
+    /// `Fail` above `Inconclusive` above `Pass`: a genuinely `Failed` check
+    /// -- real evidence something is broken -- always wins over an
+    /// `Inconclusive` one on the same run, even though both block the gate
+    /// identically (see `passed`). A run that is *only* ever unreliable (no
+    /// `Failed` check at all) reports the first `Inconclusive` check's
+    /// reason; announcing that reason as if it were the *whole* story when
+    /// a real failure sits alongside it would say "proves nothing" about a
+    /// run that, in fact, proved something broke -- see `gate_announcement`,
+    /// which still lists any accompanying `Inconclusive` checks by id even
+    /// when the overall outcome is `Fail`.
     pub fn outcome(&self) -> GateOutcome {
+        if self
+            .checks
+            .iter()
+            .any(|check| check.status == CheckStatus::Failed)
+        {
+            return GateOutcome::Fail;
+        }
         if let Some(check) = self
             .checks
             .iter()
@@ -872,6 +884,14 @@ fn looks_like_tool_missing(exit_code: Option<i32>, output: &str) -> bool {
 /// `test result:` line per binary, never one combined total), so this is
 /// "how many test outcomes did the runner report finishing", not "how many
 /// binaries ran". `None` means no summary line was found at all.
+///
+/// `#[cfg(test)]`: production code (`run_check`) gets this same total from
+/// `FailureNameScanner`'s full-stream `summary_seen`/`summary_total`
+/// instead, never from a piece of already-capped display text -- see
+/// `classify_test_outcome`'s own doc comment for why. This function (and
+/// [`classify_test_report`] below) exist only so the decision table has a
+/// pure, fixture-driven entry point for tests.
+#[cfg(test)]
 fn extract_test_total(output: &str) -> Option<u64> {
     let mut total = 0u64;
     let mut found = false;
@@ -946,11 +966,36 @@ fn parse_nextest_summary_line(line: &str) -> Option<u64> {
 /// runner leaves no `test result:`/`Summary [...]` line behind for
 /// [`parse_cargo_test_failure_names`] to find, and an empty failure-name set
 /// used to read as a clean pass -- or `ReportUnparseable` on a successful
-/// one (a well-formed pass always prints its summary; the tail-capping this
-/// module already applies keeps the *end* of the stream, so a genuine
-/// summary line essentially never falls victim to it).
+/// one.
+///
+/// `#[cfg(test)]`: exists so this decision table has a pure, text-in
+/// entry point fixture files can exercise directly. `run_check` calls
+/// [`classify_test_outcome`] instead, with a total taken from the check's
+/// complete, uncapped output -- text handed to *this* function can
+/// legitimately have lost its summary line to display-buffer capping (see
+/// `classify_test_outcome`'s own doc comment), which is exactly the bug a
+/// caller relying on this function for production classification would
+/// have reintroduced.
+#[cfg(test)]
 fn classify_test_report(output: &str, exit_success: bool) -> Option<InconclusiveReason> {
-    match extract_test_total(output) {
+    classify_test_outcome(extract_test_total(output), exit_success)
+}
+
+/// The actual decision table behind [`classify_test_report`], taking the
+/// already-extracted total directly rather than re-deriving it from text.
+/// `run_check` calls this with a total computed from the check's *complete*
+/// uncapped output (see `FailureNameScanner`'s `summary_total`/
+/// `summary_seen`, fed during capture exactly like failing test names
+/// already are) -- never from the capped *display* buffer, which two
+/// independent 16 KiB caps (`read_capped_tail_and_scan`'s own tail cap, then
+/// `run_check`'s second cap on the stdout+stderr concatenation) can leave
+/// with no summary line at all even though the runner printed one. Doing
+/// this classification against that doubly-capped text let a `cargo test
+/// --verbose` run's compiler noise alone misreport a real pass as
+/// `ReportUnparseable` or a real failure as `RunnerCrashed`, which the
+/// mandated `--verbose` gate made likely rather than theoretical.
+fn classify_test_outcome(total: Option<u64>, exit_success: bool) -> Option<InconclusiveReason> {
+    match total {
         Some(0) if exit_success => Some(InconclusiveReason::NoTestsSelected),
         Some(0) => Some(InconclusiveReason::RunnerCrashed),
         Some(_) => None,
@@ -962,7 +1007,13 @@ fn classify_test_report(output: &str, exit_success: bool) -> Option<Inconclusive
 /// Applies both of `run_check`'s post-hoc `Inconclusive` reclassifications
 /// (issue #268) to an otherwise-final `(status, exit_code)`: a tool the
 /// shell could not find, then -- only for a `cargo test`/`cargo nextest
-/// run`-shaped `Unit` check -- [`classify_test_report`]. Never touches
+/// run`-shaped `Unit` check -- [`classify_test_outcome`], fed
+/// `test_summary_total` from the check's complete, uncapped output (see that
+/// function's own doc comment for why the capped display text must never be
+/// used here). `output` itself is only ever consulted for the tool-missing
+/// heuristic, which is fine against the capped text: a "command not
+/// found"/exit-127 signal shows up early and reliably, unlike a summary line
+/// a large enough later flood can push out of a capped tail. Never touches
 /// `CheckStatus::DryRun`/`Skipped`/`TimedOut`: a timeout already blocks every
 /// gate exactly as hard as `Inconclusive` does (see `CheckStatus::
 /// Inconclusive`'s own doc comment), and dry-run/skipped checks were never
@@ -972,6 +1023,7 @@ fn classify_gate_status(
     exit_code: Option<i32>,
     output: &str,
     is_test_runner_check: bool,
+    test_summary_total: Option<u64>,
 ) -> (CheckStatus, Option<InconclusiveReason>) {
     if status == CheckStatus::Failed && looks_like_tool_missing(exit_code, output) {
         return (
@@ -981,7 +1033,8 @@ fn classify_gate_status(
     }
     if is_test_runner_check
         && matches!(status, CheckStatus::Passed | CheckStatus::Failed)
-        && let Some(reason) = classify_test_report(output, status == CheckStatus::Passed)
+        && let Some(reason) =
+            classify_test_outcome(test_summary_total, status == CheckStatus::Passed)
     {
         return (CheckStatus::Inconclusive, Some(reason));
     }
@@ -1046,6 +1099,18 @@ fn parse_cargo_test_failure_names(output: &str) -> std::collections::BTreeSet<St
 /// ignorable up to its next newline, rather than buffering an unbounded
 /// amount of a single newline-less stream -- which would otherwise defeat
 /// the memory cap the capped *display* tail is meant to provide.
+///
+/// Also recognizes the `cargo test`/`cargo nextest run` summary line itself
+/// (`summary_seen`/`summary_total`, fed by `parse_cargo_test_result_line`/
+/// `parse_nextest_summary_line`, same as `extract_test_total`) -- for the
+/// identical reason names are recovered from the full stream rather than
+/// the capped display tail: `run_check` concatenates the stdout and stderr
+/// tails and caps the result a *second* time, and verbose compiler noise on
+/// either stream can push the entire summary line out of that second cap
+/// even though both per-stream tails individually held it. Classifying off
+/// that doubly-capped text let a real pass or failure misreport as
+/// `Inconclusive`; `classify_gate_status` now uses `summary_seen`/
+/// `summary_total` from this full-stream scan instead.
 #[derive(Default)]
 struct FailureNameScanner {
     names: std::collections::BTreeSet<String>,
@@ -1053,6 +1118,8 @@ struct FailureNameScanner {
     partial: Vec<u8>,
     partial_overflowed: bool,
     saw_failures_header: bool,
+    summary_seen: bool,
+    summary_total: u64,
 }
 
 impl FailureNameScanner {
@@ -1087,6 +1154,16 @@ impl FailureNameScanner {
     }
 
     fn observe_line(&mut self, line: &str) {
+        // Independent of the `failures:`/pending-name state machine below:
+        // a summary line is a summary line regardless of what surrounds it,
+        // so this never interferes with (and is never interfered with by)
+        // the existing name-recovery branches.
+        if let Some(count) =
+            parse_cargo_test_result_line(line).or_else(|| parse_nextest_summary_line(line))
+        {
+            self.summary_seen = true;
+            self.summary_total = self.summary_total.saturating_add(count);
+        }
         let trimmed = line.trim();
         if trimmed == "failures:" {
             self.pending.clear();
@@ -1114,13 +1191,17 @@ impl FailureNameScanner {
     }
 
     /// Consumes the scanner, flushing any final unterminated line (a stream
-    /// that ends without a trailing newline) before returning the names.
-    fn finish(mut self) -> std::collections::BTreeSet<String> {
+    /// that ends without a trailing newline) before returning the names,
+    /// plus whether a summary line was seen anywhere in the full stream and
+    /// the running total it declared (summed across every such line found,
+    /// exactly like `extract_test_total` -- a multi-binary `cargo test` run
+    /// prints one `test result:` line per binary, never one combined total).
+    fn finish(mut self) -> (std::collections::BTreeSet<String>, bool, u64) {
         if !self.partial.is_empty() && !self.partial_overflowed {
             let line = String::from_utf8_lossy(&self.partial).into_owned();
             self.observe_line(line.trim_end_matches(['\n', '\r']));
         }
-        self.names
+        (self.names, self.summary_seen, self.summary_total)
     }
 }
 
@@ -1325,16 +1406,18 @@ fn command_for_shell(command: &str) -> Command {
 
 /// The retained tail (whether the stream ended in a read error rather than
 /// at EOF is the second element -- an error read as a clean end silently
-/// turned a truncated failure log into a complete-looking one), plus the
-/// failing test names a [`FailureNameScanner`] recognized in the *full*,
-/// uncapped stream as it went by -- see that struct's doc comment for why
-/// this must happen during capture rather than against the capped tail
-/// alone. Every check's output goes through this path (`run_check`); only
-/// the retained-tail element is ever a display artifact.
+/// turned a truncated failure log into a complete-looking one), plus what a
+/// [`FailureNameScanner`] recognized in the *full*, uncapped stream as it
+/// went by -- the failing test names, whether a `test result:`/`Summary
+/// [...]` line was seen at all, and the total it declared -- see that
+/// struct's doc comment for why this must happen during capture rather than
+/// against the capped tail alone. Every check's output goes through this
+/// path (`run_check`); only the retained-tail element is ever a display
+/// artifact.
 fn read_capped_tail_and_scan(
     mut reader: impl Read,
     cap: usize,
-) -> (Vec<u8>, bool, std::collections::BTreeSet<String>) {
+) -> (Vec<u8>, bool, std::collections::BTreeSet<String>, bool, u64) {
     let mut kept = Vec::with_capacity(cap);
     let mut chunk = [0u8; 8192];
     let mut errored = false;
@@ -1360,7 +1443,8 @@ fn read_capped_tail_and_scan(
         }
         kept.extend_from_slice(&chunk[..count]);
     }
-    (kept, errored, scanner.finish())
+    let (names, summary_seen, summary_total) = scanner.finish();
+    (kept, errored, names, summary_seen, summary_total)
 }
 
 /// The last `cap` bytes as text, on a char boundary. `utils::truncate_bytes`
@@ -1623,13 +1707,17 @@ fn run_check(
         }
     }
     /// One check's raw run outcome: status, exit code, combined capped
-    /// output, and the failing test names a `FailureNameScanner` recognized
-    /// while that output streamed by.
+    /// output (display/storage only -- never classification, see
+    /// `FailureNameScanner`'s doc comment), the failing test names a
+    /// `FailureNameScanner` recognized while that output streamed by, and
+    /// whether/what total a `test result:`/`Summary [...]` line declared
+    /// anywhere in the *complete* stdout+stderr streams.
     type RawCheckOutcome = (
         CheckStatus,
         Option<i32>,
         Vec<u8>,
         std::collections::BTreeSet<String>,
+        Option<u64>,
     );
     let result = (|| -> CtxResult<RawCheckOutcome> {
         let mut child = command.spawn()?;
@@ -1668,34 +1756,53 @@ fn run_check(
             }
             std::thread::sleep(Duration::from_millis(25));
         };
-        let (mut output, mut errored, mut names) = stdout_thread.join().unwrap_or_default();
-        let (stderr_output, stderr_errored, stderr_names) =
-            stderr_thread.join().unwrap_or_default();
+        let (mut output, mut errored, mut names, stdout_summary_seen, stdout_summary_total) =
+            stdout_thread.join().unwrap_or_default();
+        let (
+            stderr_output,
+            stderr_errored,
+            stderr_names,
+            stderr_summary_seen,
+            stderr_summary_total,
+        ) = stderr_thread.join().unwrap_or_default();
         output.extend(stderr_output);
         errored |= stderr_errored;
         names.extend(stderr_names);
+        // Full-stream totals, never the capped `output` buffer below: a
+        // `cargo test`/`cargo nextest run` summary line survives here even
+        // when the doubly-capped display buffer (per-stream tail, then a
+        // second cap on the stdout+stderr concatenation) has lost it to a
+        // large enough flood of noise on either stream -- see
+        // `classify_test_outcome`'s own doc comment.
+        let summary_seen = stdout_summary_seen || stderr_summary_seen;
+        let summary_total =
+            summary_seen.then(|| stdout_summary_total.saturating_add(stderr_summary_total));
         if output.len() > MAX_FAILURE_OUTPUT_BYTES {
             output.drain(..output.len() - MAX_FAILURE_OUTPUT_BYTES);
         }
         if errored {
             output.extend_from_slice(b"\n[output stream ended in a read error]");
         }
-        Ok((status, code, output, names))
+        Ok((status, code, output, names, summary_total))
     })();
 
-    let (status, exit_code, output, failure_test_names, spawn_tool_missing) = match result {
-        Ok((status, code, output, names)) => (status, code, output, names, false),
-        Err(err) => {
-            let missing = is_spawn_not_found(err.as_ref());
-            (
-                CheckStatus::Failed,
-                None,
-                err.to_string().into_bytes(),
-                std::collections::BTreeSet::new(),
-                missing,
-            )
-        }
-    };
+    let (status, exit_code, output, failure_test_names, test_summary_total, spawn_tool_missing) =
+        match result {
+            Ok((status, code, output, names, summary_total)) => {
+                (status, code, output, names, summary_total, false)
+            }
+            Err(err) => {
+                let missing = is_spawn_not_found(err.as_ref());
+                (
+                    CheckStatus::Failed,
+                    None,
+                    err.to_string().into_bytes(),
+                    std::collections::BTreeSet::new(),
+                    None,
+                    missing,
+                )
+            }
+        };
     let failure_output = (status != CheckStatus::Passed)
         .then(|| scrub_output(&tail_text(&output, MAX_FAILURE_OUTPUT_BYTES)));
     // Scrubbed the same way `failure_output` is: a name recognized inside
@@ -1726,6 +1833,7 @@ fn run_check(
             exit_code,
             &String::from_utf8_lossy(&output),
             is_test_runner_check,
+            test_summary_total,
         )
     };
     CheckResult {
@@ -1919,10 +2027,29 @@ pub fn gate_announcement(state: &StateDir, repo: &Path, final_only: bool) -> Str
              repeats, investigate before treating the change as verified",
             reason.as_str()
         ),
-        GateOutcome::Fail | GateOutcome::Pass => format!(
-            "gate: Fail · proves: the current evidence does not cover this change set, or has \
-             unwaived failures · fix: run `{command}`"
-        ),
+        GateOutcome::Fail | GateOutcome::Pass => {
+            // `outcome()` ranks `Fail` above `Inconclusive`, so a mixed
+            // report (one check genuinely failed, another's runner
+            // crashed) lands here -- the accompanying `Inconclusive`
+            // check(s) are still worth naming, not silently absorbed into
+            // a plain "Fail" that implies every check produced real
+            // evidence.
+            let inconclusive_ids: Vec<&str> = report
+                .checks
+                .iter()
+                .filter(|check| check.status == CheckStatus::Inconclusive)
+                .map(|check| check.id.as_str())
+                .collect();
+            let suffix = if inconclusive_ids.is_empty() {
+                String::new()
+            } else {
+                format!(" (also inconclusive: {})", inconclusive_ids.join(", "))
+            };
+            format!(
+                "gate: Fail · proves: the current evidence does not cover this change set, or \
+                 has unwaived failures · fix: run `{command}`{suffix}"
+            )
+        }
     }
 }
 
@@ -3042,7 +3169,7 @@ mod tests {
         let input: Vec<u8> = (0..MAX_FAILURE_OUTPUT_BYTES + 4096)
             .map(|index| (index % 251) as u8)
             .collect();
-        let (retained, errored, _names) =
+        let (retained, errored, _names, _summary_seen, _summary_total) =
             read_capped_tail_and_scan(std::io::Cursor::new(&input), MAX_FAILURE_OUTPUT_BYTES);
         assert!(!errored);
         assert_eq!(retained.len(), MAX_FAILURE_OUTPUT_BYTES);
@@ -3682,7 +3809,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             input.extend_from_slice(b"[17:08:14] zirv \xe2\x96\xb8 sandbox posture noise\r\n");
         }
 
-        let (retained, errored, names) =
+        let (retained, errored, names, _summary_seen, _summary_total) =
             read_capped_tail_and_scan(std::io::Cursor::new(&input), MAX_FAILURE_OUTPUT_BYTES);
         assert!(!errored);
         let retained_text = String::from_utf8_lossy(&retained);
@@ -3793,7 +3920,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             );
         }
         // Fed 128 * 4096 = 512 KiB total with never a single newline.
-        let names = scanner.finish();
+        let (names, _summary_seen, _summary_total) = scanner.finish();
         assert!(
             names.is_empty(),
             "a newline-less flood can never contain a real failing test name: {names:?}"
@@ -3816,7 +3943,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             b"test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; \
               finished in 0.01s\n",
         );
-        let names = scanner.finish();
+        let (names, _summary_seen, _summary_total) = scanner.finish();
         assert!(
             names.is_empty(),
             "a `test result: FAILED` with no preceding `failures:` header must yield no names: \
@@ -3844,7 +3971,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
         scanner.feed(b"failures:\n");
         scanner.feed(b"    crate_b::tests::second_failure\n");
         scanner.feed(b"test result: FAILED. 0 passed; 1 failed\n");
-        let names = scanner.finish();
+        let (names, _summary_seen, _summary_total) = scanner.finish();
         assert_eq!(
             names,
             std::collections::BTreeSet::from([
@@ -3958,6 +4085,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             Some(0),
             "jest output, no cargo shape",
             false,
+            None,
         );
         assert_eq!(status, CheckStatus::Passed);
         assert_eq!(reason, None);
@@ -3966,23 +4094,108 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
     #[test]
     fn classify_gate_status_reclassifies_a_crashed_test_runner_check() {
         let output = include_str!("../../../tests/fixtures/test-reports/cargo-test-crash.txt");
-        let (status, reason) = classify_gate_status(CheckStatus::Failed, Some(1), output, true);
+        let total = extract_test_total(output);
+        let (status, reason) =
+            classify_gate_status(CheckStatus::Failed, Some(1), output, true, total);
         assert_eq!(status, CheckStatus::Inconclusive);
         assert_eq!(reason, Some(InconclusiveReason::RunnerCrashed));
     }
 
     #[test]
     fn classify_gate_status_reclassifies_exit_127_regardless_of_check_kind() {
-        let (status, reason) = classify_gate_status(CheckStatus::Failed, Some(127), "", false);
+        let (status, reason) =
+            classify_gate_status(CheckStatus::Failed, Some(127), "", false, None);
         assert_eq!(status, CheckStatus::Inconclusive);
         assert_eq!(reason, Some(InconclusiveReason::ToolMissing));
     }
 
-    /// `VerificationReport::outcome`: `Inconclusive` wins over `Fail` (it
-    /// blocks the gate no less, but is announced differently), and a report
-    /// with only passing checks is `Pass`.
+    /// `classify_gate_status` must classify off the total the full,
+    /// uncapped stream declared, not off `output`'s own (possibly
+    /// summary-less) capped display text -- a doubly-capped `output`
+    /// buffer that lost its summary line entirely to noise must not, on its
+    /// own, produce `Inconclusive` once the real full-stream total is
+    /// supplied. See `a_late_output_flood_cannot_evict_the_earlier_
+    /// summary_line_from_capture` below for the actual capping/eviction
+    /// this seam is exercised against in `run_check`.
     #[test]
-    fn report_outcome_prefers_inconclusive_over_a_plain_fail() {
+    fn classify_gate_status_is_immune_to_the_capped_display_text_losing_the_summary() {
+        let output_with_no_summary: String = "noisy compiler output\n".repeat(50);
+        assert_eq!(extract_test_total(&output_with_no_summary), None);
+
+        let (passed_status, passed_reason) = classify_gate_status(
+            CheckStatus::Passed,
+            Some(0),
+            &output_with_no_summary,
+            true,
+            Some(3),
+        );
+        assert_eq!(passed_status, CheckStatus::Passed, "{passed_reason:?}");
+        assert_eq!(passed_reason, None);
+
+        let (failed_status, failed_reason) = classify_gate_status(
+            CheckStatus::Failed,
+            Some(101),
+            &output_with_no_summary,
+            true,
+            Some(2),
+        );
+        assert_eq!(failed_status, CheckStatus::Failed, "{failed_reason:?}");
+        assert_eq!(failed_reason, None);
+    }
+
+    /// The actual bug this issue's review caught: `run_check` capped each
+    /// stream's own tail to `MAX_FAILURE_OUTPUT_BYTES`, concatenated
+    /// stdout-then-stderr, then capped the result a *second* time from the
+    /// front -- so more than `MAX_FAILURE_OUTPUT_BYTES` of noise on either
+    /// stream *ahead of* a valid summary line could evict the summary from
+    /// the final display buffer entirely, exactly like
+    /// `a_late_output_flood_cannot_evict_the_earlier_failing_name_from_
+    /// capture` already proved for failing test names. `FailureNameScanner`
+    /// must recover the summary the identical way: from the full,
+    /// pre-capping stream as it is fed in, immune to the capped tail's own
+    /// eviction.
+    #[test]
+    fn a_late_output_flood_cannot_evict_the_earlier_summary_line_from_capture() {
+        let mut input = Vec::new();
+        input.extend_from_slice(
+            b"running 3 tests\ntest tests::a ... ok\ntest tests::b ... ok\ntest tests::c ... ok\n\n",
+        );
+        input.extend_from_slice(
+            b"test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; \
+              finished in 0.01s\n",
+        );
+        let after_summary = input.len();
+        while input.len() - after_summary <= MAX_FAILURE_OUTPUT_BYTES {
+            input.extend_from_slice(b"[compiler] warning: unused import noise\n");
+        }
+
+        let (retained, errored, _names, summary_seen, summary_total) =
+            read_capped_tail_and_scan(std::io::Cursor::new(&input), MAX_FAILURE_OUTPUT_BYTES);
+        assert!(!errored);
+        let retained_text = String::from_utf8_lossy(&retained);
+        assert!(
+            !retained_text.contains("test result:"),
+            "sanity check: the capped display tail must actually have evicted the summary, \
+             reproducing the real bug -- got {retained_text:?}"
+        );
+        assert!(
+            summary_seen,
+            "the streaming scan must recover the summary even though the display tail lost it"
+        );
+        assert_eq!(summary_total, 3);
+        assert_eq!(
+            classify_test_outcome(Some(summary_total), true),
+            None,
+            "a recovered real summary must never classify as Inconclusive"
+        );
+    }
+
+    /// `VerificationReport::outcome`: a genuinely `Failed` check always wins
+    /// over an `Inconclusive` one on the same run -- real evidence something
+    /// broke must never be reported as "proves nothing" just because another
+    /// check on the same run happened to be inconclusive.
+    #[test]
+    fn report_outcome_prefers_fail_over_inconclusive_in_a_mixed_report() {
         let report = report_with_checks(vec![
             unit_check("clippy-ish", CheckStatus::Failed, None),
             CheckResult {
@@ -3998,9 +4211,33 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
                 inconclusive_reason: Some(InconclusiveReason::RunnerCrashed),
             },
         ]);
+        assert_eq!(report.outcome(), GateOutcome::Fail);
+    }
+
+    /// A report with no genuine `Failed` check but at least one
+    /// `Inconclusive` one is still `Inconclusive`, not `Fail` -- the ranking
+    /// only promotes `Fail` above `Inconclusive` when a real failure is
+    /// actually present.
+    #[test]
+    fn report_outcome_is_inconclusive_with_no_failed_check_present() {
+        let report = report_with_checks(vec![
+            unit_check("format", CheckStatus::Passed, None),
+            CheckResult {
+                id: "test".into(),
+                kind: CheckKind::Unit,
+                command: "cargo test".into(),
+                source: CheckSource::DiscoveredToolchain,
+                status: CheckStatus::Inconclusive,
+                exit_code: None,
+                duration_ms: 1,
+                failure_output: None,
+                failure_test_names: Vec::new(),
+                inconclusive_reason: Some(InconclusiveReason::NoTestsSelected),
+            },
+        ]);
         assert_eq!(
             report.outcome(),
-            GateOutcome::Inconclusive(InconclusiveReason::RunnerCrashed)
+            GateOutcome::Inconclusive(InconclusiveReason::NoTestsSelected)
         );
     }
 
@@ -4107,6 +4344,55 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
         assert!(announcement.contains("proves: nothing"), "{announcement}");
         assert!(announcement.contains("runner-crashed"), "{announcement}");
         assert!(announcement.contains("fix:"), "{announcement}");
+    }
+
+    /// A mixed run (one check genuinely failed, another's runner crashed)
+    /// announces `Fail`, not `Inconclusive` -- but must still name the
+    /// inconclusive check by id rather than silently dropping it, since a
+    /// plain "Fail" alone would wrongly imply every check produced real
+    /// evidence.
+    #[test]
+    fn gate_announcement_lists_inconclusive_checks_alongside_a_real_failure() {
+        let repo = git_repo();
+        let state_root = tempdir().unwrap();
+        let state = StateDir::from_root(state_root.path().to_path_buf());
+        let fingerprint = change_fingerprint(repo.path()).unwrap();
+        let report = VerificationReport {
+            schema_version: VERIFY_REPORT_SCHEMA_VERSION,
+            id: "mixed".into(),
+            mode: VerificationMode::Final,
+            source: "configured".into(),
+            repo: repo.path().to_path_buf(),
+            change_fingerprint: fingerprint,
+            changed_paths: vec![],
+            fallback_to_full: false,
+            narrowed_to: vec![],
+            notes: vec![],
+            started_at: 0,
+            finished_at: 0,
+            checks: vec![
+                unit_check("clippy", CheckStatus::Failed, Some("warning: unused")),
+                CheckResult {
+                    id: "test".into(),
+                    kind: CheckKind::Unit,
+                    command: "cargo test".into(),
+                    source: CheckSource::DiscoveredToolchain,
+                    status: CheckStatus::Inconclusive,
+                    exit_code: Some(1),
+                    duration_ms: 1,
+                    failure_output: None,
+                    failure_test_names: Vec::new(),
+                    inconclusive_reason: Some(InconclusiveReason::RunnerCrashed),
+                },
+            ],
+        };
+        save_report(&state, &report).unwrap();
+        let announcement = gate_announcement(&state, repo.path(), true);
+        assert!(announcement.contains("gate: Fail"), "{announcement}");
+        assert!(
+            announcement.contains("also inconclusive") && announcement.contains("test"),
+            "must still name the inconclusive check: {announcement}"
+        );
     }
 
     /// An operator-recorded baseline written before `green_streaks` existed

--- a/src/commands/workflow/verification.rs
+++ b/src/commands/workflow/verification.rs
@@ -117,9 +117,13 @@ impl VerificationConfig {
             )
             .into());
         }
-        if self.checks.is_empty() {
-            return Err("verification config has no checks".into());
-        }
+        // Issue #268: an explicitly empty `checks = []` used to hard-error
+        // here, which meant `zirv verify` on a checked-in but empty
+        // `.zirv/verify.toml` bricked the command outright instead of
+        // producing a report an operator could see. `run_mode` now turns
+        // zero resolved checks into an `Inconclusive` report (or a `Passed`
+        // one under the `workflow.allow_empty_verify` override) -- see its
+        // own doc comment.
         let mut ids = std::collections::BTreeSet::new();
         for check in &self.checks {
             check.validate()?;
@@ -322,11 +326,10 @@ fn load_or_discover_raw(repo: &Path) -> CtxResult<(VerificationConfig, &'static 
         schema_version: VERIFY_CONFIG_SCHEMA_VERSION,
         checks,
     };
-    config
-        .validate()
-        .map_err(|_| -> Box<dyn std::error::Error> {
-            "no verification checks configured or discoverable; add .zirv/verify.toml".into()
-        })?;
+    // Zero checks (neither a Cargo nor a recognized package.json project) is
+    // no longer a hard error here -- see issue #268 and `run_mode`'s own
+    // handling of `resolved.checks.is_empty()`.
+    config.validate()?;
     // `npm run <id>` executes a command body written in the repository's own
     // package.json: discovered by zirv, authored by the checkout, and gated
     // as such. The Cargo commands are zirv's own text.
@@ -542,6 +545,71 @@ pub enum CheckStatus {
     /// Selected and reported, but deliberately not executed -- today only
     /// because `workflow.repo_checks_enabled` is off. Never counts as passing.
     Skipped,
+    /// Issue #268: the check *proves nothing either way* -- a test runner
+    /// that crashed before printing a summary, an empty selection, a command
+    /// that could not be found, or (see `run_mode`) no checks at all being
+    /// configured or discoverable. Distinct from `Failed`: a `Failed` check
+    /// is evidence something is broken; `Inconclusive` is the absence of
+    /// evidence, which must block a gate exactly as hard as `Failed` (see
+    /// `VerificationReport::passed`/`evaluate_against_baseline`) but is
+    /// reported and, per `run_baseline`, never eligible for baselining.
+    Inconclusive,
+}
+
+/// Why one [`CheckResult`] came back `Inconclusive` (issue #268). Set only
+/// when `status == CheckStatus::Inconclusive`; see `CheckResult::
+/// inconclusive_reason`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InconclusiveReason {
+    /// The check's command could not be spawned, or exited in a way that
+    /// looks like the shell never found it (`exit code 127`, or a
+    /// "command not found"/"not recognized" message) -- see
+    /// `looks_like_tool_missing`.
+    ToolMissing,
+    /// A `cargo test`/`cargo nextest run`-shaped `Unit` check exited
+    /// non-zero without printing a single parseable summary line -- the
+    /// STATUS_ACCESS_VIOLATION trap this issue exists to close: no
+    /// `test result:`/`Summary [...]` line means the runner never finished
+    /// reporting, not that nothing failed. See `classify_test_report`.
+    RunnerCrashed,
+    /// A `cargo test`/`cargo nextest run`-shaped `Unit` check's summary line
+    /// declared zero tests run with a successful exit -- an empty filter or
+    /// a selection that matched nothing, not evidence the change set is
+    /// clean.
+    NoTestsSelected,
+    /// A `cargo test`/`cargo nextest run`-shaped `Unit` check exited zero
+    /// but no summary line could be found at all -- reserved for a
+    /// well-formed-but-empty output that is neither a crash (exit succeeded)
+    /// nor a recognizable summary.
+    ReportUnparseable,
+    /// The check's own process-level timeout fired. Reserved for parity with
+    /// the design's reason list; `CheckStatus::TimedOut` already carries
+    /// this distinctly and continues to block every gate exactly like
+    /// `Inconclusive` does, so nothing in this module currently emits
+    /// `Inconclusive` with this reason.
+    Timeout,
+    /// `run_mode` found zero verification checks configured or
+    /// discoverable at all (an empty/absent `verify.toml` with nothing
+    /// else to fall back on) and no operator override
+    /// (`workflow.allow_empty_verify`) was set.
+    NoChecks,
+}
+
+impl InconclusiveReason {
+    /// The kebab-case spelling this reason serializes as -- reused for the
+    /// operator-facing `proves:`/`fix:` announcement (`gate_announcement`)
+    /// so the two never drift apart.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ToolMissing => "tool-missing",
+            Self::RunnerCrashed => "runner-crashed",
+            Self::NoTestsSelected => "no-tests-selected",
+            Self::ReportUnparseable => "report-unparseable",
+            Self::Timeout => "timeout",
+            Self::NoChecks => "no-checks",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -567,10 +635,30 @@ pub struct CheckResult {
     /// did before -- see `evaluate_against_baseline` and `run_baseline`.
     #[serde(default)]
     pub failure_test_names: Vec<String>,
+    /// Set exactly when `status == CheckStatus::Inconclusive` (issue #268).
+    /// `#[serde(default)]` so a report persisted before this field existed
+    /// still deserializes -- it never had an `Inconclusive` check to begin
+    /// with, so `None` is exactly right, not a lossy fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inconclusive_reason: Option<InconclusiveReason>,
 }
 
 fn default_check_source() -> CheckSource {
     CheckSource::RepoConfig
+}
+
+/// The three-valued verdict issue #268 asks for, everywhere a gate is
+/// evaluated: `Pass` only when every check in the report passed; `Fail` when
+/// at least one check is a genuine, evidenced failure; `Inconclusive` when
+/// at least one check proves nothing either way, which blocks a gate exactly
+/// like `Fail` (see `VerificationReport::passed`) but is announced
+/// differently (see `gate_announcement`) and is never eligible for baseline
+/// waiver or recording (see `evaluate_against_baseline`, `run_baseline`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateOutcome {
+    Pass,
+    Fail,
+    Inconclusive(InconclusiveReason),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -604,6 +692,31 @@ impl VerificationReport {
                 .checks
                 .iter()
                 .all(|check| check.status == CheckStatus::Passed)
+    }
+
+    /// The report's three-valued [`GateOutcome`] (issue #268). The first
+    /// `Inconclusive` check wins the reported reason -- there is exactly one
+    /// gate verdict to announce, and `Inconclusive` already blocks a gate no
+    /// less than `Fail` does (see `passed`), so which of possibly several
+    /// non-provative checks gets named is a display choice, not a policy
+    /// one.
+    pub fn outcome(&self) -> GateOutcome {
+        if let Some(check) = self
+            .checks
+            .iter()
+            .find(|check| check.status == CheckStatus::Inconclusive)
+        {
+            return GateOutcome::Inconclusive(
+                check
+                    .inconclusive_reason
+                    .unwrap_or(InconclusiveReason::ReportUnparseable),
+            );
+        }
+        if self.passed() {
+            GateOutcome::Pass
+        } else {
+            GateOutcome::Fail
+        }
     }
 
     /// Whether this (already-failing) report's failures are covered by an
@@ -723,6 +836,156 @@ fn failure_names_for(check: &CheckResult) -> std::collections::BTreeSet<String> 
         .as_deref()
         .map(parse_cargo_test_failure_names)
         .unwrap_or_default()
+}
+
+/// Whether `command` invokes one of the two test runners
+/// [`classify_test_report`] knows how to read a well-formedness verdict out
+/// of. Scoped deliberately narrow (issue #268): an arbitrary `Unit` check
+/// (`npm run test`, say) does not print either runner's summary shape, and
+/// misclassifying its ordinary output as `report-unparseable` would turn a
+/// real pass into a false `Inconclusive`.
+fn is_cargo_test_runner(command: &str) -> bool {
+    let command = command.trim_start();
+    command.starts_with("cargo test") || command.starts_with("cargo nextest")
+}
+
+/// A cheap, pure signal (issue #268's "degraded-gate ban") that a check's own
+/// command could not actually be run: the shell's own "command not found"
+/// convention (POSIX exit code 127) or message, or Windows `cmd.exe`'s own
+/// wording. Deliberately heuristic text matching -- there is no portable way
+/// to ask a shell why its child failed -- so it only ever *adds* an
+/// `Inconclusive` classification on top of what would otherwise have been
+/// `Failed`, never removes one.
+fn looks_like_tool_missing(exit_code: Option<i32>, output: &str) -> bool {
+    if exit_code == Some(127) {
+        return true;
+    }
+    let lower = output.to_ascii_lowercase();
+    lower.contains("command not found")
+        || lower.contains("is not recognized as an internal or external command")
+}
+
+/// Extracts the total test count declared by a `cargo test`/`cargo nextest
+/// run` summary line, if the output contains at least one well-formed one --
+/// the well-formedness check [`classify_test_report`] is built on. Sums
+/// across every such line found (a multi-binary `cargo test` run prints one
+/// `test result:` line per binary, never one combined total), so this is
+/// "how many test outcomes did the runner report finishing", not "how many
+/// binaries ran". `None` means no summary line was found at all.
+fn extract_test_total(output: &str) -> Option<u64> {
+    let mut total = 0u64;
+    let mut found = false;
+    for line in output.lines() {
+        if let Some(count) = parse_cargo_test_result_line(line) {
+            total += count;
+            found = true;
+        } else if let Some(count) = parse_nextest_summary_line(line) {
+            total += count;
+            found = true;
+        }
+    }
+    found.then_some(total)
+}
+
+/// Parses `test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0
+/// filtered out; finished in 0.00s` (or the `FAILED` spelling) into
+/// `passed + failed`, the count of tests the binary actually reported an
+/// outcome for. `None` when the line is not this exact shape -- callers
+/// treat that as "not this kind of summary line", not as an error.
+fn parse_cargo_test_result_line(line: &str) -> Option<u64> {
+    let rest = line.trim().strip_prefix("test result: ")?;
+    let (_, after_dot) = rest.split_once(". ")?;
+    let mut fields = after_dot.split(';');
+    let passed = parse_count_field(fields.next()?, "passed")?;
+    let failed = parse_count_field(fields.next()?, "failed")?;
+    Some(passed + failed)
+}
+
+/// Parses one `; `-delimited field of a `cargo test` summary line, e.g.
+/// `" 3 passed"` with `label = "passed"`, into its leading count. `None` when
+/// the field's label does not match, which is how callers detect the line is
+/// not the shape they expected rather than mis-summing an unrelated number.
+fn parse_count_field(field: &str, label: &str) -> Option<u64> {
+    let (count, name) = field.trim().split_once(' ')?;
+    if name.trim() != label {
+        return None;
+    }
+    count.parse().ok()
+}
+
+/// Parses a `cargo nextest run` human-readable `Summary [   0.12s] 3 tests
+/// run: 3 passed, 0 skipped` line (or the zero-tests/failing spellings) into
+/// the leading "N tests run" count. `None` when the line is not this shape.
+fn parse_nextest_summary_line(line: &str) -> Option<u64> {
+    let trimmed = line.trim();
+    let after_summary = trimmed.strip_prefix("Summary ")?;
+    let close = after_summary.find(']')?;
+    let after_bracket = after_summary[close + 1..].trim_start();
+    let mut parts = after_bracket.split_whitespace();
+    let count = parts.next()?;
+    let next = parts.next()?;
+    if !next.starts_with("test") {
+        return None;
+    }
+    count.parse().ok()
+}
+
+/// The pure runner-report classifier issue #268 asks for: whether a
+/// `cargo test`/`cargo nextest run`-shaped `Unit` check's captured output is
+/// well-formed enough to trust `exit_success` and any parsed failure names
+/// at all. `None` means "well-formed, proceed with the ordinary exit-code
+/// verdict"; `Some(reason)` means the check must be reported `Inconclusive`
+/// instead, regardless of what its exit code said.
+///
+/// A summary line declaring zero tests run is `NoTestsSelected` on a
+/// successful exit (an empty filter or a selection matching nothing) but
+/// `RunnerCrashed` on a failing one (something died before selecting any
+/// test, which a `0 tests run` line does not normally accompany). No summary
+/// line at all is `RunnerCrashed` on a failing exit -- the
+/// STATUS_ACCESS_VIOLATION trap this issue exists to close, where a crashed
+/// runner leaves no `test result:`/`Summary [...]` line behind for
+/// [`parse_cargo_test_failure_names`] to find, and an empty failure-name set
+/// used to read as a clean pass -- or `ReportUnparseable` on a successful
+/// one (a well-formed pass always prints its summary; the tail-capping this
+/// module already applies keeps the *end* of the stream, so a genuine
+/// summary line essentially never falls victim to it).
+fn classify_test_report(output: &str, exit_success: bool) -> Option<InconclusiveReason> {
+    match extract_test_total(output) {
+        Some(0) if exit_success => Some(InconclusiveReason::NoTestsSelected),
+        Some(0) => Some(InconclusiveReason::RunnerCrashed),
+        Some(_) => None,
+        None if exit_success => Some(InconclusiveReason::ReportUnparseable),
+        None => Some(InconclusiveReason::RunnerCrashed),
+    }
+}
+
+/// Applies both of `run_check`'s post-hoc `Inconclusive` reclassifications
+/// (issue #268) to an otherwise-final `(status, exit_code)`: a tool the
+/// shell could not find, then -- only for a `cargo test`/`cargo nextest
+/// run`-shaped `Unit` check -- [`classify_test_report`]. Never touches
+/// `CheckStatus::DryRun`/`Skipped`/`TimedOut`: a timeout already blocks every
+/// gate exactly as hard as `Inconclusive` does (see `CheckStatus::
+/// Inconclusive`'s own doc comment), and dry-run/skipped checks were never
+/// actually executed, so there is no output to classify.
+fn classify_gate_status(
+    status: CheckStatus,
+    exit_code: Option<i32>,
+    output: &str,
+    is_test_runner_check: bool,
+) -> (CheckStatus, Option<InconclusiveReason>) {
+    if status == CheckStatus::Failed && looks_like_tool_missing(exit_code, output) {
+        return (
+            CheckStatus::Inconclusive,
+            Some(InconclusiveReason::ToolMissing),
+        );
+    }
+    if is_test_runner_check
+        && matches!(status, CheckStatus::Passed | CheckStatus::Failed)
+        && let Some(reason) = classify_test_report(output, status == CheckStatus::Passed)
+    {
+        return (CheckStatus::Inconclusive, Some(reason));
+    }
+    (status, None)
 }
 
 fn parse_cargo_test_failure_names(output: &str) -> std::collections::BTreeSet<String> {
@@ -877,9 +1140,26 @@ pub struct TestBaseline {
     #[serde(default)]
     pub failing_tests: Vec<String>,
     pub recorded_at: u64,
+    /// Issue #268's baseline hygiene: how many consecutive non-dry-run
+    /// evaluations in a row each still-baselined name has gone unseen among
+    /// this repository's own failures (see `update_baseline_after_run`).
+    /// Reset to 0 the moment a name is seen failing again; a name reaching
+    /// `PRUNE_AFTER_GREENS` becomes eligible for `zirv test baseline
+    /// --prune` (`run_baseline_prune`). `#[serde(default)]` so a baseline
+    /// recorded before this field existed still deserializes, with every
+    /// name starting at 0 greens rather than failing to load.
+    #[serde(default)]
+    pub green_streaks: std::collections::BTreeMap<String, u32>,
 }
 
 const TEST_BASELINE_SCHEMA_VERSION: u32 = 1;
+
+/// How many consecutive green evaluations a baselined name needs before
+/// `zirv test baseline --prune` will drop it. Not yet operator-configurable
+/// (the issue's own `test.prune_after_greens` key is left for a follow-up)
+/// -- a fixed default of 3, matching the issue's own default, until that
+/// lands.
+const PRUNE_AFTER_GREENS: u32 = 3;
 
 fn test_baseline_dir() -> CtxResult<PathBuf> {
     Ok(crate::utils::home_dir()?
@@ -924,17 +1204,108 @@ pub fn save_baseline(
     repo: &Path,
     failing_tests: std::collections::BTreeSet<String>,
 ) -> CtxResult<TestBaseline> {
+    // Carries forward each still-baselined name's own green streak (from
+    // ordinary `zirv test changed`/`zirv verify` evaluations, see
+    // `update_baseline_after_run`) rather than resetting it just because the
+    // operator re-ran `zirv test baseline` -- a fresh full recompute is not
+    // itself evidence the name regressed. A name absent from the previous
+    // baseline (newly recorded) starts at 0, same as before this field
+    // existed.
+    let previous = load_baseline(repo).unwrap_or(None);
+    let green_streaks = failing_tests
+        .iter()
+        .filter_map(|name| {
+            previous
+                .as_ref()
+                .and_then(|baseline| baseline.green_streaks.get(name))
+                .map(|streak| (name.clone(), *streak))
+        })
+        .collect();
     let baseline = TestBaseline {
         schema_version: TEST_BASELINE_SCHEMA_VERSION,
         failing_tests: failing_tests.into_iter().collect(),
         recorded_at: now_secs(),
+        green_streaks,
     };
+    write_baseline(repo, &baseline)?;
+    Ok(baseline)
+}
+
+fn write_baseline(repo: &Path, baseline: &TestBaseline) -> CtxResult<()> {
     create_private_dir_all(&test_baseline_dir()?)?;
     write_private(
         &test_baseline_path(repo)?,
-        &serde_json::to_string_pretty(&baseline)?,
+        &serde_json::to_string_pretty(baseline)?,
     )?;
-    Ok(baseline)
+    Ok(())
+}
+
+/// Issue #268's baseline-hygiene half: after every non-dry-run evaluation
+/// (`zirv test changed`/`zirv test all`/`zirv verify`, and `zirv test
+/// baseline` itself before it overwrites the file), advances each
+/// still-baselined name's `green_streaks` counter when this run's evidence
+/// says it is clean, or resets it to 0 the moment it is seen failing again --
+/// so a name only ever earns `zirv test baseline --prune` eligibility from
+/// repeated, real green evidence, never from a single lucky run or a run
+/// that never even exercised it.
+///
+/// Does nothing (returns `None`, touches no file) when there is no baseline
+/// yet, the baseline is empty, this run selected no `Unit`, non-repo-supplied
+/// check at all (so it has no opinion on any baselined name), or any such
+/// check came back `Inconclusive`/`TimedOut` -- an unreliable run must never
+/// advance a streak on a guess. Only ever ingests failing names from the
+/// same check sources `run_baseline` itself trusts (never `RepoConfig`/
+/// `DiscoveredScript`), so a repository-authored check can neither manufacture
+/// nor erase prune eligibility for a name it does not own.
+///
+/// Returns an operator-facing note naming how many entries just became
+/// prune-eligible, if any -- the `zirv test changed` hint the issue's design
+/// asks for.
+fn update_baseline_after_run(repo: &Path, report: &VerificationReport) -> Option<String> {
+    let mut baseline = load_baseline(repo).ok().flatten()?;
+    if baseline.failing_tests.is_empty() {
+        return None;
+    }
+    let unit_checks: Vec<&CheckResult> = report
+        .checks
+        .iter()
+        .filter(|check| check.kind == CheckKind::Unit && !check.source.repo_supplied())
+        .collect();
+    if unit_checks.is_empty()
+        || unit_checks.iter().any(|check| {
+            matches!(
+                check.status,
+                CheckStatus::Inconclusive | CheckStatus::TimedOut
+            )
+        })
+    {
+        return None;
+    }
+    let observed_failing: std::collections::BTreeSet<String> = unit_checks
+        .iter()
+        .filter(|check| check.status == CheckStatus::Failed)
+        .flat_map(|check| failure_names_for(check))
+        .collect();
+    let mut eligible = 0usize;
+    for name in &baseline.failing_tests {
+        let streak = baseline.green_streaks.entry(name.clone()).or_insert(0);
+        if observed_failing.contains(name) {
+            *streak = 0;
+        } else {
+            *streak = streak.saturating_add(1);
+        }
+        if *streak >= PRUNE_AFTER_GREENS {
+            eligible += 1;
+        }
+    }
+    write_baseline(repo, &baseline).ok()?;
+    (eligible > 0).then(|| {
+        let plural = if eligible == 1 { "y" } else { "ies" };
+        format!(
+            "baseline: {eligible} entr{plural} eligible for prune (run `zirv test baseline \
+             --prune`)"
+        )
+    })
 }
 
 fn command_for_shell(command: &str) -> Command {
@@ -1054,6 +1425,7 @@ fn check_result(check: &ResolvedCheck, status: CheckStatus) -> CheckResult {
         duration_ms: 0,
         failure_output: None,
         failure_test_names: Vec::new(),
+        inconclusive_reason: None,
     }
 }
 
@@ -1219,6 +1591,8 @@ fn run_check(
     }
     let check_source = check.source;
     let check = &check.spec;
+    let is_test_runner_check =
+        check.kind == CheckKind::Unit && is_cargo_test_runner(&check.command);
     let started = Instant::now();
     let mut command = command_for_shell(&check.command);
     super::isolate_process_tree(&mut command);
@@ -1309,14 +1683,19 @@ fn run_check(
         Ok((status, code, output, names))
     })();
 
-    let (status, exit_code, output, failure_test_names) = result.unwrap_or_else(|err| {
-        (
-            CheckStatus::Failed,
-            None,
-            err.to_string().into_bytes(),
-            std::collections::BTreeSet::new(),
-        )
-    });
+    let (status, exit_code, output, failure_test_names, spawn_tool_missing) = match result {
+        Ok((status, code, output, names)) => (status, code, output, names, false),
+        Err(err) => {
+            let missing = is_spawn_not_found(err.as_ref());
+            (
+                CheckStatus::Failed,
+                None,
+                err.to_string().into_bytes(),
+                std::collections::BTreeSet::new(),
+                missing,
+            )
+        }
+    };
     let failure_output = (status != CheckStatus::Passed)
         .then(|| scrub_output(&tail_text(&output, MAX_FAILURE_OUTPUT_BYTES)));
     // Scrubbed the same way `failure_output` is: a name recognized inside
@@ -1329,6 +1708,26 @@ fn run_check(
             .map(|name| scrub_line(&name))
             .collect()
     };
+    // Issue #268: never trust a bare exit code alone for a test runner. A
+    // literal spawn failure (the shell binary itself missing -- vanishingly
+    // rare) and a shell-reported "command not found" (the command inside it
+    // missing -- the realistic case for a misconfigured `verify.toml`) both
+    // become `Inconclusive`, and so does a `cargo test`/`cargo nextest
+    // run`-shaped `Unit` check whose own output never reached a well-formed
+    // summary line.
+    let (status, inconclusive_reason) = if spawn_tool_missing {
+        (
+            CheckStatus::Inconclusive,
+            Some(InconclusiveReason::ToolMissing),
+        )
+    } else {
+        classify_gate_status(
+            status,
+            exit_code,
+            &String::from_utf8_lossy(&output),
+            is_test_runner_check,
+        )
+    };
     CheckResult {
         id: check.id.clone(),
         kind: check.kind,
@@ -1339,7 +1738,21 @@ fn run_check(
         duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
         failure_output,
         failure_test_names,
+        inconclusive_reason,
     }
+}
+
+/// Whether `error` is (or wraps) an [`std::io::Error`] of
+/// [`std::io::ErrorKind::NotFound`] -- the kind [`std::process::Command::
+/// spawn`] returns when the program it was told to run does not exist.
+/// Distinct from a shell finding *itself* but failing to find the command
+/// named *inside* it (`looks_like_tool_missing`'s exit-127 case): this is
+/// the shell (`sh`/`cmd`) itself never starting, which in practice only
+/// happens in a badly broken environment.
+fn is_spawn_not_found(error: &(dyn std::error::Error + 'static)) -> bool {
+    error
+        .downcast_ref::<std::io::Error>()
+        .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)
 }
 
 fn report_dir(state: &StateDir, repo: &Path) -> PathBuf {
@@ -1483,6 +1896,36 @@ pub fn evaluate_against_operator_baseline(
     report.evaluate_against_baseline(baseline.as_ref())
 }
 
+/// The `proves:`/`fix:` announcement issue #268 asks for alongside a gate
+/// failure: an `Inconclusive` verdict is worded differently from an ordinary
+/// `Fail`, since a crashed runner or an empty selection proves nothing about
+/// the change set in either direction, whereas a real failure at least
+/// proves something is broken. Meant to be appended to the plain "run `zirv
+/// test changed`/`zirv verify`" message every `latest_is_fresh_and_passing`
+/// call site already produces on its own -- see `engine.rs`'s step gate and
+/// `deploy.rs`'s production gate.
+pub fn gate_announcement(state: &StateDir, repo: &Path, final_only: bool) -> String {
+    let command = if final_only {
+        "zirv verify"
+    } else {
+        "zirv test changed"
+    };
+    let Ok(Some(report)) = load_latest(state, repo) else {
+        return format!("proves: nothing (no verification evidence yet) · fix: run `{command}`");
+    };
+    match report.outcome() {
+        GateOutcome::Inconclusive(reason) => format!(
+            "gate: Inconclusive ({}) · proves: nothing · fix: re-run `{command}`; if it \
+             repeats, investigate before treating the change as verified",
+            reason.as_str()
+        ),
+        GateOutcome::Fail | GateOutcome::Pass => format!(
+            "gate: Fail · proves: the current evidence does not cover this change set, or has \
+             unwaived failures · fix: run `{command}`"
+        ),
+    }
+}
+
 fn run_mode(
     repo: &Path,
     mode: VerificationMode,
@@ -1496,6 +1939,55 @@ fn run_mode(
     let repo_gates = super::repo_gates(repo);
     let repo_checks_enabled = repo_gates.checks;
     let mut notes = resolved.notes;
+    // Issue #268's degraded-gate ban: zero checks configured or
+    // discoverable is reported, not silently treated as a pass and not a
+    // hard `Err` either (an empty/absent `verify.toml` must not brick `zirv
+    // test`/`zirv verify` outright -- same reasoning as the repo-gate note
+    // above). Only the operator-only `workflow.allow_empty_verify` override
+    // can make this a `Passed` run instead; the override's use is recorded
+    // in `notes` either way, so it is visible in the report.
+    if resolved.checks.is_empty() {
+        let allow_empty = repo_gates.allow_empty_verify;
+        notes.push(if allow_empty {
+            "no verification checks configured or discoverable; passing only because the \
+             operator override workflow.allow_empty_verify is set"
+                .to_string()
+        } else {
+            "no verification checks configured or discoverable; add .zirv/verify.toml (or set \
+             the operator override workflow.allow_empty_verify)"
+                .to_string()
+        });
+        return Ok(VerificationReport {
+            schema_version: VERIFY_REPORT_SCHEMA_VERSION,
+            id: uuid::Uuid::new_v4().to_string(),
+            mode,
+            source: resolved.origin.to_string(),
+            repo: repo.to_path_buf(),
+            change_fingerprint: change_fingerprint(repo)?,
+            changed_paths: Vec::new(),
+            fallback_to_full: false,
+            narrowed_to: only.to_vec(),
+            notes,
+            started_at: now_secs(),
+            finished_at: now_secs(),
+            checks: vec![CheckResult {
+                id: "no-checks".into(),
+                kind: CheckKind::Custom,
+                command: String::new(),
+                source: CheckSource::DiscoveredToolchain,
+                status: if allow_empty {
+                    CheckStatus::Passed
+                } else {
+                    CheckStatus::Inconclusive
+                },
+                exit_code: None,
+                duration_ms: 0,
+                failure_output: None,
+                failure_test_names: Vec::new(),
+                inconclusive_reason: (!allow_empty).then_some(InconclusiveReason::NoChecks),
+            }],
+        });
+    }
     let paths = changed_paths(repo)?;
     let mut fallback_to_full = false;
     let mut selected: Vec<&ResolvedCheck> = resolved
@@ -1642,7 +2134,12 @@ fn run_and_persist(
     args: &RunArgs,
     writer: &mut impl Write,
 ) -> CtxResult<(i32, VerificationReport)> {
-    let report = run_mode(repo, mode, &args.checks, args.dry_run)?;
+    let mut report = run_mode(repo, mode, &args.checks, args.dry_run)?;
+    if !args.dry_run
+        && let Some(note) = update_baseline_after_run(repo, &report)
+    {
+        report.notes.push(note);
+    }
     // `zirv verify | head` closes the pipe mid-report. Printing is the part
     // that failed, so the run's own results are still worth storing -- without
     // this, piping into a pager silently cost the workflow its evidence.
@@ -1698,10 +2195,25 @@ fn run_and_report(
 /// still fails the run and still blocks the gate -- it is simply never
 /// consulted for baseline *names*, exactly like any other unrecordable
 /// check.
-fn run_baseline(repo: &Path, args: &RunArgs, writer: &mut impl Write) -> CtxResult<i32> {
-    let (code, report) = run_and_persist(repo, VerificationMode::All, args, writer)?;
-    if args.dry_run {
+fn run_baseline(repo: &Path, args: &BaselineArgs, writer: &mut impl Write) -> CtxResult<i32> {
+    if args.prune {
+        return run_baseline_prune(repo, writer);
+    }
+    let (code, report) = run_and_persist(repo, VerificationMode::All, &args.run, writer)?;
+    if args.run.dry_run {
         return Ok(code);
+    }
+    // Issue #268's degraded-gate ban: a run that proves nothing either way
+    // must never be recorded as evidence a set of tests is exactly this
+    // repository's known-bad list -- that is what let a crashed runner (or
+    // an empty selection) silently become "the baseline says this is fine".
+    if let GateOutcome::Inconclusive(reason) = report.outcome() {
+        crate::output::warn(format!(
+            "baseline not recorded: this run was inconclusive ({}) -- re-run once the runner \
+             produces a well-formed result",
+            reason.as_str()
+        ));
+        return Ok(1);
     }
     let mut failing = std::collections::BTreeSet::new();
     let mut unrecordable = Vec::new();
@@ -1748,6 +2260,51 @@ fn run_baseline(repo: &Path, args: &RunArgs, writer: &mut impl Write) -> CtxResu
     Ok(0)
 }
 
+/// `zirv test baseline --prune`: removes exactly the baseline entries that
+/// have reached `PRUNE_AFTER_GREENS` consecutive green evaluations (see
+/// `update_baseline_after_run`), without re-running any check -- pruning is a
+/// maintenance action over evidence already accumulated by ordinary `zirv
+/// test changed`/`zirv verify` runs, not a fresh recording.
+fn run_baseline_prune(repo: &Path, writer: &mut impl Write) -> CtxResult<i32> {
+    let Some(mut baseline) = load_baseline(repo)? else {
+        writeln!(
+            writer,
+            "no recorded baseline for {}; nothing to prune",
+            scrub_line(&repo_slug(repo))
+        )?;
+        return Ok(0);
+    };
+    let eligible: Vec<String> = baseline
+        .failing_tests
+        .iter()
+        .filter(|name| {
+            baseline.green_streaks.get(*name).copied().unwrap_or(0) >= PRUNE_AFTER_GREENS
+        })
+        .cloned()
+        .collect();
+    if eligible.is_empty() {
+        writeln!(
+            writer,
+            "no baseline entries have reached {PRUNE_AFTER_GREENS} consecutive green runs yet"
+        )?;
+        return Ok(0);
+    }
+    baseline
+        .failing_tests
+        .retain(|name| !eligible.contains(name));
+    for name in &eligible {
+        baseline.green_streaks.remove(name);
+    }
+    write_baseline(repo, &baseline)?;
+    writeln!(
+        writer,
+        "pruned {} baseline entry(ies): {}",
+        eligible.len(),
+        scrub_line(&eligible.join(", "))
+    )?;
+    Ok(0)
+}
+
 #[derive(Debug, Args)]
 pub struct RunArgs {
     #[arg(long)]
@@ -1759,6 +2316,17 @@ pub struct RunArgs {
     pub dry_run: bool,
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct BaselineArgs {
+    #[command(flatten)]
+    pub run: RunArgs,
+    /// Remove baseline entries that have reached `PRUNE_AFTER_GREENS`
+    /// consecutive green evaluations, instead of running every check and
+    /// recording a fresh baseline (issue #268).
+    #[arg(long)]
+    pub prune: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1776,8 +2344,10 @@ pub enum TestCommand {
     /// Run every check and record its failing test names as this
     /// repository's operator-owned baseline (issue #215), so a later step
     /// gate may waive exactly these pre-existing failures instead of
-    /// blocking on them forever. Always an explicit operator action.
-    Baseline(RunArgs),
+    /// blocking on them forever. Always an explicit operator action. Never
+    /// records from an `Inconclusive` run (issue #268); `--prune` instead
+    /// removes matured entries without re-running anything.
+    Baseline(BaselineArgs),
 }
 
 #[derive(Debug, Args)]
@@ -1857,7 +2427,7 @@ pub fn run_test(args: &TestArgs, writer: &mut impl Write) -> CtxResult<i32> {
             writer,
         ),
         TestCommand::Baseline(args) => {
-            run_baseline(&resolved_repo(args.repo.as_deref())?, args, writer)
+            run_baseline(&resolved_repo(args.run.repo.as_deref())?, args, writer)
         }
     }
 }
@@ -2253,6 +2823,7 @@ mod tests {
                 duration_ms: 1,
                 failure_output: None,
                 failure_test_names: Vec::new(),
+                inconclusive_reason: None,
             }],
         };
         save_report(&state, &report).unwrap();
@@ -2334,6 +2905,7 @@ mod tests {
                 duration_ms: 1,
                 failure_output: None,
                 failure_test_names: Vec::new(),
+                inconclusive_reason: None,
             }],
             started_at: 0,
             finished_at: 0,
@@ -2390,6 +2962,7 @@ mod tests {
                 duration_ms: 1,
                 failure_output: None,
                 failure_test_names: Vec::new(),
+                inconclusive_reason: None,
             }],
         }
     }
@@ -2804,6 +3377,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             duration_ms: 1,
             failure_output: failure_output.map(str::to_string),
             failure_test_names: Vec::new(),
+            inconclusive_reason: None,
         }
     }
 
@@ -2837,6 +3411,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             schema_version: TEST_BASELINE_SCHEMA_VERSION,
             failing_tests: names.iter().map(|name| name.to_string()).collect(),
             recorded_at: 0,
+            green_streaks: std::collections::BTreeMap::new(),
         }
     }
 
@@ -2912,6 +3487,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             duration_ms: 1,
             failure_output: Some("warning: unused variable".into()),
             failure_test_names: Vec::new(),
+            inconclusive_reason: None,
         }]);
         // Even a baseline that happens to contain the exact failure text must
         // not waive a check that names no individual tests at all.
@@ -3133,6 +3709,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
             duration_ms: 1,
             failure_output: Some(retained_text.into_owned()),
             failure_test_names: names.into_iter().collect(),
+            inconclusive_reason: None,
         };
         assert!(
             failure_names_for(&check).contains(real_name),
@@ -3170,11 +3747,14 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
         with_state(state_root.path(), || {
             run_baseline(
                 repo.path(),
-                &RunArgs {
-                    repo: None,
-                    checks: vec![],
-                    dry_run: false,
-                    json: false,
+                &BaselineArgs {
+                    run: RunArgs {
+                        repo: None,
+                        checks: vec![],
+                        dry_run: false,
+                        json: false,
+                    },
+                    prune: false,
                 },
                 &mut out,
             )
@@ -3272,6 +3852,541 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
                 "crate_b::tests::second_failure".to_string(),
             ]),
             "each binary's block must be judged independently by its own header: {names:?}"
+        );
+    }
+
+    // -- Issue #268: three-valued gate outcomes -----------------------------
+
+    /// The STATUS_ACCESS_VIOLATION trap this issue exists to close: a
+    /// crashed `cargo test` run leaves partial per-test lines but never
+    /// reaches its own `test result:` summary, and exits non-zero. A bare
+    /// exit-code check reads this exactly like an empty (i.e. clean) failure
+    /// set; `classify_test_report` must call it `Inconclusive`, never `None`
+    /// (which would let `run_check` leave it `Passed`/`Failed` off the raw
+    /// exit code alone).
+    #[test]
+    fn a_captured_status_access_violation_transcript_classifies_as_runner_crashed() {
+        let output = include_str!("../../../tests/fixtures/test-reports/cargo-test-crash.txt");
+        assert_eq!(
+            classify_test_report(output, false),
+            Some(InconclusiveReason::RunnerCrashed)
+        );
+    }
+
+    /// An empty nextest filter -- `0 tests run` with a *successful* exit --
+    /// must never read as "the change set is clean"; it read nothing at
+    /// all.
+    #[test]
+    fn an_empty_nextest_filter_classifies_as_no_tests_selected() {
+        let output = include_str!("../../../tests/fixtures/test-reports/nextest-empty-filter.txt");
+        assert_eq!(
+            classify_test_report(output, true),
+            Some(InconclusiveReason::NoTestsSelected)
+        );
+    }
+
+    /// The same zero-tests summary with a *failing* exit is not "empty
+    /// selection" -- nothing selected does not normally fail -- it is
+    /// treated as a crash instead.
+    #[test]
+    fn a_zero_tests_summary_with_a_failing_exit_is_runner_crashed_not_no_tests_selected() {
+        let output = include_str!("../../../tests/fixtures/test-reports/nextest-empty-filter.txt");
+        assert_eq!(
+            classify_test_report(output, false),
+            Some(InconclusiveReason::RunnerCrashed)
+        );
+    }
+
+    /// A well-formed clean run (either runner) is never `Inconclusive`: a
+    /// real summary declaring at least one test run must defer entirely to
+    /// the ordinary exit-code verdict.
+    #[test]
+    fn well_formed_reports_with_a_real_summary_are_never_inconclusive() {
+        let cargo_clean = include_str!("../../../tests/fixtures/test-reports/cargo-test-clean.txt");
+        assert_eq!(classify_test_report(cargo_clean, true), None);
+
+        let cargo_failed =
+            include_str!("../../../tests/fixtures/test-reports/cargo-test-failure.txt");
+        assert_eq!(classify_test_report(cargo_failed, false), None);
+
+        let nextest_clean = include_str!("../../../tests/fixtures/test-reports/nextest-clean.txt");
+        assert_eq!(classify_test_report(nextest_clean, true), None);
+    }
+
+    /// A successful exit with no summary line at all (neither a crash --
+    /// exit succeeded -- nor a recognizable empty-selection summary) is the
+    /// residual `ReportUnparseable` case.
+    #[test]
+    fn a_successful_exit_with_no_summary_at_all_is_report_unparseable() {
+        assert_eq!(
+            classify_test_report("nothing recognizable here\n", true),
+            Some(InconclusiveReason::ReportUnparseable)
+        );
+    }
+
+    #[test]
+    fn is_cargo_test_runner_matches_both_known_runners_and_nothing_else() {
+        assert!(is_cargo_test_runner("cargo test --verbose"));
+        assert!(is_cargo_test_runner("cargo nextest run --no-fail-fast"));
+        assert!(!is_cargo_test_runner("npm run test"));
+        assert!(!is_cargo_test_runner("cargo build"));
+    }
+
+    #[test]
+    fn looks_like_tool_missing_matches_exit_127_and_shell_messages() {
+        assert!(looks_like_tool_missing(Some(127), ""));
+        assert!(looks_like_tool_missing(
+            Some(1),
+            "sh: some-tool: command not found"
+        ));
+        assert!(looks_like_tool_missing(
+            Some(1),
+            "'some-tool' is not recognized as an internal or external command"
+        ));
+        assert!(!looks_like_tool_missing(Some(1), "assertion failed"));
+    }
+
+    /// `classify_gate_status` is the seam `run_check` actually calls: a
+    /// non-runner `Unit` check (`npm run test`, say) must never be
+    /// reclassified by `classify_test_report` at all, even if its output
+    /// happens to contain no cargo-shaped summary -- only `cargo test`/
+    /// `cargo nextest run` commands are in scope (`is_cargo_test_runner`).
+    #[test]
+    fn classify_gate_status_never_touches_a_non_runner_unit_check() {
+        let (status, reason) = classify_gate_status(
+            CheckStatus::Passed,
+            Some(0),
+            "jest output, no cargo shape",
+            false,
+        );
+        assert_eq!(status, CheckStatus::Passed);
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn classify_gate_status_reclassifies_a_crashed_test_runner_check() {
+        let output = include_str!("../../../tests/fixtures/test-reports/cargo-test-crash.txt");
+        let (status, reason) = classify_gate_status(CheckStatus::Failed, Some(1), output, true);
+        assert_eq!(status, CheckStatus::Inconclusive);
+        assert_eq!(reason, Some(InconclusiveReason::RunnerCrashed));
+    }
+
+    #[test]
+    fn classify_gate_status_reclassifies_exit_127_regardless_of_check_kind() {
+        let (status, reason) = classify_gate_status(CheckStatus::Failed, Some(127), "", false);
+        assert_eq!(status, CheckStatus::Inconclusive);
+        assert_eq!(reason, Some(InconclusiveReason::ToolMissing));
+    }
+
+    /// `VerificationReport::outcome`: `Inconclusive` wins over `Fail` (it
+    /// blocks the gate no less, but is announced differently), and a report
+    /// with only passing checks is `Pass`.
+    #[test]
+    fn report_outcome_prefers_inconclusive_over_a_plain_fail() {
+        let report = report_with_checks(vec![
+            unit_check("clippy-ish", CheckStatus::Failed, None),
+            CheckResult {
+                id: "test".into(),
+                kind: CheckKind::Unit,
+                command: "cargo test".into(),
+                source: CheckSource::DiscoveredToolchain,
+                status: CheckStatus::Inconclusive,
+                exit_code: None,
+                duration_ms: 1,
+                failure_output: None,
+                failure_test_names: Vec::new(),
+                inconclusive_reason: Some(InconclusiveReason::RunnerCrashed),
+            },
+        ]);
+        assert_eq!(
+            report.outcome(),
+            GateOutcome::Inconclusive(InconclusiveReason::RunnerCrashed)
+        );
+    }
+
+    #[test]
+    fn report_outcome_is_pass_only_when_every_check_passed() {
+        let passing = report_with_checks(vec![unit_check("test", CheckStatus::Passed, None)]);
+        assert_eq!(passing.outcome(), GateOutcome::Pass);
+
+        let failing = report_with_checks(vec![unit_check(
+            "test",
+            CheckStatus::Failed,
+            Some(&cargo_failure_output("wrap::tests::a")),
+        )]);
+        assert_eq!(failing.outcome(), GateOutcome::Fail);
+    }
+
+    /// The core acceptance criterion: `latest_is_fresh_and_passing` must
+    /// return `false` for a fresh, un-narrowed report whose only check is
+    /// `Inconclusive` -- it must never be read as passing just because
+    /// `evaluate_against_baseline`'s existing waiver path only knows how to
+    /// waive a `Failed` `Unit` check, not an `Inconclusive` one.
+    #[test]
+    fn latest_is_fresh_and_passing_returns_false_for_an_inconclusive_report() {
+        let repo = git_repo();
+        let state_root = tempdir().unwrap();
+        let state = StateDir::from_root(state_root.path().to_path_buf());
+        let fingerprint = change_fingerprint(repo.path()).unwrap();
+        let report = VerificationReport {
+            schema_version: VERIFY_REPORT_SCHEMA_VERSION,
+            id: "inconclusive".into(),
+            mode: VerificationMode::Final,
+            source: "configured".into(),
+            repo: repo.path().to_path_buf(),
+            change_fingerprint: fingerprint,
+            changed_paths: vec![],
+            fallback_to_full: false,
+            narrowed_to: vec![],
+            notes: vec![],
+            started_at: 0,
+            finished_at: 0,
+            checks: vec![CheckResult {
+                id: "test".into(),
+                kind: CheckKind::Unit,
+                command: "cargo test".into(),
+                source: CheckSource::DiscoveredToolchain,
+                status: CheckStatus::Inconclusive,
+                exit_code: Some(1),
+                duration_ms: 1,
+                failure_output: None,
+                failure_test_names: Vec::new(),
+                inconclusive_reason: Some(InconclusiveReason::RunnerCrashed),
+            }],
+        };
+        save_report(&state, &report).unwrap();
+        assert!(
+            !latest_is_fresh_and_passing(&state, repo.path(), true).unwrap(),
+            "an Inconclusive report must never satisfy the gate"
+        );
+
+        // Even with the exact same failing (absent) names as a recorded
+        // baseline would waive, `Inconclusive` is never eligible for that
+        // waiver -- `evaluate_against_baseline` only ever waives a `Failed`
+        // `Unit` check with parseable names.
+        let evaluation = evaluate_against_operator_baseline(&report, repo.path());
+        assert!(!evaluation.gate_passed);
+    }
+
+    /// The `proves:`/`fix:` announcement must name the reason and never
+    /// claim the run proved anything.
+    #[test]
+    fn gate_announcement_names_the_inconclusive_reason() {
+        let repo = git_repo();
+        let state_root = tempdir().unwrap();
+        let state = StateDir::from_root(state_root.path().to_path_buf());
+        let fingerprint = change_fingerprint(repo.path()).unwrap();
+        let report = VerificationReport {
+            schema_version: VERIFY_REPORT_SCHEMA_VERSION,
+            id: "inconclusive".into(),
+            mode: VerificationMode::Final,
+            source: "configured".into(),
+            repo: repo.path().to_path_buf(),
+            change_fingerprint: fingerprint,
+            changed_paths: vec![],
+            fallback_to_full: false,
+            narrowed_to: vec![],
+            notes: vec![],
+            started_at: 0,
+            finished_at: 0,
+            checks: vec![CheckResult {
+                id: "test".into(),
+                kind: CheckKind::Unit,
+                command: "cargo test".into(),
+                source: CheckSource::DiscoveredToolchain,
+                status: CheckStatus::Inconclusive,
+                exit_code: Some(1),
+                duration_ms: 1,
+                failure_output: None,
+                failure_test_names: Vec::new(),
+                inconclusive_reason: Some(InconclusiveReason::RunnerCrashed),
+            }],
+        };
+        save_report(&state, &report).unwrap();
+        let announcement = gate_announcement(&state, repo.path(), true);
+        assert!(announcement.contains("proves: nothing"), "{announcement}");
+        assert!(announcement.contains("runner-crashed"), "{announcement}");
+        assert!(announcement.contains("fix:"), "{announcement}");
+    }
+
+    /// An operator-recorded baseline written before `green_streaks` existed
+    /// must still load, with every name starting at 0 greens rather than
+    /// failing to deserialize outright.
+    #[test]
+    fn a_pre_268_baseline_file_without_green_streaks_still_loads() {
+        let home = tempdir().unwrap();
+        let _home_guard = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let repo = PathBuf::from("/some/old/repo");
+        let dir = home.path().join(".zirv").join("test-baseline");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{}.json", repo_slug(&repo))),
+            r#"{"schema_version":1,"failing_tests":["a::one","b::two"],"recorded_at":123}"#,
+        )
+        .unwrap();
+
+        let loaded = load_baseline(&repo).expect("load").expect("exists");
+        assert_eq!(loaded.failing_tests, vec!["a::one", "b::two"]);
+        assert!(loaded.green_streaks.is_empty());
+    }
+
+    /// Baseline hygiene end to end: three consecutive runs in which a
+    /// baselined name does not appear among the observed failures advance
+    /// its streak to the prune threshold; `--prune` removes exactly that
+    /// name (leaving an untouched one behind), and a run where it *does*
+    /// fail again resets the streak to 0.
+    #[test]
+    fn three_green_runs_make_a_name_prune_eligible_and_prune_removes_exactly_it() {
+        let repo = git_repo();
+        let home = tempdir().unwrap();
+        let _home_guard = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        save_baseline(
+            repo.path(),
+            std::collections::BTreeSet::from([
+                "wrap::tests::a".to_string(),
+                "wrap::tests::b".to_string(),
+            ]),
+        )
+        .unwrap();
+
+        // A clean `Unit` run: neither baselined name appears among this
+        // run's failures, so both should be advancing.
+        let clean_report = report_with_checks(vec![unit_check("test", CheckStatus::Passed, None)]);
+        for _ in 0..PRUNE_AFTER_GREENS {
+            update_baseline_after_run(repo.path(), &clean_report);
+        }
+        let baseline = load_baseline(repo.path()).unwrap().unwrap();
+        assert_eq!(
+            baseline.green_streaks.get("wrap::tests::a").copied(),
+            Some(PRUNE_AFTER_GREENS)
+        );
+        assert_eq!(
+            baseline.green_streaks.get("wrap::tests::b").copied(),
+            Some(PRUNE_AFTER_GREENS)
+        );
+
+        let mut out = Vec::new();
+        run_baseline_prune(repo.path(), &mut out).unwrap();
+        let pruned = String::from_utf8(out).unwrap();
+        assert!(pruned.contains("wrap::tests::a"));
+        assert!(pruned.contains("wrap::tests::b"));
+        let baseline = load_baseline(repo.path()).unwrap().unwrap();
+        assert!(
+            baseline.failing_tests.is_empty(),
+            "both matured entries must be gone: {:?}",
+            baseline.failing_tests
+        );
+    }
+
+    /// One red run resets the streak to 0, so an intermittently-green name
+    /// never quietly matures for pruning.
+    #[test]
+    fn a_red_run_resets_the_green_streak() {
+        let repo = git_repo();
+        let home = tempdir().unwrap();
+        let _home_guard = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        save_baseline(
+            repo.path(),
+            std::collections::BTreeSet::from(["wrap::tests::a".to_string()]),
+        )
+        .unwrap();
+
+        let clean_report = report_with_checks(vec![unit_check("test", CheckStatus::Passed, None)]);
+        update_baseline_after_run(repo.path(), &clean_report);
+        update_baseline_after_run(repo.path(), &clean_report);
+        assert_eq!(
+            load_baseline(repo.path())
+                .unwrap()
+                .unwrap()
+                .green_streaks
+                .get("wrap::tests::a")
+                .copied(),
+            Some(2)
+        );
+
+        let red_report = report_with_checks(vec![unit_check(
+            "test",
+            CheckStatus::Failed,
+            Some(&cargo_failure_output("wrap::tests::a")),
+        )]);
+        update_baseline_after_run(repo.path(), &red_report);
+        assert_eq!(
+            load_baseline(repo.path())
+                .unwrap()
+                .unwrap()
+                .green_streaks
+                .get("wrap::tests::a")
+                .copied(),
+            Some(0)
+        );
+    }
+
+    /// An `Inconclusive`/`TimedOut` `Unit` check's own run must never
+    /// advance (or reset) any baselined name's streak -- an unreliable run
+    /// has no opinion on whether a name is actually clean.
+    #[test]
+    fn an_inconclusive_run_never_advances_any_green_streak() {
+        let repo = git_repo();
+        let home = tempdir().unwrap();
+        let _home_guard = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        save_baseline(
+            repo.path(),
+            std::collections::BTreeSet::from(["wrap::tests::a".to_string()]),
+        )
+        .unwrap();
+
+        let inconclusive_report = report_with_checks(vec![CheckResult {
+            id: "test".into(),
+            kind: CheckKind::Unit,
+            command: "cargo test".into(),
+            source: CheckSource::DiscoveredToolchain,
+            status: CheckStatus::Inconclusive,
+            exit_code: Some(1),
+            duration_ms: 1,
+            failure_output: None,
+            failure_test_names: Vec::new(),
+            inconclusive_reason: Some(InconclusiveReason::RunnerCrashed),
+        }]);
+        assert!(update_baseline_after_run(repo.path(), &inconclusive_report).is_none());
+        assert_eq!(
+            load_baseline(repo.path())
+                .unwrap()
+                .unwrap()
+                .green_streaks
+                .get("wrap::tests::a")
+                .copied(),
+            None,
+            "an inconclusive run must leave the streak untouched"
+        );
+    }
+
+    /// `zirv test baseline` must refuse to record from an `Inconclusive`
+    /// run rather than silently treating "proves nothing" as "everything
+    /// currently failing".
+    #[test]
+    fn run_baseline_refuses_to_record_from_an_inconclusive_run() {
+        // A repo with none of the recognized project shapes (no Cargo.toml,
+        // no package.json) and no `.zirv/verify.toml` resolves zero checks,
+        // which `run_mode` now reports as `Inconclusive { NoChecks }` rather
+        // than erroring outright.
+        let repo = git_repo();
+        let state_root = tempdir().unwrap();
+        let home = tempdir().unwrap();
+        let _home_guard = crate::commands::ctx::testenv::HomeGuard::set(home.path());
+        let mut out = Vec::new();
+        let code = with_state(state_root.path(), || {
+            run_baseline(
+                repo.path(),
+                &BaselineArgs {
+                    run: RunArgs {
+                        repo: None,
+                        checks: vec![],
+                        dry_run: false,
+                        json: false,
+                    },
+                    prune: false,
+                },
+                &mut out,
+            )
+            .expect("must not hard-error")
+        });
+        assert_eq!(code, 1, "an inconclusive run must not exit 0");
+        assert!(
+            load_baseline(repo.path()).unwrap().is_none(),
+            "nothing must be recorded from an inconclusive run"
+        );
+    }
+
+    /// Issue #268's degraded-gate ban: zero checks configured or
+    /// discoverable is `Inconclusive`, not a silent pass and not a hard
+    /// `Err` that would brick `zirv verify` outright.
+    #[test]
+    fn zero_checks_is_inconclusive_not_a_silent_pass_or_a_hard_error() {
+        let repo = git_repo();
+        let report =
+            run_mode(repo.path(), VerificationMode::Final, &[], false).expect("must not error");
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.checks[0].status, CheckStatus::Inconclusive);
+        assert_eq!(
+            report.checks[0].inconclusive_reason,
+            Some(InconclusiveReason::NoChecks)
+        );
+        assert!(!report.passed());
+    }
+
+    /// The operator-only override makes the same zero-checks run `Passed`
+    /// instead, with the override's use visible in the report's notes.
+    #[test]
+    fn the_allow_empty_verify_override_makes_zero_checks_pass_and_says_so() {
+        let repo = git_repo();
+        // SAFETY: single-threaded suite (`--test-threads=1`).
+        unsafe {
+            std::env::set_var("ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY", "true");
+        }
+        let report = run_mode(repo.path(), VerificationMode::Final, &[], false);
+        unsafe {
+            std::env::remove_var("ZIRV_CTX_WORKFLOW_ALLOW_EMPTY_VERIFY");
+        }
+        let report = report.expect("must not error");
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.checks[0].status, CheckStatus::Passed);
+        assert!(report.passed());
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("allow_empty_verify")),
+            "the override's use must be visible in the report: {:?}",
+            report.notes
+        );
+    }
+
+    /// A repository's own `.zirv/ctx.toml` must never be able to set this
+    /// override for itself -- `workflow.allow_empty_verify` is
+    /// `REPO_FORBIDDEN` (see `config.rs`'s
+    /// `repo_layer_cannot_set_workflow_allow_empty_verify`), so `CtxConfig::
+    /// load` hard-errors on it exactly like `auto_spawn_on_gate`/
+    /// `check_env_passthrough`, and `repo_gates` degrades that to its usual
+    /// fail-closed default (`false`) rather than letting the repo's own
+    /// attempt flip the gate.
+    #[test]
+    fn a_repo_ctx_toml_cannot_set_the_allow_empty_verify_override() {
+        let repo = git_repo();
+        std::fs::create_dir_all(repo.path().join(".zirv")).unwrap();
+        std::fs::write(
+            repo.path().join(".zirv/ctx.toml"),
+            "[workflow]\nallow_empty_verify = true\n",
+        )
+        .unwrap();
+        let report =
+            run_mode(repo.path(), VerificationMode::Final, &[], false).expect("must not error");
+        assert_eq!(
+            report.checks[0].status,
+            CheckStatus::Inconclusive,
+            "a repo-forbidden key set from the repo's own ctx.toml must fail closed, not flip \
+             the override"
+        );
+    }
+
+    /// A genuinely missing tool (not a cargo/nextest shape at all) reclassifies
+    /// through the real `run_check` seam, not just the pure classifier --
+    /// exercising `is_spawn_not_found`/`looks_like_tool_missing` end to end.
+    #[test]
+    fn a_missing_command_is_inconclusive_through_the_real_run_check_seam() {
+        let repo = git_repo();
+        let state_root = tempdir().unwrap();
+        write_verify_toml(
+            repo.path(),
+            "schema_version=1\n[[checks]]\nid='missing'\nkind='custom'\ncommand='zirv-268-does-not-exist-cmd'\n",
+        );
+        let report = with_state(state_root.path(), || {
+            run_mode(repo.path(), VerificationMode::Final, &[], false).expect("must not error")
+        });
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.checks[0].status, CheckStatus::Inconclusive);
+        assert_eq!(
+            report.checks[0].inconclusive_reason,
+            Some(InconclusiveReason::ToolMissing)
         );
     }
 }

--- a/tests/fixtures/claude-provider-errors-model-drift.jsonl
+++ b/tests/fixtures/claude-provider-errors-model-drift.jsonl
@@ -1,0 +1,6 @@
+{"type":"user","message":{"content":"first turn"}}
+{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"[zirv] first"}],"usage":{"input_tokens":1000}}}
+{"type":"user","message":{"content":"second turn"}}
+{"type":"assistant","message":{"model":"claude-sonnet-5","content":[{"type":"text","text":"[zirv] second"}],"usage":{"input_tokens":2000}}}
+{"type":"assistant","isApiErrorMessage":true,"error":"rate_limit","message":{"model":"<synthetic>","content":[{"type":"text","text":"API Error: rate limit: prompt is too long"}],"usage":{"input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","isApiErrorMessage":true,"error":"invalid_request","message":{"model":"<synthetic>","content":[{"type":"text","text":"API Error: prompt is too long: 210000 tokens > 200000 maximum"}],"usage":{"input_tokens":0,"output_tokens":0}}}

--- a/tests/fixtures/codex-provider-errors-model-drift.jsonl
+++ b/tests/fixtures/codex-provider-errors-model-drift.jsonl
@@ -1,0 +1,9 @@
+{"timestamp":"2026-09-02T10:00:00.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}
+{"timestamp":"2026-09-02T10:00:00.100Z","type":"turn_context","payload":{"turn_id":"turn-1","model":"gpt-5.6-sol"}}
+{"timestamp":"2026-09-02T10:00:01.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","last_agent_message":"done"}}
+{"timestamp":"2026-09-02T10:01:00.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"}}
+{"timestamp":"2026-09-02T10:01:00.100Z","type":"turn_context","payload":{"turn_id":"turn-2","model":"gpt-5.6-terra"}}
+{"timestamp":"2026-09-02T10:01:01.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-2","last_agent_message":null,"error":{"message":"rate limit: too many requests while request_too_large was retried","codex_error_info":"other"}}}
+{"timestamp":"2026-09-02T10:02:00.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-3"}}
+{"timestamp":"2026-09-02T10:02:00.100Z","type":"turn_context","payload":{"turn_id":"turn-3","model":"gpt-5.6-terra"}}
+{"timestamp":"2026-09-02T10:02:01.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-3","last_agent_message":null,"error":{"message":"Your input exceeds the context window of this model","codex_error_info":"other"}}}

--- a/tests/fixtures/fake-agent.sh
+++ b/tests/fixtures/fake-agent.sh
@@ -7,7 +7,7 @@
 #   fake-agent.sh -p <prompt> --session-id <uuid> [extra...]
 #
 # Behavior comes from the environment:
-#   FAKE_AGENT_MODE=healthy|rot|hang|fail   (default healthy)
+#   FAKE_AGENT_MODE=healthy|rot|compact-tier|hang|fail   (default healthy)
 #   FAKE_AGENT_MODE_FILE=<path>             one mode per line, popped per run
 #   FAKE_AGENT_TURNS=<n>                    (default 12)
 #   FAKE_AGENT_SLEEP=<secs>                 rot mode only (default 0)
@@ -30,10 +30,13 @@
 #                                           test can assert a headless
 #                                           spawn's child actually launched
 #                                           in the requested --workdir)
+#   FAKE_AGENT_COMPACTION_EVENT=0           omit the compact-boundary event,
+#                                           exercising fail-closed verification
 #
 #   healthy  distinct tool inputs, marker on every final, 20k tokens
 #   rot      identical tool input, every result an error, marker only on the
 #            first two turns, 170k tokens: score 100, verdict restart
+#   compact-tier  healthy signals at 165k tokens: verdict compact
 #   hang     writes a healthy transcript then never exits
 #   fail     writes a healthy transcript then exits 3
 #   limit    writes a healthy transcript, prints the documented limit-hit
@@ -68,20 +71,37 @@ mv_bin=mv
 [ -z "${FAKE_AGENT_ARGV_LOG:-}" ] || printf '%s\n' "$*" >> "$FAKE_AGENT_ARGV_LOG"
 
 session=""
+prompt=""
+resumed=false
 while [ $# -gt 0 ]; do
   case "$1" in
     --session-id) session="${2:-}"; shift 2 ;;
+    --resume) session="${2:-}"; resumed=true; shift 2 ;;
+    -p)
+      if [ $# -gt 1 ] && [ "${2#--}" = "$2" ]; then
+        prompt=$2
+        shift 2
+      else
+        shift
+      fi
+      ;;
     *) shift ;;
   esac
 done
 [ -n "$session" ] || { echo "fake-agent: no --session-id given" >&2; exit 64; }
 
 mode="${FAKE_AGENT_MODE:-healthy}"
-if [ -n "${FAKE_AGENT_MODE_FILE:-}" ] && [ -s "${FAKE_AGENT_MODE_FILE}" ]; then
-  mode=$("$head_bin" -n 1 "$FAKE_AGENT_MODE_FILE")
-  "$tail_bin" -n +2 "$FAKE_AGENT_MODE_FILE" > "$FAKE_AGENT_MODE_FILE.next"
-  "$mv_bin" "$FAKE_AGENT_MODE_FILE.next" "$FAKE_AGENT_MODE_FILE"
-fi
+case "$prompt" in
+  /compact*) ;;
+  *)
+    if [ -n "${FAKE_AGENT_MODE_FILE:-}" ] && [ -s "${FAKE_AGENT_MODE_FILE}" ]; then
+      mode=$("$head_bin" -n 1 "$FAKE_AGENT_MODE_FILE")
+      "$tail_bin" -n +2 "$FAKE_AGENT_MODE_FILE" > "$FAKE_AGENT_MODE_FILE.next"
+      "$mv_bin" "$FAKE_AGENT_MODE_FILE.next" "$FAKE_AGENT_MODE_FILE"
+    fi
+    ;;
+esac
+
 if [ -n "${FAKE_AGENT_SESSION_ENV_LOG:-}" ]; then
   printf '%s\n' "${ZIRV_CTX_SESSION:-}" >> "$FAKE_AGENT_SESSION_ENV_LOG"
 fi
@@ -105,7 +125,21 @@ slug=$(printf '%s' "$cwd" | tr -c 'A-Za-z0-9-' '-')
 dir="$HOME/.claude/projects/$slug"
 mkdir -p "$dir"
 t="$dir/$session.jsonl"
-: > "$t"
+if [ "$resumed" = false ]; then
+  : > "$t"
+fi
+
+# A headless in-place compaction resumes the existing conversation with the
+# adapter's compact command as its prompt. It must not consume the next normal
+# run mode: the continuation launched immediately afterwards owns that entry.
+case "$prompt" in
+  /compact*)
+    if [ "${FAKE_AGENT_COMPACTION_EVENT:-1}" != "0" ]; then
+      printf '{"type":"system","subtype":"compact_boundary","content":"compacted"}\n' >> "$t"
+    fi
+    exit 0
+    ;;
+esac
 
 emit_turn() { # $1 tool input  $2 is_error  $3 final text  $4 tokens
   printf '{"type":"user","message":{"content":"do the thing"}}\n' >> "$t"
@@ -119,6 +153,8 @@ while [ "$i" -le "$turns" ]; do
   if [ "$mode" = "rot" ]; then
     if [ "$i" -le 2 ]; then final="[zirv] step $i"; else final="step $i"; fi
     emit_turn '{"command":"ls"}' true "$final" 170000
+  elif [ "$mode" = "compact-tier" ]; then
+    emit_turn "{\"command\":\"ls $i\"}" false "[zirv] step $i" 165000
   else
     emit_turn "{\"command\":\"ls $i\"}" false "[zirv] step $i" 20000
   fi
@@ -126,7 +162,7 @@ while [ "$i" -le "$turns" ]; do
 done
 
 sleep_secs="${FAKE_AGENT_SLEEP:-0}"
-if [ "$mode" = "rot" ] && [ "$sleep_secs" != "0" ]; then
+if { [ "$mode" = "rot" ] || [ "$mode" = "compact-tier" ]; } && [ "$sleep_secs" != "0" ]; then
   "$sleep_bin" "$sleep_secs"
 fi
 

--- a/tests/fixtures/test-reports/cargo-test-clean.txt
+++ b/tests/fixtures/test-reports/cargo-test-clean.txt
@@ -1,0 +1,6 @@
+running 3 tests
+test tests::a ... ok
+test tests::b ... ok
+test tests::c ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

--- a/tests/fixtures/test-reports/cargo-test-crash.txt
+++ b/tests/fixtures/test-reports/cargo-test-crash.txt
@@ -1,0 +1,3 @@
+running 12 tests
+test tests::a ... ok
+test tests::b ... ok

--- a/tests/fixtures/test-reports/cargo-test-failure.txt
+++ b/tests/fixtures/test-reports/cargo-test-failure.txt
@@ -1,0 +1,14 @@
+running 2 tests
+test tests::a ... ok
+test tests::b ... FAILED
+
+failures:
+
+---- tests::b stdout ----
+thread 'tests::b' panicked at src/lib.rs:10:5:
+assertion failed
+
+failures:
+    tests::b
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

--- a/tests/fixtures/test-reports/nextest-clean.txt
+++ b/tests/fixtures/test-reports/nextest-clean.txt
@@ -1,0 +1,5 @@
+    Starting 3 tests across 1 binary
+        PASS [   0.003s] zirv tests::a
+        PASS [   0.003s] zirv tests::b
+        PASS [   0.004s] zirv tests::c
+     Summary [   0.010s] 3 tests run: 3 passed, 0 skipped

--- a/tests/fixtures/test-reports/nextest-empty-filter.txt
+++ b/tests/fixtures/test-reports/nextest-empty-filter.txt
@@ -1,0 +1,2 @@
+    Starting 0 tests across 0 binaries (16 skipped)
+     Summary [   0.005s] 0 tests run: 0 passed, 0 skipped


### PR DESCRIPTION
Top-5 batch from the 2026-09-02 issue triage. Version 3.8.0 -> 3.9.0.

Closes #268, closes #282, closes #283, closes #286, closes #298.

- #268 Test/verify gates get a third outcome, Inconclusive, so a crashed or empty test run can no longer read as green; baseline green-streak prune via `zirv test baseline --prune`; new operator-only key `workflow.allow_empty_verify`.
- #282 Rot engine resets its behavioural window at a harness compaction, classifies provider errors (rate limit never reads as overflow, overflow escalates), and tracks mid-session model changes.
- #283 Headless `exec`/`loop` act on the Compact tier with a verified in-place compaction and fail-closed fallback to restart. Claude only for now; codex tracked in #303.
- #286 Work-group token budget and deadline are enforced at admission for headless and dashboard workers, with a per-group lock and spend accounting.
- #298 Harness roster lines are omitted for disabled or absent harnesses, with a cached liveness probe so the prompt prefix stays byte-stable.

Review: one full-diff round (claude sonnet + codex), nine confirmed findings fixed, fix diff re-reviewed clean. Deferred to #301 (per-child token reservation) and #302 (baseline locking).

Gates on the merged branch: cargo build, cargo nextest run --no-fail-fast, cargo test -- --test-threads=1, cargo fmt --check, cargo clippy -D warnings, all clean.
