### PR TITLE
fix(claude): strip the Windows verbatim prefix from worktree and sibling grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zirv"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zirv"
-version = "3.15.0"
+version = "3.15.1"
 edition = "2024"
 authors = ["Jonathan Solskov <josj@zirv.io>"]
 description = "A CLI tool for executing developer-defined YAML scripts with support for interactive commands and OS-specific execution."

--- a/src/commands/ctx/adapters/claude.rs
+++ b/src/commands/ctx/adapters/claude.rs
@@ -3173,11 +3173,11 @@ mod tests {
     /// A canonicalized root (what worktree and sibling discovery produces)
     /// carries the `\\?\` verbatim prefix on Windows; the rendered grant
     /// must not, or Claude Code refuses it as a network path.
-    #[cfg(windows)]
     #[test]
     fn grant_paths_never_carry_the_windows_verbatim_prefix() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let canonical = std::fs::canonicalize(tmp.path()).expect("canonical");
+        #[cfg(windows)]
         assert!(canonical.to_string_lossy().starts_with(r"\\?\"));
         let rendered = grant_path(&canonical);
         assert!(!rendered.starts_with(r"\\?\"), "{rendered}");

--- a/src/commands/ctx/adapters/claude.rs
+++ b/src/commands/ctx/adapters/claude.rs
@@ -821,7 +821,7 @@ impl LaunchEnvironment {
             })
             .unwrap_or_default()
             .iter()
-            .map(|path| path.display().to_string())
+            .map(|path| grant_path(path))
             .collect();
         #[cfg(test)]
         let workspace_write_roots = Vec::new();
@@ -1183,8 +1183,20 @@ fn additional_worktree_roots(
 fn linked_worktree_args(repo: &Path) -> Vec<String> {
     linked_worktree_roots(repo)
         .into_iter()
-        .flat_map(|path| ["--add-dir".to_string(), path.display().to_string()])
+        .flat_map(|path| ["--add-dir".to_string(), grant_path(&path)])
         .collect()
+}
+
+/// Renders a discovered worktree or sibling root for Claude's own settings
+/// and argv. Discovery canonicalizes, which on Windows yields a `\\?\`
+/// verbatim path; Claude Code reads that prefix as a network share and
+/// rejects the directory at startup ("is a network path, which cannot be
+/// added as a working directory"), one warning per grant, so every sibling
+/// grant from issue #329 was refused on Windows. The verbatim prefix is
+/// only ever needed for Win32 calls, never for a path handed to another
+/// program, so it is stripped here.
+fn grant_path(path: &Path) -> String {
+    super::super::state::display_path(path)
 }
 
 /// The discovery half of [`linked_worktree_args`], shared with
@@ -3156,6 +3168,22 @@ mod tests {
         let settings = launch_settings_value(&policy, policy_path, &LaunchEnvironment::default())
             .expect("settings");
         assert!(settings["permissions"]["additionalDirectories"].is_null());
+    }
+
+    /// A canonicalized root (what worktree and sibling discovery produces)
+    /// carries the `\\?\` verbatim prefix on Windows; the rendered grant
+    /// must not, or Claude Code refuses it as a network path.
+    #[cfg(windows)]
+    #[test]
+    fn grant_paths_never_carry_the_windows_verbatim_prefix() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let canonical = std::fs::canonicalize(tmp.path()).expect("canonical");
+        assert!(canonical.to_string_lossy().starts_with(r"\\?\"));
+        let rendered = grant_path(&canonical);
+        assert!(!rendered.starts_with(r"\\?\"), "{rendered}");
+        // Still the same directory, just spelled the way another program
+        // can consume it.
+        assert_eq!(std::fs::canonicalize(&rendered).expect("exists"), canonical);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Right after `zirv ctx chat` renders the dashboard, the orchestrator pane shows a burst of warnings, one per sibling checkout:

```
\?\D:\GitHub\Jira is a network path, which cannot be added as a working directory. On Windows, map the share to a drive letter and pass it at launch with --add-dir ...
```

`LaunchEnvironment::resolve` (issue #329 sibling write grants) and `linked_worktree_args` canonicalize the discovered roots. On Windows `std::fs::canonicalize` yields `\?\D:\...` verbatim paths, and Claude Code reads that prefix as a UNC share and refuses every such `permissions.additionalDirectories` entry (and would refuse a `--add-dir` too). So besides the noise, none of the #329 sibling grants took effect on Windows.

Reproduced outside the dashboard with `claude --settings <zirv launch settings> -p ok`: 18 warnings with the generated file, none with the same file after stripping the prefix.

## Fix

Render both grant surfaces through the existing `state::display_path`, which already strips `\?\` / `\?\UNC\` for user-facing output. New `grant_path` helper, one Windows test proving a canonicalized tempdir renders without the prefix and still names the same directory.

Version 3.15.1.

## Verification (Windows worktree)

- `cargo build`
- `cargo nextest run adapters::claude::` — 99 passed
- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings` — clean

https://claude.ai/code/session_01Kzn8hRpCwxzs6qraHa6WdC
